### PR TITLE
✨ [Feat] backend-api 공통 응답과 예외 처리 skeleton 추가

### DIFF
--- a/backend-api/src/main/java/com/moonju/preprocess/api/global/error/BusinessException.java
+++ b/backend-api/src/main/java/com/moonju/preprocess/api/global/error/BusinessException.java
@@ -1,0 +1,20 @@
+package com.moonju.preprocess.api.global.error;
+
+public class BusinessException extends RuntimeException {
+
+    private final ErrorCode errorCode;
+
+    public BusinessException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+
+    public BusinessException(ErrorCode errorCode, String message) {
+        super(message);
+        this.errorCode = errorCode;
+    }
+
+    public ErrorCode getErrorCode() {
+        return errorCode;
+    }
+}

--- a/backend-api/src/main/java/com/moonju/preprocess/api/global/error/ErrorCode.java
+++ b/backend-api/src/main/java/com/moonju/preprocess/api/global/error/ErrorCode.java
@@ -1,0 +1,41 @@
+package com.moonju.preprocess.api.global.error;
+
+import org.springframework.http.HttpStatus;
+
+public enum ErrorCode {
+
+    COMMON_OK(HttpStatus.OK, "common200", "요청에 성공했습니다."),
+    COMMON_CREATED(HttpStatus.CREATED, "common201", "생성에 성공했습니다."),
+    COMMON_NO_CONTENT(HttpStatus.NO_CONTENT, "common204", "요청에 성공했습니다."),
+
+    COMMON_BAD_REQUEST(HttpStatus.BAD_REQUEST, "common400", "잘못된 요청입니다."),
+    COMMON_UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "common401", "인증이 필요합니다."),
+    COMMON_FORBIDDEN(HttpStatus.FORBIDDEN, "common403", "접근 권한이 없습니다."),
+    COMMON_NOT_FOUND(HttpStatus.NOT_FOUND, "common404", "요청한 리소스를 찾을 수 없습니다."),
+    COMMON_CONFLICT(HttpStatus.CONFLICT, "common409", "요청 상태가 현재 리소스 상태와 충돌합니다."),
+    COMMON_INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "common500", "서버 내부 오류가 발생했습니다."),
+
+    VALIDATION_ERROR(HttpStatus.BAD_REQUEST, "VALIDATION400", "요청 값이 올바르지 않습니다.");
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+
+    ErrorCode(HttpStatus httpStatus, String code, String message) {
+        this.httpStatus = httpStatus;
+        this.code = code;
+        this.message = message;
+    }
+
+    public HttpStatus getHttpStatus() {
+        return httpStatus;
+    }
+
+    public String getCode() {
+        return code;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+}

--- a/backend-api/src/main/java/com/moonju/preprocess/api/global/error/ErrorResponse.java
+++ b/backend-api/src/main/java/com/moonju/preprocess/api/global/error/ErrorResponse.java
@@ -1,0 +1,37 @@
+package com.moonju.preprocess.api.global.error;
+
+import java.util.List;
+
+public record ErrorResponse(
+    boolean isSuccess,
+    String code,
+    String message,
+    Object result,
+    List<FieldErrorResponse> errors
+) {
+
+    public static ErrorResponse of(ErrorCode errorCode) {
+        return of(errorCode, errorCode.getMessage());
+    }
+
+    public static ErrorResponse of(ErrorCode errorCode, String message) {
+        return new ErrorResponse(false, errorCode.getCode(), message, null, List.of());
+    }
+
+    public static ErrorResponse validation(List<FieldErrorResponse> errors) {
+        return new ErrorResponse(
+            false,
+            ErrorCode.VALIDATION_ERROR.getCode(),
+            ErrorCode.VALIDATION_ERROR.getMessage(),
+            null,
+            errors
+        );
+    }
+
+    public record FieldErrorResponse(
+        String field,
+        String rejectedValue,
+        String reason
+    ) {
+    }
+}

--- a/backend-api/src/main/java/com/moonju/preprocess/api/global/error/GlobalExceptionHandler.java
+++ b/backend-api/src/main/java/com/moonju/preprocess/api/global/error/GlobalExceptionHandler.java
@@ -1,0 +1,70 @@
+package com.moonju.preprocess.api.global.error;
+
+import jakarta.validation.ConstraintViolationException;
+import java.util.List;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(BusinessException.class)
+    public ResponseEntity<ErrorResponse> handleBusinessException(BusinessException exception) {
+        ErrorCode errorCode = exception.getErrorCode();
+        return ResponseEntity
+            .status(errorCode.getHttpStatus())
+            .body(ErrorResponse.of(errorCode, exception.getMessage()));
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ErrorResponse> handleMethodArgumentNotValidException(
+        MethodArgumentNotValidException exception
+    ) {
+        List<ErrorResponse.FieldErrorResponse> errors = exception.getBindingResult()
+            .getFieldErrors()
+            .stream()
+            .map(this::toFieldErrorResponse)
+            .toList();
+
+        return ResponseEntity
+            .status(ErrorCode.VALIDATION_ERROR.getHttpStatus())
+            .body(ErrorResponse.validation(errors));
+    }
+
+    @ExceptionHandler(ConstraintViolationException.class)
+    public ResponseEntity<ErrorResponse> handleConstraintViolationException(
+        ConstraintViolationException exception
+    ) {
+        List<ErrorResponse.FieldErrorResponse> errors = exception.getConstraintViolations()
+            .stream()
+            .map(violation -> new ErrorResponse.FieldErrorResponse(
+                violation.getPropertyPath().toString(),
+                String.valueOf(violation.getInvalidValue()),
+                violation.getMessage()
+            ))
+            .toList();
+
+        return ResponseEntity
+            .status(ErrorCode.VALIDATION_ERROR.getHttpStatus())
+            .body(ErrorResponse.validation(errors));
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ErrorResponse> handleException(Exception exception) {
+        ErrorCode errorCode = ErrorCode.COMMON_INTERNAL_SERVER_ERROR;
+        return ResponseEntity
+            .status(errorCode.getHttpStatus())
+            .body(ErrorResponse.of(errorCode));
+    }
+
+    private ErrorResponse.FieldErrorResponse toFieldErrorResponse(FieldError fieldError) {
+        return new ErrorResponse.FieldErrorResponse(
+            fieldError.getField(),
+            String.valueOf(fieldError.getRejectedValue()),
+            fieldError.getDefaultMessage()
+        );
+    }
+}

--- a/backend-api/src/main/java/com/moonju/preprocess/api/global/response/ApiResponse.java
+++ b/backend-api/src/main/java/com/moonju/preprocess/api/global/response/ApiResponse.java
@@ -1,0 +1,31 @@
+package com.moonju.preprocess.api.global.response;
+
+import com.moonju.preprocess.api.global.error.ErrorCode;
+
+public record ApiResponse<T>(
+    boolean isSuccess,
+    String code,
+    String message,
+    T result
+) {
+
+    public static <T> ApiResponse<T> success(T result) {
+        return success(ErrorCode.COMMON_OK, result);
+    }
+
+    public static <T> ApiResponse<T> success(ErrorCode code, T result) {
+        return new ApiResponse<>(true, code.getCode(), code.getMessage(), result);
+    }
+
+    public static <T> ApiResponse<T> success(String code, String message, T result) {
+        return new ApiResponse<>(true, code, message, result);
+    }
+
+    public static ApiResponse<Void> fail(ErrorCode code) {
+        return fail(code.getCode(), code.getMessage());
+    }
+
+    public static ApiResponse<Void> fail(String code, String message) {
+        return new ApiResponse<>(false, code, message, null);
+    }
+}

--- a/backend-api/src/main/java/com/moonju/preprocess/api/global/response/PageResponse.java
+++ b/backend-api/src/main/java/com/moonju/preprocess/api/global/response/PageResponse.java
@@ -1,0 +1,25 @@
+package com.moonju.preprocess.api.global.response;
+
+import java.util.List;
+import org.springframework.data.domain.Page;
+
+public record PageResponse<T>(
+    List<T> content,
+    int page,
+    int size,
+    long totalElements,
+    int totalPages,
+    boolean hasNext
+) {
+
+    public static <T> PageResponse<T> from(Page<T> page) {
+        return new PageResponse<>(
+            page.getContent(),
+            page.getNumber(),
+            page.getSize(),
+            page.getTotalElements(),
+            page.getTotalPages(),
+            page.hasNext()
+        );
+    }
+}

--- a/backend-api/src/main/java/com/moonju/preprocess/api/global/response/SliceResponse.java
+++ b/backend-api/src/main/java/com/moonju/preprocess/api/global/response/SliceResponse.java
@@ -1,0 +1,21 @@
+package com.moonju.preprocess.api.global.response;
+
+import java.util.List;
+import org.springframework.data.domain.Slice;
+
+public record SliceResponse<T>(
+    List<T> content,
+    int page,
+    int size,
+    boolean hasNext
+) {
+
+    public static <T> SliceResponse<T> from(Slice<T> slice) {
+        return new SliceResponse<>(
+            slice.getContent(),
+            slice.getNumber(),
+            slice.getSize(),
+            slice.hasNext()
+        );
+    }
+}

--- a/backend-api/src/main/java/com/moonju/preprocess/api/global/support/BaseEntity.java
+++ b/backend-api/src/main/java/com/moonju/preprocess/api/global/support/BaseEntity.java
@@ -1,0 +1,30 @@
+package com.moonju.preprocess.api.global.support;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseEntity {
+
+    @CreatedDate
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(nullable = false)
+    private LocalDateTime updatedAt;
+
+    public LocalDateTime getCreatedAt() {
+        return createdAt;
+    }
+
+    public LocalDateTime getUpdatedAt() {
+        return updatedAt;
+    }
+}

--- a/backend-api/src/main/java/com/moonju/preprocess/api/global/support/CurrentUser.java
+++ b/backend-api/src/main/java/com/moonju/preprocess/api/global/support/CurrentUser.java
@@ -1,0 +1,11 @@
+package com.moonju.preprocess.api.global.support;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface CurrentUser {
+}

--- a/backend-api/src/test/java/com/moonju/preprocess/api/global/error/BusinessExceptionTests.java
+++ b/backend-api/src/test/java/com/moonju/preprocess/api/global/error/BusinessExceptionTests.java
@@ -1,0 +1,24 @@
+package com.moonju.preprocess.api.global.error;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class BusinessExceptionTests {
+
+    @Test
+    void keepsErrorCodeAndDefaultMessage() {
+        BusinessException exception = new BusinessException(ErrorCode.COMMON_NOT_FOUND);
+
+        assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.COMMON_NOT_FOUND);
+        assertThat(exception.getMessage()).isEqualTo(ErrorCode.COMMON_NOT_FOUND.getMessage());
+    }
+
+    @Test
+    void supportsCustomMessage() {
+        BusinessException exception = new BusinessException(ErrorCode.COMMON_CONFLICT, "custom conflict");
+
+        assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.COMMON_CONFLICT);
+        assertThat(exception.getMessage()).isEqualTo("custom conflict");
+    }
+}

--- a/backend-api/src/test/java/com/moonju/preprocess/api/global/error/ErrorResponseTests.java
+++ b/backend-api/src/test/java/com/moonju/preprocess/api/global/error/ErrorResponseTests.java
@@ -1,0 +1,35 @@
+package com.moonju.preprocess.api.global.error;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class ErrorResponseTests {
+
+    @Test
+    void createsBusinessErrorResponse() {
+        ErrorResponse response = ErrorResponse.of(ErrorCode.COMMON_FORBIDDEN);
+
+        assertThat(response.isSuccess()).isFalse();
+        assertThat(response.code()).isEqualTo("common403");
+        assertThat(response.message()).isEqualTo(ErrorCode.COMMON_FORBIDDEN.getMessage());
+        assertThat(response.result()).isNull();
+        assertThat(response.errors()).isEmpty();
+    }
+
+    @Test
+    void createsValidationErrorResponse() {
+        ErrorResponse.FieldErrorResponse fieldError = new ErrorResponse.FieldErrorResponse(
+            "name",
+            "",
+            "must not be blank"
+        );
+
+        ErrorResponse response = ErrorResponse.validation(List.of(fieldError));
+
+        assertThat(response.isSuccess()).isFalse();
+        assertThat(response.code()).isEqualTo("VALIDATION400");
+        assertThat(response.errors()).containsExactly(fieldError);
+    }
+}

--- a/backend-api/src/test/java/com/moonju/preprocess/api/global/response/ApiResponseTests.java
+++ b/backend-api/src/test/java/com/moonju/preprocess/api/global/response/ApiResponseTests.java
@@ -1,0 +1,28 @@
+package com.moonju.preprocess.api.global.response;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.moonju.preprocess.api.global.error.ErrorCode;
+import org.junit.jupiter.api.Test;
+
+class ApiResponseTests {
+
+    @Test
+    void createsSuccessResponse() {
+        ApiResponse<String> response = ApiResponse.success("ok");
+
+        assertThat(response.isSuccess()).isTrue();
+        assertThat(response.code()).isEqualTo("common200");
+        assertThat(response.message()).isEqualTo(ErrorCode.COMMON_OK.getMessage());
+        assertThat(response.result()).isEqualTo("ok");
+    }
+
+    @Test
+    void createsFailResponse() {
+        ApiResponse<Void> response = ApiResponse.fail(ErrorCode.COMMON_UNAUTHORIZED);
+
+        assertThat(response.isSuccess()).isFalse();
+        assertThat(response.code()).isEqualTo("common401");
+        assertThat(response.result()).isNull();
+    }
+}

--- a/docs/feature-specs/issue-9-global-error-response.md
+++ b/docs/feature-specs/issue-9-global-error-response.md
@@ -1,0 +1,66 @@
+# Issue 9. Global error and response skeleton
+
+## 이슈
+
+- Issue: `#9`
+- Title: `✨ [Feat] backend-api 공통 응답과 예외 처리 skeleton 추가`
+- Branch: `feat/som/9`
+- Base: `feat/som/6`
+
+## 목표
+
+`backend-api` 전체 controller와 service에서 공통으로 사용할 응답 wrapper, 예외 base, error code, global exception handler를 만든다.
+
+## 작업 범위
+
+1. `BusinessException`
+2. `ErrorCode`
+3. `ErrorResponse`
+4. `GlobalExceptionHandler`
+5. `ApiResponse`
+6. `PageResponse`
+7. `SliceResponse`
+8. `BaseEntity`
+9. `CurrentUser`
+10. 공통 응답/예외 단위 테스트
+
+## 응답 원칙
+
+성공 응답은 `ApiResponse<T>`를 사용한다.
+
+```json
+{
+  "isSuccess": true,
+  "code": "common200",
+  "message": "요청에 성공했습니다.",
+  "result": {}
+}
+```
+
+실패 응답은 `ErrorResponse`를 사용한다.
+
+```json
+{
+  "isSuccess": false,
+  "code": "common400",
+  "message": "잘못된 요청입니다.",
+  "result": null,
+  "errors": []
+}
+```
+
+## 예외 처리 원칙
+
+1. `BusinessException`은 내부 `ErrorCode`를 가진다.
+2. `ErrorCode`는 HTTP status와 내부 code를 함께 가진다.
+3. `GlobalExceptionHandler`는 business, validation, unknown exception을 분리한다.
+4. 내부 stack trace는 사용자 응답에 노출하지 않는다.
+5. 도메인 전용 예외는 각 도메인 패키지에 둔다.
+
+## 범위 제외
+
+1. 도메인 전용 예외 구현
+2. 인증 사용자 resolver 구현
+3. JPA entity 구현
+4. Swagger 설정
+5. 실제 controller API 구현


### PR DESCRIPTION
## #️⃣ 기능 설명

`backend-api` 전체에서 사용할 공통 응답 wrapper, 공통 예외 base, error code, global exception handler, paging response, JPA base entity skeleton을 추가했습니다.

PR #8이 아직 main에 merge되지 않았기 때문에 이 PR은 `feat/som/6`을 base로 하는 stacked PR입니다.

Depends on #8
Closes #9

## 🛠️ 작업 상세 내용

- [x] `BusinessException` 추가
- [x] `ErrorCode` 추가
- [x] `ErrorResponse` 추가
- [x] `GlobalExceptionHandler` 추가
- [x] `ApiResponse` 추가
- [x] `PageResponse` 추가
- [x] `SliceResponse` 추가
- [x] `BaseEntity` 추가
- [x] `CurrentUser` annotation placeholder 추가
- [x] 공통 응답/예외 단위 테스트 추가
- [x] `docs/feature-specs/issue-9-global-error-response.md` 추가

## 📁 변경 파일 요약

- `backend-api/src/main/java/com/moonju/preprocess/api/global/error/*`
- `backend-api/src/main/java/com/moonju/preprocess/api/global/response/*`
- `backend-api/src/main/java/com/moonju/preprocess/api/global/support/*`
- `backend-api/src/test/java/com/moonju/preprocess/api/global/error/*`
- `backend-api/src/test/java/com/moonju/preprocess/api/global/response/*`
- `docs/feature-specs/issue-9-global-error-response.md`

## ✅ 검증 내용

- [x] `git diff --cached --check`: 통과
- [x] 최상위 패키지가 `domain/global/infra`만 있는지 확인
- [x] backend-api에 Worker listener/OpenCV 처리 로직이 없는지 확인
- [ ] `gradle test`: 로컬에 Gradle/Gradle wrapper가 없어 실행하지 못함
- [ ] Docker Gradle 테스트: Docker Desktop daemon이 실행 중이 아니어서 실행하지 못함

## 🔎 리뷰어가 확인해야 할 부분

- 실패 응답에서 `ErrorResponse`를 별도 사용하고, 성공 응답에서 `ApiResponse`를 쓰는 방향이 팀 컨벤션에 맞는지 확인해주세요.
- validation error 확장 필드 `errors` 구조가 충분한지 확인해주세요.
- `BaseEntity`의 JPA auditing 기준이 후속 entity 구현에 적절한지 확인해주세요.

## 📸 스크린샷

백엔드 skeleton 작업이라 없음.

## 💬 기타 공유사항 to 리뷰어

실제 domain controller/service 구현은 포함하지 않았습니다.