### PR TITLE
✨ [Feat] user/auth 도메인 entity, repository skeleton 추가

### DIFF
--- a/backend-api/src/main/java/com/moonju/preprocess/api/domain/auth/entity/RefreshToken.java
+++ b/backend-api/src/main/java/com/moonju/preprocess/api/domain/auth/entity/RefreshToken.java
@@ -1,0 +1,73 @@
+package com.moonju.preprocess.api.domain.auth.entity;
+
+import com.moonju.preprocess.api.global.support.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(
+    name = "refresh_tokens",
+    uniqueConstraints = {
+        @UniqueConstraint(name = "uk_refresh_token_hash", columnNames = "token_hash")
+    }
+)
+public class RefreshToken extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private Long userId;
+
+    @Column(name = "token_hash", nullable = false, length = 128)
+    private String tokenHash;
+
+    @Column(nullable = false)
+    private LocalDateTime expiresAt;
+
+    private LocalDateTime revokedAt;
+
+    protected RefreshToken() {
+    }
+
+    public RefreshToken(Long userId, String tokenHash, LocalDateTime expiresAt) {
+        this.userId = userId;
+        this.tokenHash = tokenHash;
+        this.expiresAt = expiresAt;
+    }
+
+    public void revoke(LocalDateTime revokedAt) {
+        this.revokedAt = revokedAt;
+    }
+
+    public boolean isRevoked() {
+        return revokedAt != null;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public Long getUserId() {
+        return userId;
+    }
+
+    public String getTokenHash() {
+        return tokenHash;
+    }
+
+    public LocalDateTime getExpiresAt() {
+        return expiresAt;
+    }
+
+    public LocalDateTime getRevokedAt() {
+        return revokedAt;
+    }
+}

--- a/backend-api/src/main/java/com/moonju/preprocess/api/domain/auth/repository/RefreshTokenRepository.java
+++ b/backend-api/src/main/java/com/moonju/preprocess/api/domain/auth/repository/RefreshTokenRepository.java
@@ -1,0 +1,15 @@
+package com.moonju.preprocess.api.domain.auth.repository;
+
+import com.moonju.preprocess.api.domain.auth.entity.RefreshToken;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
+
+    Optional<RefreshToken> findByTokenHash(String tokenHash);
+
+    List<RefreshToken> findAllByUserId(Long userId);
+
+    void deleteAllByUserId(Long userId);
+}

--- a/backend-api/src/main/java/com/moonju/preprocess/api/domain/user/entity/SocialAccount.java
+++ b/backend-api/src/main/java/com/moonju/preprocess/api/domain/user/entity/SocialAccount.java
@@ -1,0 +1,74 @@
+package com.moonju.preprocess.api.domain.user.entity;
+
+import com.moonju.preprocess.api.global.support.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+
+@Entity
+@Table(
+    name = "social_accounts",
+    uniqueConstraints = {
+        @UniqueConstraint(name = "uk_social_account_provider_user", columnNames = {"provider", "provider_user_id"}),
+        @UniqueConstraint(name = "uk_social_account_user_provider", columnNames = {"user_id", "provider"})
+    }
+)
+public class SocialAccount extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 30)
+    private SocialProvider provider;
+
+    @Column(name = "provider_user_id", nullable = false, length = 200)
+    private String providerUserId;
+
+    @Column(length = 320)
+    private String email;
+
+    protected SocialAccount() {
+    }
+
+    public SocialAccount(User user, SocialProvider provider, String providerUserId, String email) {
+        this.user = user;
+        this.provider = provider;
+        this.providerUserId = providerUserId;
+        this.email = email;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public User getUser() {
+        return user;
+    }
+
+    public SocialProvider getProvider() {
+        return provider;
+    }
+
+    public String getProviderUserId() {
+        return providerUserId;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+}

--- a/backend-api/src/main/java/com/moonju/preprocess/api/domain/user/entity/SocialProvider.java
+++ b/backend-api/src/main/java/com/moonju/preprocess/api/domain/user/entity/SocialProvider.java
@@ -1,0 +1,6 @@
+package com.moonju.preprocess.api.domain.user.entity;
+
+public enum SocialProvider {
+    GOOGLE,
+    KAKAO
+}

--- a/backend-api/src/main/java/com/moonju/preprocess/api/domain/user/entity/User.java
+++ b/backend-api/src/main/java/com/moonju/preprocess/api/domain/user/entity/User.java
@@ -1,0 +1,80 @@
+package com.moonju.preprocess.api.domain.user.entity;
+
+import com.moonju.preprocess.api.global.support.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+@Entity
+@Table(name = "users")
+public class User extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, length = 320)
+    private String email;
+
+    @Column(nullable = false, length = 100)
+    private String name;
+
+    @Column(length = 1000)
+    private String profileImageUrl;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 30)
+    private UserRole role;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 30)
+    private UserStatus status;
+
+    protected User() {
+    }
+
+    public User(String email, String name, String profileImageUrl, UserRole role, UserStatus status) {
+        this.email = email;
+        this.name = name;
+        this.profileImageUrl = profileImageUrl;
+        this.role = role;
+        this.status = status;
+    }
+
+    public static User createUser(String email, String name, String profileImageUrl) {
+        return new User(email, name, profileImageUrl, UserRole.USER, UserStatus.ACTIVE);
+    }
+
+    public void delete() {
+        this.status = UserStatus.DELETED;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getProfileImageUrl() {
+        return profileImageUrl;
+    }
+
+    public UserRole getRole() {
+        return role;
+    }
+
+    public UserStatus getStatus() {
+        return status;
+    }
+}

--- a/backend-api/src/main/java/com/moonju/preprocess/api/domain/user/entity/UserRole.java
+++ b/backend-api/src/main/java/com/moonju/preprocess/api/domain/user/entity/UserRole.java
@@ -1,0 +1,6 @@
+package com.moonju.preprocess.api.domain.user.entity;
+
+public enum UserRole {
+    USER,
+    ADMIN
+}

--- a/backend-api/src/main/java/com/moonju/preprocess/api/domain/user/entity/UserStatus.java
+++ b/backend-api/src/main/java/com/moonju/preprocess/api/domain/user/entity/UserStatus.java
@@ -1,0 +1,7 @@
+package com.moonju.preprocess.api.domain.user.entity;
+
+public enum UserStatus {
+    ACTIVE,
+    DELETED,
+    BANNED
+}

--- a/backend-api/src/main/java/com/moonju/preprocess/api/domain/user/repository/SocialAccountRepository.java
+++ b/backend-api/src/main/java/com/moonju/preprocess/api/domain/user/repository/SocialAccountRepository.java
@@ -1,0 +1,15 @@
+package com.moonju.preprocess.api.domain.user.repository;
+
+import com.moonju.preprocess.api.domain.user.entity.SocialAccount;
+import com.moonju.preprocess.api.domain.user.entity.SocialProvider;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SocialAccountRepository extends JpaRepository<SocialAccount, Long> {
+
+    Optional<SocialAccount> findByProviderAndProviderUserId(SocialProvider provider, String providerUserId);
+
+    boolean existsByProviderAndProviderUserId(SocialProvider provider, String providerUserId);
+
+    boolean existsByUserIdAndProvider(Long userId, SocialProvider provider);
+}

--- a/backend-api/src/main/java/com/moonju/preprocess/api/domain/user/repository/UserRepository.java
+++ b/backend-api/src/main/java/com/moonju/preprocess/api/domain/user/repository/UserRepository.java
@@ -1,0 +1,12 @@
+package com.moonju.preprocess.api.domain.user.repository;
+
+import com.moonju.preprocess.api.domain.user.entity.User;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+
+    Optional<User> findByEmail(String email);
+
+    boolean existsByEmail(String email);
+}

--- a/backend-api/src/test/java/com/moonju/preprocess/api/domain/auth/entity/RefreshTokenTests.java
+++ b/backend-api/src/test/java/com/moonju/preprocess/api/domain/auth/entity/RefreshTokenTests.java
@@ -1,0 +1,31 @@
+package com.moonju.preprocess.api.domain.auth.entity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.Test;
+
+class RefreshTokenTests {
+
+    @Test
+    void createsRefreshToken() {
+        LocalDateTime expiresAt = LocalDateTime.now().plusDays(14);
+        RefreshToken refreshToken = new RefreshToken(1L, "hash", expiresAt);
+
+        assertThat(refreshToken.getUserId()).isEqualTo(1L);
+        assertThat(refreshToken.getTokenHash()).isEqualTo("hash");
+        assertThat(refreshToken.getExpiresAt()).isEqualTo(expiresAt);
+        assertThat(refreshToken.isRevoked()).isFalse();
+    }
+
+    @Test
+    void revokesRefreshToken() {
+        RefreshToken refreshToken = new RefreshToken(1L, "hash", LocalDateTime.now().plusDays(14));
+        LocalDateTime revokedAt = LocalDateTime.now();
+
+        refreshToken.revoke(revokedAt);
+
+        assertThat(refreshToken.isRevoked()).isTrue();
+        assertThat(refreshToken.getRevokedAt()).isEqualTo(revokedAt);
+    }
+}

--- a/backend-api/src/test/java/com/moonju/preprocess/api/domain/user/entity/SocialAccountTests.java
+++ b/backend-api/src/test/java/com/moonju/preprocess/api/domain/user/entity/SocialAccountTests.java
@@ -1,0 +1,19 @@
+package com.moonju.preprocess.api.domain.user.entity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class SocialAccountTests {
+
+    @Test
+    void createsSocialAccount() {
+        User user = User.createUser("moonju@example.com", "MoonJu", null);
+        SocialAccount socialAccount = new SocialAccount(user, SocialProvider.GOOGLE, "google-123", user.getEmail());
+
+        assertThat(socialAccount.getUser()).isSameAs(user);
+        assertThat(socialAccount.getProvider()).isEqualTo(SocialProvider.GOOGLE);
+        assertThat(socialAccount.getProviderUserId()).isEqualTo("google-123");
+        assertThat(socialAccount.getEmail()).isEqualTo(user.getEmail());
+    }
+}

--- a/backend-api/src/test/java/com/moonju/preprocess/api/domain/user/entity/UserTests.java
+++ b/backend-api/src/test/java/com/moonju/preprocess/api/domain/user/entity/UserTests.java
@@ -1,0 +1,27 @@
+package com.moonju.preprocess.api.domain.user.entity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class UserTests {
+
+    @Test
+    void createsDefaultUser() {
+        User user = User.createUser("moonju@example.com", "MoonJu", "https://example.com/profile.png");
+
+        assertThat(user.getEmail()).isEqualTo("moonju@example.com");
+        assertThat(user.getName()).isEqualTo("MoonJu");
+        assertThat(user.getRole()).isEqualTo(UserRole.USER);
+        assertThat(user.getStatus()).isEqualTo(UserStatus.ACTIVE);
+    }
+
+    @Test
+    void marksUserDeleted() {
+        User user = User.createUser("moonju@example.com", "MoonJu", null);
+
+        user.delete();
+
+        assertThat(user.getStatus()).isEqualTo(UserStatus.DELETED);
+    }
+}

--- a/docs/feature-specs/issue-12-user-auth-skeleton.md
+++ b/docs/feature-specs/issue-12-user-auth-skeleton.md
@@ -1,0 +1,71 @@
+# Issue 12. User/Auth domain skeleton
+
+## 이슈
+
+- Issue: `#12`
+- Title: `✨ [Feat] user/auth 도메인 entity, repository skeleton 추가`
+- Branch: `feat/som/12`
+- Base: `feat/som/9`
+
+## 목표
+
+Google/Kakao 소셜 로그인과 refresh token 관리를 위한 user/auth 도메인의 entity와 repository skeleton을 만든다.
+
+## 작업 범위
+
+1. `User`
+2. `SocialAccount`
+3. `RefreshToken`
+4. `UserRole`
+5. `UserStatus`
+6. `SocialProvider`
+7. `UserRepository`
+8. `SocialAccountRepository`
+9. `RefreshTokenRepository`
+10. entity 단위 테스트
+
+## 도메인 모델
+
+`User`:
+
+1. email
+2. name
+3. profileImageUrl
+4. role
+5. status
+
+`SocialAccount`:
+
+1. user
+2. provider
+3. providerUserId
+4. email
+
+`RefreshToken`:
+
+1. userId
+2. tokenHash
+3. expiresAt
+4. revokedAt
+
+## repository 기준
+
+1. `UserRepository`는 email 기반 조회를 지원한다.
+2. `SocialAccountRepository`는 provider + providerUserId 기반 조회를 지원한다.
+3. `RefreshTokenRepository`는 tokenHash와 userId 기반 조회/삭제를 지원한다.
+
+## 범위 제외
+
+1. OAuth2 login success handler
+2. JWT 발급
+3. Refresh token cookie 설정
+4. SecurityConfig
+5. Controller API
+6. DB migration
+
+## 주의 사항
+
+1. Worker에 인증 로직을 넣지 않는다.
+2. OAuth client secret을 커밋하지 않는다.
+3. Access token을 장기 토큰으로 사용하지 않는다.
+4. API 서버에 OpenCV 전처리 로직을 넣지 않는다.


### PR DESCRIPTION
## #️⃣ 기능 설명

`backend-api`의 user/auth 도메인에 사용자, 소셜 계정, refresh token entity와 repository skeleton을 추가했습니다.

PR #11이 아직 main에 merge되지 않았기 때문에 이 PR은 `feat/som/9`를 base로 하는 stacked PR입니다.

Depends on #11
Closes #12

## 🛠️ 작업 상세 내용

- [x] `User` entity 추가
- [x] `SocialAccount` entity 추가
- [x] `RefreshToken` entity 추가
- [x] `UserRole`, `UserStatus`, `SocialProvider` enum 추가
- [x] `UserRepository` 추가
- [x] `SocialAccountRepository` 추가
- [x] `RefreshTokenRepository` 추가
- [x] entity 단위 테스트 추가
- [x] `docs/feature-specs/issue-12-user-auth-skeleton.md` 추가

## 📁 변경 파일 요약

- `backend-api/src/main/java/com/moonju/preprocess/api/domain/user/entity/*`
- `backend-api/src/main/java/com/moonju/preprocess/api/domain/user/repository/*`
- `backend-api/src/main/java/com/moonju/preprocess/api/domain/auth/entity/*`
- `backend-api/src/main/java/com/moonju/preprocess/api/domain/auth/repository/*`
- `backend-api/src/test/java/com/moonju/preprocess/api/domain/user/entity/*`
- `backend-api/src/test/java/com/moonju/preprocess/api/domain/auth/entity/*`
- `docs/feature-specs/issue-12-user-auth-skeleton.md`

## ✅ 검증 내용

- [x] Docker 기반 `gradle test`: 통과
- [x] `git diff --cached --check`: 통과
- [x] 최상위 패키지가 `domain/global/infra`만 있는지 확인
- [x] backend-api에 Worker listener/OpenCV 처리 로직이 없는지 확인
- [x] OAuth client secret 또는 storage secret 미추가 확인

검증 명령:

```powershell
$backendPath = Join-Path (Get-Location) 'backend-api'
docker run --rm -v "${backendPath}:/workspace" -w /workspace gradle:8.10-jdk21 gradle test --no-daemon
```

## 🔎 리뷰어가 확인해야 할 부분

- `SocialAccount` unique constraint가 provider + providerUserId, user + provider 기준으로 충분한지 확인해주세요.
- `RefreshToken`이 `userId` 직접 참조로 충분한지, `User` 연관관계가 필요한지 확인해주세요.
- 실제 OAuth2/JWT 구현을 다음 PR로 분리하는 범위가 적절한지 확인해주세요.

## 📸 스크린샷

백엔드 entity skeleton 작업이라 없음.

## 💬 기타 공유사항 to 리뷰어

실제 OAuth2 로그인, JWT 발급, SecurityConfig 구현은 포함하지 않았습니다.