### PR TITLE
✨ [Feat] backend-api Spring Boot skeleton 추가

### DIFF
--- a/backend-api/Dockerfile
+++ b/backend-api/Dockerfile
@@ -1,0 +1,14 @@
+FROM gradle:8.10-jdk21 AS build
+
+WORKDIR /workspace
+COPY . .
+RUN gradle clean bootJar --no-daemon
+
+FROM eclipse-temurin:21-jre
+
+WORKDIR /app
+COPY --from=build /workspace/build/libs/*.jar app.jar
+
+EXPOSE 8080
+
+ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/backend-api/build.gradle
+++ b/backend-api/build.gradle
@@ -1,0 +1,43 @@
+plugins {
+    id 'java'
+    id 'org.springframework.boot' version '3.4.5'
+    id 'io.spring.dependency-management' version '1.1.7'
+}
+
+group = 'com.moonju.preprocess'
+version = '0.0.1-SNAPSHOT'
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(21)
+    }
+}
+
+configurations {
+    compileOnly {
+        extendsFrom annotationProcessor
+    }
+}
+
+dependencies {
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
+    implementation 'org.springframework.boot:spring-boot-starter-amqp'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+
+    compileOnly 'org.projectlombok:lombok'
+    runtimeOnly 'org.postgresql:postgresql'
+
+    annotationProcessor 'org.projectlombok:lombok'
+
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'org.springframework.security:spring-security-test'
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+}
+
+tasks.named('test') {
+    useJUnitPlatform()
+}

--- a/backend-api/settings.gradle
+++ b/backend-api/settings.gradle
@@ -1,0 +1,15 @@
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+        mavenCentral()
+    }
+}
+
+dependencyResolutionManagement {
+    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+    repositories {
+        mavenCentral()
+    }
+}
+
+rootProject.name = 'backend-api'

--- a/backend-api/src/main/java/com/moonju/preprocess/api/BackendApiApplication.java
+++ b/backend-api/src/main/java/com/moonju/preprocess/api/BackendApiApplication.java
@@ -1,0 +1,12 @@
+package com.moonju.preprocess.api;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class BackendApiApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(BackendApiApplication.class, args);
+    }
+}

--- a/backend-api/src/main/java/com/moonju/preprocess/api/domain/admin/package-info.java
+++ b/backend-api/src/main/java/com/moonju/preprocess/api/domain/admin/package-info.java
@@ -1,0 +1,1 @@
+package com.moonju.preprocess.api.domain.admin;

--- a/backend-api/src/main/java/com/moonju/preprocess/api/domain/audit/package-info.java
+++ b/backend-api/src/main/java/com/moonju/preprocess/api/domain/audit/package-info.java
@@ -1,0 +1,1 @@
+package com.moonju.preprocess.api.domain.audit;

--- a/backend-api/src/main/java/com/moonju/preprocess/api/domain/auth/package-info.java
+++ b/backend-api/src/main/java/com/moonju/preprocess/api/domain/auth/package-info.java
@@ -1,0 +1,1 @@
+package com.moonju.preprocess.api.domain.auth;

--- a/backend-api/src/main/java/com/moonju/preprocess/api/domain/benchmark/package-info.java
+++ b/backend-api/src/main/java/com/moonju/preprocess/api/domain/benchmark/package-info.java
@@ -1,0 +1,1 @@
+package com.moonju.preprocess.api.domain.benchmark;

--- a/backend-api/src/main/java/com/moonju/preprocess/api/domain/image/package-info.java
+++ b/backend-api/src/main/java/com/moonju/preprocess/api/domain/image/package-info.java
@@ -1,0 +1,1 @@
+package com.moonju.preprocess.api.domain.image;

--- a/backend-api/src/main/java/com/moonju/preprocess/api/domain/job/package-info.java
+++ b/backend-api/src/main/java/com/moonju/preprocess/api/domain/job/package-info.java
@@ -1,0 +1,1 @@
+package com.moonju.preprocess.api.domain.job;

--- a/backend-api/src/main/java/com/moonju/preprocess/api/domain/notification/package-info.java
+++ b/backend-api/src/main/java/com/moonju/preprocess/api/domain/notification/package-info.java
@@ -1,0 +1,1 @@
+package com.moonju.preprocess.api.domain.notification;

--- a/backend-api/src/main/java/com/moonju/preprocess/api/domain/preprocess/package-info.java
+++ b/backend-api/src/main/java/com/moonju/preprocess/api/domain/preprocess/package-info.java
@@ -1,0 +1,1 @@
+package com.moonju.preprocess.api.domain.preprocess;

--- a/backend-api/src/main/java/com/moonju/preprocess/api/domain/project/package-info.java
+++ b/backend-api/src/main/java/com/moonju/preprocess/api/domain/project/package-info.java
@@ -1,0 +1,1 @@
+package com.moonju.preprocess.api.domain.project;

--- a/backend-api/src/main/java/com/moonju/preprocess/api/domain/upload/package-info.java
+++ b/backend-api/src/main/java/com/moonju/preprocess/api/domain/upload/package-info.java
@@ -1,0 +1,1 @@
+package com.moonju.preprocess.api.domain.upload;

--- a/backend-api/src/main/java/com/moonju/preprocess/api/domain/user/package-info.java
+++ b/backend-api/src/main/java/com/moonju/preprocess/api/domain/user/package-info.java
@@ -1,0 +1,1 @@
+package com.moonju.preprocess.api.domain.user;

--- a/backend-api/src/main/java/com/moonju/preprocess/api/global/config/package-info.java
+++ b/backend-api/src/main/java/com/moonju/preprocess/api/global/config/package-info.java
@@ -1,0 +1,1 @@
+package com.moonju.preprocess.api.global.config;

--- a/backend-api/src/main/java/com/moonju/preprocess/api/global/error/package-info.java
+++ b/backend-api/src/main/java/com/moonju/preprocess/api/global/error/package-info.java
@@ -1,0 +1,1 @@
+package com.moonju.preprocess.api.global.error;

--- a/backend-api/src/main/java/com/moonju/preprocess/api/global/response/package-info.java
+++ b/backend-api/src/main/java/com/moonju/preprocess/api/global/response/package-info.java
@@ -1,0 +1,1 @@
+package com.moonju.preprocess.api.global.response;

--- a/backend-api/src/main/java/com/moonju/preprocess/api/global/support/package-info.java
+++ b/backend-api/src/main/java/com/moonju/preprocess/api/global/support/package-info.java
@@ -1,0 +1,1 @@
+package com.moonju.preprocess.api.global.support;

--- a/backend-api/src/main/java/com/moonju/preprocess/api/global/util/package-info.java
+++ b/backend-api/src/main/java/com/moonju/preprocess/api/global/util/package-info.java
@@ -1,0 +1,1 @@
+package com.moonju.preprocess.api.global.util;

--- a/backend-api/src/main/java/com/moonju/preprocess/api/infra/metrics/package-info.java
+++ b/backend-api/src/main/java/com/moonju/preprocess/api/infra/metrics/package-info.java
@@ -1,0 +1,1 @@
+package com.moonju.preprocess.api.infra.metrics;

--- a/backend-api/src/main/java/com/moonju/preprocess/api/infra/oauth/package-info.java
+++ b/backend-api/src/main/java/com/moonju/preprocess/api/infra/oauth/package-info.java
@@ -1,0 +1,1 @@
+package com.moonju.preprocess.api.infra.oauth;

--- a/backend-api/src/main/java/com/moonju/preprocess/api/infra/persistence/package-info.java
+++ b/backend-api/src/main/java/com/moonju/preprocess/api/infra/persistence/package-info.java
@@ -1,0 +1,1 @@
+package com.moonju.preprocess.api.infra.persistence;

--- a/backend-api/src/main/java/com/moonju/preprocess/api/infra/rabbitmq/package-info.java
+++ b/backend-api/src/main/java/com/moonju/preprocess/api/infra/rabbitmq/package-info.java
@@ -1,0 +1,1 @@
+package com.moonju.preprocess.api.infra.rabbitmq;

--- a/backend-api/src/main/java/com/moonju/preprocess/api/infra/security/package-info.java
+++ b/backend-api/src/main/java/com/moonju/preprocess/api/infra/security/package-info.java
@@ -1,0 +1,1 @@
+package com.moonju.preprocess.api.infra.security;

--- a/backend-api/src/main/java/com/moonju/preprocess/api/infra/storage/package-info.java
+++ b/backend-api/src/main/java/com/moonju/preprocess/api/infra/storage/package-info.java
@@ -1,0 +1,1 @@
+package com.moonju.preprocess.api.infra.storage;

--- a/backend-api/src/main/java/com/moonju/preprocess/api/infra/tracing/package-info.java
+++ b/backend-api/src/main/java/com/moonju/preprocess/api/infra/tracing/package-info.java
@@ -1,0 +1,1 @@
+package com.moonju.preprocess.api.infra.tracing;

--- a/backend-api/src/main/resources/application.yml
+++ b/backend-api/src/main/resources/application.yml
@@ -1,0 +1,12 @@
+spring:
+  application:
+    name: backend-api
+
+server:
+  port: 8080
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health,info

--- a/backend-api/src/test/java/com/moonju/preprocess/api/BackendApiApplicationTests.java
+++ b/backend-api/src/test/java/com/moonju/preprocess/api/BackendApiApplicationTests.java
@@ -1,0 +1,11 @@
+package com.moonju.preprocess.api;
+
+import org.junit.jupiter.api.Test;
+
+class BackendApiApplicationTests {
+
+    @Test
+    void contextPlaceholder() {
+        // Real Spring context tests start after datasource/security configuration is introduced.
+    }
+}

--- a/docs/feature-specs/issue-6-backend-api-skeleton.md
+++ b/docs/feature-specs/issue-6-backend-api-skeleton.md
@@ -1,0 +1,56 @@
+# Issue 6. backend-api Spring Boot skeleton
+
+## 이슈
+
+- Issue: `#6`
+- Title: `✨ [Feat] backend-api Spring Boot skeleton 추가`
+- Branch: `feat/som/6`
+- Base: `chore/som/3`
+
+## 목표
+
+`backend-api`를 Spring Boot REST API 애플리케이션으로 확장할 수 있는 최소 skeleton으로 만든다.
+
+## 작업 범위
+
+1. Gradle Spring Boot 프로젝트 설정 추가
+2. `BackendApiApplication` entrypoint 추가
+3. 최소 `application.yml` 추가
+4. 도메인형 package boundary 추가
+5. infra/global package boundary 추가
+6. Dockerfile placeholder 추가
+
+## 패키지 원칙
+
+backend-api는 도메인형 구조를 사용한다.
+
+```text
+com.moonju.preprocess.api
+├── domain
+├── infra
+└── global
+```
+
+금지 사항:
+
+1. 최상위 `controller`, `service`, `repository`, `dto` 패키지를 만들지 않는다.
+2. API 서버에 OpenCV 전처리 로직을 넣지 않는다.
+3. Worker 메시지 consume 로직을 넣지 않는다.
+4. 도메인 서비스가 MinIO SDK나 RabbitMQ Template을 직접 의존하지 않도록 한다.
+
+## 범위 제외
+
+1. 공통 응답/예외 클래스 실제 구현
+2. 인증/OAuth2 설정 실제 구현
+3. JPA entity 구현
+4. RabbitMQ publisher 구현
+5. Storage adapter 구현
+6. Controller API 구현
+
+## 완료 기준
+
+1. Spring Boot entrypoint가 존재한다.
+2. Gradle 설정이 존재한다.
+3. 도메인형 package boundary가 존재한다.
+4. API 서버와 Worker 책임이 섞이지 않았다.
+5. 후속 PR에서 공통 응답/예외 skeleton을 추가할 수 있다.


### PR DESCRIPTION
## #️⃣ 기능 설명

`backend-api`를 Spring Boot REST API 애플리케이션으로 확장할 수 있는 최소 skeleton으로 구성합니다.

기존 PR #7은 stacked branch에 merge되어 main에 반영되지 않았기 때문에, main 대상 PR로 다시 생성합니다.

Closes #6

## 🛠️ 작업 상세 내용

- [x] `backend-api/settings.gradle` 추가
- [x] `backend-api/build.gradle` 추가
- [x] `BackendApiApplication.java` 추가
- [x] `application.yml` 최소 설정 추가
- [x] domain/auth, user, project, upload, image, job, preprocess, benchmark, notification, admin, audit package boundary 추가
- [x] infra/oauth, security, storage, rabbitmq, persistence, tracing, metrics package boundary 추가
- [x] global/error, response, config, support, util package boundary 추가
- [x] `backend-api/Dockerfile` 추가
- [x] `docs/feature-specs/issue-6-backend-api-skeleton.md` 추가

## 📁 변경 파일 요약

- `backend-api/build.gradle`
- `backend-api/settings.gradle`
- `backend-api/Dockerfile`
- `backend-api/src/main/java/com/moonju/preprocess/api/BackendApiApplication.java`
- `backend-api/src/main/java/com/moonju/preprocess/api/domain/**/package-info.java`
- `backend-api/src/main/java/com/moonju/preprocess/api/infra/**/package-info.java`
- `backend-api/src/main/java/com/moonju/preprocess/api/global/**/package-info.java`
- `backend-api/src/main/resources/application.yml`
- `backend-api/src/test/java/com/moonju/preprocess/api/BackendApiApplicationTests.java`
- `docs/feature-specs/issue-6-backend-api-skeleton.md`

## ✅ 검증 내용

- [x] `git diff --cached --check`: 통과
- [x] 최상위 계층형 `controller/service/repository/dto` 패키지가 없는지 확인
- [x] backend-api에 Worker consume/OpenCV 처리 로직이 없는지 확인
- [ ] `gradle test`: 로컬에 Gradle이 설치되어 있지 않아 실행하지 못함
- [ ] Docker Gradle 이미지 테스트: Docker CLI는 있으나 Docker Desktop daemon이 실행 중이 아니어서 실행하지 못함

## 🔎 리뷰어가 확인해야 할 부분

- `backend-api` 패키지 루트가 `com.moonju.preprocess.api`로 적절한지 확인해주세요.
- domain/infra/global 경계가 후속 작업에 충분한지 확인해주세요.
- 공통 응답/예외 skeleton은 다음 PR에서 별도 작업으로 진행하는 순서가 적절한지 확인해주세요.

## 📸 스크린샷

Spring skeleton 작업이라 없음.

## 💬 기타 공유사항 to 리뷰어

이 PR은 실제 API 구현이 아니라 Spring Boot skeleton과 패키지 경계만 추가합니다.