### PR TITLE
✨ [Feat] Upload 도메인 skeleton 추가

### DIFF
--- a/backend-api/src/main/java/com/moonju/preprocess/api/domain/upload/controller/UploadSessionController.java
+++ b/backend-api/src/main/java/com/moonju/preprocess/api/domain/upload/controller/UploadSessionController.java
@@ -1,0 +1,84 @@
+package com.moonju.preprocess.api.domain.upload.controller;
+
+import com.moonju.preprocess.api.domain.upload.dto.PresignedUploadUrlRequest;
+import com.moonju.preprocess.api.domain.upload.dto.PresignedUploadUrlResponse;
+import com.moonju.preprocess.api.domain.upload.dto.UploadCompleteRequest;
+import com.moonju.preprocess.api.domain.upload.dto.UploadCompleteResponse;
+import com.moonju.preprocess.api.domain.upload.dto.UploadSessionCreateRequest;
+import com.moonju.preprocess.api.domain.upload.dto.UploadSessionResponse;
+import com.moonju.preprocess.api.domain.upload.service.PresignedUploadService;
+import com.moonju.preprocess.api.domain.upload.service.UploadCompleteService;
+import com.moonju.preprocess.api.domain.upload.service.UploadSessionService;
+import com.moonju.preprocess.api.global.response.ApiResponse;
+import com.moonju.preprocess.api.global.support.CurrentUser;
+import jakarta.validation.Valid;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1")
+public class UploadSessionController {
+
+    private final UploadSessionService uploadSessionService;
+    private final PresignedUploadService presignedUploadService;
+    private final UploadCompleteService uploadCompleteService;
+
+    public UploadSessionController(
+        UploadSessionService uploadSessionService,
+        PresignedUploadService presignedUploadService,
+        UploadCompleteService uploadCompleteService
+    ) {
+        this.uploadSessionService = uploadSessionService;
+        this.presignedUploadService = presignedUploadService;
+        this.uploadCompleteService = uploadCompleteService;
+    }
+
+    @PostMapping("/projects/{projectId}/upload-sessions")
+    public ApiResponse<UploadSessionResponse> create(
+        @CurrentUser Long currentUserId,
+        @PathVariable Long projectId,
+        @Valid @RequestBody UploadSessionCreateRequest request
+    ) {
+        return ApiResponse.success(uploadSessionService.create(currentUserId, projectId, request));
+    }
+
+    @GetMapping("/upload-sessions/{sessionId}")
+    public ApiResponse<UploadSessionResponse> findOne(
+        @CurrentUser Long currentUserId,
+        @PathVariable Long sessionId
+    ) {
+        return ApiResponse.success(uploadSessionService.findOne(currentUserId, sessionId));
+    }
+
+    @PostMapping("/upload-sessions/{sessionId}/files/presigned-url")
+    public ApiResponse<PresignedUploadUrlResponse> createPresignedUrls(
+        @CurrentUser Long currentUserId,
+        @PathVariable Long sessionId,
+        @Valid @RequestBody PresignedUploadUrlRequest request
+    ) {
+        return ApiResponse.success(presignedUploadService.createUploadUrls(currentUserId, sessionId, request));
+    }
+
+    @PostMapping("/upload-sessions/{sessionId}/complete")
+    public ApiResponse<UploadCompleteResponse> complete(
+        @CurrentUser Long currentUserId,
+        @PathVariable Long sessionId,
+        @Valid @RequestBody UploadCompleteRequest request
+    ) {
+        return ApiResponse.success(uploadCompleteService.complete(currentUserId, sessionId, request));
+    }
+
+    @DeleteMapping("/upload-sessions/{sessionId}")
+    public ApiResponse<Void> cancel(
+        @CurrentUser Long currentUserId,
+        @PathVariable Long sessionId
+    ) {
+        uploadSessionService.cancel(currentUserId, sessionId);
+        return ApiResponse.success("common204", "Upload session cancelled.", null);
+    }
+}

--- a/backend-api/src/main/java/com/moonju/preprocess/api/domain/upload/dto/PresignedUploadFileRequest.java
+++ b/backend-api/src/main/java/com/moonju/preprocess/api/domain/upload/dto/PresignedUploadFileRequest.java
@@ -1,0 +1,24 @@
+package com.moonju.preprocess.api.domain.upload.dto;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+
+public record PresignedUploadFileRequest(
+    @NotBlank
+    @Size(max = 255)
+    String fileName,
+
+    @NotBlank
+    @Size(max = 100)
+    String contentType,
+
+    @Min(1)
+    long sizeBytes,
+
+    @NotBlank
+    @Pattern(regexp = "^[a-fA-F0-9]{64}$")
+    String checksumSha256
+) {
+}

--- a/backend-api/src/main/java/com/moonju/preprocess/api/domain/upload/dto/PresignedUploadUrlRequest.java
+++ b/backend-api/src/main/java/com/moonju/preprocess/api/domain/upload/dto/PresignedUploadUrlRequest.java
@@ -1,0 +1,14 @@
+package com.moonju.preprocess.api.domain.upload.dto;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.Size;
+import java.util.List;
+
+public record PresignedUploadUrlRequest(
+    @Valid
+    @NotEmpty
+    @Size(max = 500)
+    List<PresignedUploadFileRequest> files
+) {
+}

--- a/backend-api/src/main/java/com/moonju/preprocess/api/domain/upload/dto/PresignedUploadUrlResponse.java
+++ b/backend-api/src/main/java/com/moonju/preprocess/api/domain/upload/dto/PresignedUploadUrlResponse.java
@@ -1,0 +1,36 @@
+package com.moonju.preprocess.api.domain.upload.dto;
+
+import com.moonju.preprocess.api.domain.upload.entity.UploadSessionFile;
+import com.moonju.preprocess.api.infra.storage.PresignedUploadTarget;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+
+public record PresignedUploadUrlResponse(
+    Long sessionId,
+    List<UploadTargetResponse> uploadTargets
+) {
+
+    public static PresignedUploadUrlResponse of(Long sessionId, List<UploadTargetResponse> uploadTargets) {
+        return new PresignedUploadUrlResponse(sessionId, uploadTargets);
+    }
+
+    public record UploadTargetResponse(
+        Long uploadFileId,
+        String objectKey,
+        String uploadUrl,
+        Instant expiresAt,
+        Map<String, String> requiredHeaders
+    ) {
+
+        public static UploadTargetResponse of(UploadSessionFile file, PresignedUploadTarget target) {
+            return new UploadTargetResponse(
+                file.getId(),
+                target.objectKey(),
+                target.uploadUrl(),
+                target.expiresAt(),
+                target.requiredHeaders()
+            );
+        }
+    }
+}

--- a/backend-api/src/main/java/com/moonju/preprocess/api/domain/upload/dto/UploadCompleteRequest.java
+++ b/backend-api/src/main/java/com/moonju/preprocess/api/domain/upload/dto/UploadCompleteRequest.java
@@ -1,0 +1,10 @@
+package com.moonju.preprocess.api.domain.upload.dto;
+
+import jakarta.validation.constraints.NotEmpty;
+import java.util.List;
+
+public record UploadCompleteRequest(
+    @NotEmpty
+    List<Long> uploadFileIds
+) {
+}

--- a/backend-api/src/main/java/com/moonju/preprocess/api/domain/upload/dto/UploadCompleteResponse.java
+++ b/backend-api/src/main/java/com/moonju/preprocess/api/domain/upload/dto/UploadCompleteResponse.java
@@ -1,0 +1,15 @@
+package com.moonju.preprocess.api.domain.upload.dto;
+
+import com.moonju.preprocess.api.domain.upload.entity.UploadSession;
+import com.moonju.preprocess.api.domain.upload.entity.UploadSessionStatus;
+
+public record UploadCompleteResponse(
+    Long sessionId,
+    UploadSessionStatus status,
+    int uploadedFileCount
+) {
+
+    public static UploadCompleteResponse of(UploadSession uploadSession, int uploadedFileCount) {
+        return new UploadCompleteResponse(uploadSession.getId(), uploadSession.getStatus(), uploadedFileCount);
+    }
+}

--- a/backend-api/src/main/java/com/moonju/preprocess/api/domain/upload/dto/UploadSessionCreateRequest.java
+++ b/backend-api/src/main/java/com/moonju/preprocess/api/domain/upload/dto/UploadSessionCreateRequest.java
@@ -1,0 +1,17 @@
+package com.moonju.preprocess.api.domain.upload.dto;
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+
+public record UploadSessionCreateRequest(
+    @NotNull
+    @Min(1)
+    @Max(100_000)
+    Integer expectedFileCount,
+
+    @NotNull
+    @Min(1)
+    Long expectedTotalSizeBytes
+) {
+}

--- a/backend-api/src/main/java/com/moonju/preprocess/api/domain/upload/dto/UploadSessionResponse.java
+++ b/backend-api/src/main/java/com/moonju/preprocess/api/domain/upload/dto/UploadSessionResponse.java
@@ -1,0 +1,30 @@
+package com.moonju.preprocess.api.domain.upload.dto;
+
+import com.moonju.preprocess.api.domain.upload.entity.UploadSession;
+import com.moonju.preprocess.api.domain.upload.entity.UploadSessionStatus;
+import java.time.LocalDateTime;
+
+public record UploadSessionResponse(
+    Long id,
+    Long projectId,
+    Long userId,
+    UploadSessionStatus status,
+    int expectedFileCount,
+    long expectedTotalSizeBytes,
+    LocalDateTime completedAt,
+    LocalDateTime cancelledAt
+) {
+
+    public static UploadSessionResponse from(UploadSession uploadSession) {
+        return new UploadSessionResponse(
+            uploadSession.getId(),
+            uploadSession.getProjectId(),
+            uploadSession.getUserId(),
+            uploadSession.getStatus(),
+            uploadSession.getExpectedFileCount(),
+            uploadSession.getExpectedTotalSizeBytes(),
+            uploadSession.getCompletedAt(),
+            uploadSession.getCancelledAt()
+        );
+    }
+}

--- a/backend-api/src/main/java/com/moonju/preprocess/api/domain/upload/entity/UploadFileStatus.java
+++ b/backend-api/src/main/java/com/moonju/preprocess/api/domain/upload/entity/UploadFileStatus.java
@@ -1,0 +1,6 @@
+package com.moonju.preprocess.api.domain.upload.entity;
+
+public enum UploadFileStatus {
+    UPLOAD_URL_ISSUED,
+    UPLOADED
+}

--- a/backend-api/src/main/java/com/moonju/preprocess/api/domain/upload/entity/UploadSession.java
+++ b/backend-api/src/main/java/com/moonju/preprocess/api/domain/upload/entity/UploadSession.java
@@ -1,0 +1,125 @@
+package com.moonju.preprocess.api.domain.upload.entity;
+
+import com.moonju.preprocess.api.global.support.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "upload_sessions")
+public class UploadSession extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private Long projectId;
+
+    @Column(nullable = false)
+    private Long userId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 30)
+    private UploadSessionStatus status;
+
+    @Column(nullable = false)
+    private int expectedFileCount;
+
+    @Column(nullable = false)
+    private long expectedTotalSizeBytes;
+
+    private LocalDateTime completedAt;
+
+    private LocalDateTime cancelledAt;
+
+    protected UploadSession() {
+    }
+
+    public UploadSession(
+        Long projectId,
+        Long userId,
+        UploadSessionStatus status,
+        int expectedFileCount,
+        long expectedTotalSizeBytes
+    ) {
+        this.projectId = projectId;
+        this.userId = userId;
+        this.status = status;
+        this.expectedFileCount = expectedFileCount;
+        this.expectedTotalSizeBytes = expectedTotalSizeBytes;
+    }
+
+    public static UploadSession create(
+        Long projectId,
+        Long userId,
+        int expectedFileCount,
+        long expectedTotalSizeBytes
+    ) {
+        return new UploadSession(
+            projectId,
+            userId,
+            UploadSessionStatus.CREATED,
+            expectedFileCount,
+            expectedTotalSizeBytes
+        );
+    }
+
+    public void markUploadUrlIssued() {
+        if (status == UploadSessionStatus.CREATED) {
+            status = UploadSessionStatus.UPLOAD_URL_ISSUED;
+        }
+    }
+
+    public void complete() {
+        status = UploadSessionStatus.COMPLETED;
+        completedAt = LocalDateTime.now();
+    }
+
+    public void cancel() {
+        status = UploadSessionStatus.CANCELLED;
+        cancelledAt = LocalDateTime.now();
+    }
+
+    public boolean isOpen() {
+        return status == UploadSessionStatus.CREATED || status == UploadSessionStatus.UPLOAD_URL_ISSUED;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public Long getProjectId() {
+        return projectId;
+    }
+
+    public Long getUserId() {
+        return userId;
+    }
+
+    public UploadSessionStatus getStatus() {
+        return status;
+    }
+
+    public int getExpectedFileCount() {
+        return expectedFileCount;
+    }
+
+    public long getExpectedTotalSizeBytes() {
+        return expectedTotalSizeBytes;
+    }
+
+    public LocalDateTime getCompletedAt() {
+        return completedAt;
+    }
+
+    public LocalDateTime getCancelledAt() {
+        return cancelledAt;
+    }
+}

--- a/backend-api/src/main/java/com/moonju/preprocess/api/domain/upload/entity/UploadSessionFile.java
+++ b/backend-api/src/main/java/com/moonju/preprocess/api/domain/upload/entity/UploadSessionFile.java
@@ -1,0 +1,133 @@
+package com.moonju.preprocess.api.domain.upload.entity;
+
+import com.moonju.preprocess.api.global.support.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+@Entity
+@Table(name = "upload_session_files")
+public class UploadSessionFile extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private Long uploadSessionId;
+
+    @Column(nullable = false)
+    private Long projectId;
+
+    @Column(nullable = false, length = 255)
+    private String originalFileName;
+
+    @Column(nullable = false, length = 1000)
+    private String objectKey;
+
+    @Column(nullable = false, length = 100)
+    private String contentType;
+
+    @Column(nullable = false)
+    private long sizeBytes;
+
+    @Column(nullable = false, length = 64)
+    private String checksumSha256;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 30)
+    private UploadFileStatus status;
+
+    protected UploadSessionFile() {
+    }
+
+    public UploadSessionFile(
+        Long uploadSessionId,
+        Long projectId,
+        String originalFileName,
+        String objectKey,
+        String contentType,
+        long sizeBytes,
+        String checksumSha256,
+        UploadFileStatus status
+    ) {
+        this.uploadSessionId = uploadSessionId;
+        this.projectId = projectId;
+        this.originalFileName = originalFileName;
+        this.objectKey = objectKey;
+        this.contentType = contentType;
+        this.sizeBytes = sizeBytes;
+        this.checksumSha256 = checksumSha256;
+        this.status = status;
+    }
+
+    public static UploadSessionFile issued(
+        Long uploadSessionId,
+        Long projectId,
+        String originalFileName,
+        String objectKey,
+        String contentType,
+        long sizeBytes,
+        String checksumSha256
+    ) {
+        return new UploadSessionFile(
+            uploadSessionId,
+            projectId,
+            originalFileName,
+            objectKey,
+            contentType,
+            sizeBytes,
+            checksumSha256,
+            UploadFileStatus.UPLOAD_URL_ISSUED
+        );
+    }
+
+    public void markUploaded() {
+        status = UploadFileStatus.UPLOADED;
+    }
+
+    public boolean isUploaded() {
+        return status == UploadFileStatus.UPLOADED;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public Long getUploadSessionId() {
+        return uploadSessionId;
+    }
+
+    public Long getProjectId() {
+        return projectId;
+    }
+
+    public String getOriginalFileName() {
+        return originalFileName;
+    }
+
+    public String getObjectKey() {
+        return objectKey;
+    }
+
+    public String getContentType() {
+        return contentType;
+    }
+
+    public long getSizeBytes() {
+        return sizeBytes;
+    }
+
+    public String getChecksumSha256() {
+        return checksumSha256;
+    }
+
+    public UploadFileStatus getStatus() {
+        return status;
+    }
+}

--- a/backend-api/src/main/java/com/moonju/preprocess/api/domain/upload/entity/UploadSessionStatus.java
+++ b/backend-api/src/main/java/com/moonju/preprocess/api/domain/upload/entity/UploadSessionStatus.java
@@ -1,0 +1,8 @@
+package com.moonju.preprocess.api.domain.upload.entity;
+
+public enum UploadSessionStatus {
+    CREATED,
+    UPLOAD_URL_ISSUED,
+    COMPLETED,
+    CANCELLED
+}

--- a/backend-api/src/main/java/com/moonju/preprocess/api/domain/upload/exception/InvalidUploadFileException.java
+++ b/backend-api/src/main/java/com/moonju/preprocess/api/domain/upload/exception/InvalidUploadFileException.java
@@ -1,0 +1,11 @@
+package com.moonju.preprocess.api.domain.upload.exception;
+
+import com.moonju.preprocess.api.global.error.BusinessException;
+import com.moonju.preprocess.api.global.error.ErrorCode;
+
+public class InvalidUploadFileException extends BusinessException {
+
+    public InvalidUploadFileException(String message) {
+        super(ErrorCode.VALIDATION_ERROR, message);
+    }
+}

--- a/backend-api/src/main/java/com/moonju/preprocess/api/domain/upload/exception/UploadNotCompletedException.java
+++ b/backend-api/src/main/java/com/moonju/preprocess/api/domain/upload/exception/UploadNotCompletedException.java
@@ -1,0 +1,11 @@
+package com.moonju.preprocess.api.domain.upload.exception;
+
+import com.moonju.preprocess.api.global.error.BusinessException;
+import com.moonju.preprocess.api.global.error.ErrorCode;
+
+public class UploadNotCompletedException extends BusinessException {
+
+    public UploadNotCompletedException(String message) {
+        super(ErrorCode.COMMON_CONFLICT, message);
+    }
+}

--- a/backend-api/src/main/java/com/moonju/preprocess/api/domain/upload/exception/UploadSessionNotFoundException.java
+++ b/backend-api/src/main/java/com/moonju/preprocess/api/domain/upload/exception/UploadSessionNotFoundException.java
@@ -1,0 +1,11 @@
+package com.moonju.preprocess.api.domain.upload.exception;
+
+import com.moonju.preprocess.api.global.error.BusinessException;
+import com.moonju.preprocess.api.global.error.ErrorCode;
+
+public class UploadSessionNotFoundException extends BusinessException {
+
+    public UploadSessionNotFoundException() {
+        super(ErrorCode.COMMON_NOT_FOUND, "Upload session not found.");
+    }
+}

--- a/backend-api/src/main/java/com/moonju/preprocess/api/domain/upload/repository/UploadSessionFileRepository.java
+++ b/backend-api/src/main/java/com/moonju/preprocess/api/domain/upload/repository/UploadSessionFileRepository.java
@@ -1,0 +1,15 @@
+package com.moonju.preprocess.api.domain.upload.repository;
+
+import com.moonju.preprocess.api.domain.upload.entity.UploadSessionFile;
+import java.util.Collection;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UploadSessionFileRepository extends JpaRepository<UploadSessionFile, Long> {
+
+    boolean existsByProjectIdAndChecksumSha256(Long projectId, String checksumSha256);
+
+    List<UploadSessionFile> findByUploadSessionId(Long uploadSessionId);
+
+    List<UploadSessionFile> findByUploadSessionIdAndIdIn(Long uploadSessionId, Collection<Long> ids);
+}

--- a/backend-api/src/main/java/com/moonju/preprocess/api/domain/upload/repository/UploadSessionRepository.java
+++ b/backend-api/src/main/java/com/moonju/preprocess/api/domain/upload/repository/UploadSessionRepository.java
@@ -1,0 +1,10 @@
+package com.moonju.preprocess.api.domain.upload.repository;
+
+import com.moonju.preprocess.api.domain.upload.entity.UploadSession;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UploadSessionRepository extends JpaRepository<UploadSession, Long> {
+
+    Optional<UploadSession> findByIdAndUserId(Long id, Long userId);
+}

--- a/backend-api/src/main/java/com/moonju/preprocess/api/domain/upload/service/PresignedUploadService.java
+++ b/backend-api/src/main/java/com/moonju/preprocess/api/domain/upload/service/PresignedUploadService.java
@@ -1,0 +1,125 @@
+package com.moonju.preprocess.api.domain.upload.service;
+
+import com.moonju.preprocess.api.domain.project.service.ProjectPermissionService;
+import com.moonju.preprocess.api.domain.upload.dto.PresignedUploadFileRequest;
+import com.moonju.preprocess.api.domain.upload.dto.PresignedUploadUrlRequest;
+import com.moonju.preprocess.api.domain.upload.dto.PresignedUploadUrlResponse;
+import com.moonju.preprocess.api.domain.upload.entity.UploadSession;
+import com.moonju.preprocess.api.domain.upload.entity.UploadSessionFile;
+import com.moonju.preprocess.api.domain.upload.exception.InvalidUploadFileException;
+import com.moonju.preprocess.api.domain.upload.repository.UploadSessionFileRepository;
+import com.moonju.preprocess.api.infra.storage.PresignedUploadCommand;
+import com.moonju.preprocess.api.infra.storage.PresignedUploadTarget;
+import com.moonju.preprocess.api.infra.storage.PresignedUrlGenerator;
+import java.time.Duration;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class PresignedUploadService {
+
+    private static final Duration UPLOAD_URL_EXPIRES_IN = Duration.ofMinutes(15);
+
+    private final UploadSessionService uploadSessionService;
+    private final UploadSessionFileRepository uploadSessionFileRepository;
+    private final ProjectPermissionService projectPermissionService;
+    private final UploadFileValidationService uploadFileValidationService;
+    private final PresignedUrlGenerator presignedUrlGenerator;
+
+    public PresignedUploadService(
+        UploadSessionService uploadSessionService,
+        UploadSessionFileRepository uploadSessionFileRepository,
+        ProjectPermissionService projectPermissionService,
+        UploadFileValidationService uploadFileValidationService,
+        PresignedUrlGenerator presignedUrlGenerator
+    ) {
+        this.uploadSessionService = uploadSessionService;
+        this.uploadSessionFileRepository = uploadSessionFileRepository;
+        this.projectPermissionService = projectPermissionService;
+        this.uploadFileValidationService = uploadFileValidationService;
+        this.presignedUrlGenerator = presignedUrlGenerator;
+    }
+
+    @Transactional
+    public PresignedUploadUrlResponse createUploadUrls(
+        Long currentUserId,
+        Long sessionId,
+        PresignedUploadUrlRequest request
+    ) {
+        UploadSession uploadSession = uploadSessionService.findOpenSession(sessionId);
+        projectPermissionService.validateEditable(currentUserId, uploadSession.getProjectId());
+        validateRequest(uploadSession, request.files());
+
+        List<PresignedUploadUrlResponse.UploadTargetResponse> targets = request.files()
+            .stream()
+            .map(file -> createUploadTarget(uploadSession, file))
+            .toList();
+
+        uploadSession.markUploadUrlIssued();
+        return PresignedUploadUrlResponse.of(uploadSession.getId(), targets);
+    }
+
+    private void validateRequest(UploadSession uploadSession, List<PresignedUploadFileRequest> files) {
+        if (files.size() > uploadSession.getExpectedFileCount()) {
+            throw new InvalidUploadFileException("Requested file count exceeds upload session expectation.");
+        }
+
+        Set<String> checksums = new HashSet<>();
+        long totalSizeBytes = 0L;
+        for (PresignedUploadFileRequest file : files) {
+            uploadFileValidationService.validate(file);
+            if (!checksums.add(file.checksumSha256())) {
+                throw new InvalidUploadFileException("Duplicate checksum exists in the upload request.");
+            }
+            if (uploadSessionFileRepository.existsByProjectIdAndChecksumSha256(
+                uploadSession.getProjectId(),
+                file.checksumSha256()
+            )) {
+                throw new InvalidUploadFileException("Duplicate file checksum already exists in this project.");
+            }
+            totalSizeBytes += file.sizeBytes();
+        }
+
+        if (totalSizeBytes > uploadSession.getExpectedTotalSizeBytes()) {
+            throw new InvalidUploadFileException("Requested file size exceeds upload session expectation.");
+        }
+    }
+
+    private PresignedUploadUrlResponse.UploadTargetResponse createUploadTarget(
+        UploadSession uploadSession,
+        PresignedUploadFileRequest file
+    ) {
+        String objectKey = buildOriginalObjectKey(uploadSession, file.fileName());
+        UploadSessionFile uploadFile = uploadSessionFileRepository.save(UploadSessionFile.issued(
+            uploadSession.getId(),
+            uploadSession.getProjectId(),
+            file.fileName(),
+            objectKey,
+            file.contentType(),
+            file.sizeBytes(),
+            file.checksumSha256()
+        ));
+
+        PresignedUploadTarget target = presignedUrlGenerator.generateUploadUrl(new PresignedUploadCommand(
+            objectKey,
+            file.contentType(),
+            file.sizeBytes(),
+            UPLOAD_URL_EXPIRES_IN
+        ));
+        return PresignedUploadUrlResponse.UploadTargetResponse.of(uploadFile, target);
+    }
+
+    private String buildOriginalObjectKey(UploadSession uploadSession, String fileName) {
+        String safeFileName = fileName.replace("\\", "_").replace("/", "_");
+        return "originals/%d/%d/%s/%s".formatted(
+            uploadSession.getProjectId(),
+            uploadSession.getId(),
+            UUID.randomUUID(),
+            safeFileName
+        );
+    }
+}

--- a/backend-api/src/main/java/com/moonju/preprocess/api/domain/upload/service/UploadCompleteService.java
+++ b/backend-api/src/main/java/com/moonju/preprocess/api/domain/upload/service/UploadCompleteService.java
@@ -1,0 +1,76 @@
+package com.moonju.preprocess.api.domain.upload.service;
+
+import com.moonju.preprocess.api.domain.project.service.ProjectPermissionService;
+import com.moonju.preprocess.api.domain.upload.dto.UploadCompleteRequest;
+import com.moonju.preprocess.api.domain.upload.dto.UploadCompleteResponse;
+import com.moonju.preprocess.api.domain.upload.entity.UploadSession;
+import com.moonju.preprocess.api.domain.upload.entity.UploadSessionFile;
+import com.moonju.preprocess.api.domain.upload.exception.UploadNotCompletedException;
+import com.moonju.preprocess.api.domain.upload.repository.UploadSessionFileRepository;
+import com.moonju.preprocess.api.infra.storage.ObjectStoragePort;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class UploadCompleteService {
+
+    private final UploadSessionService uploadSessionService;
+    private final UploadSessionFileRepository uploadSessionFileRepository;
+    private final ProjectPermissionService projectPermissionService;
+    private final ObjectStoragePort objectStoragePort;
+
+    public UploadCompleteService(
+        UploadSessionService uploadSessionService,
+        UploadSessionFileRepository uploadSessionFileRepository,
+        ProjectPermissionService projectPermissionService,
+        ObjectStoragePort objectStoragePort
+    ) {
+        this.uploadSessionService = uploadSessionService;
+        this.uploadSessionFileRepository = uploadSessionFileRepository;
+        this.projectPermissionService = projectPermissionService;
+        this.objectStoragePort = objectStoragePort;
+    }
+
+    @Transactional
+    public UploadCompleteResponse complete(Long currentUserId, Long sessionId, UploadCompleteRequest request) {
+        UploadSession uploadSession = uploadSessionService.findOpenSession(sessionId);
+        projectPermissionService.validateEditable(currentUserId, uploadSession.getProjectId());
+
+        List<UploadSessionFile> files = uploadSessionFileRepository.findByUploadSessionIdAndIdIn(
+            uploadSession.getId(),
+            request.uploadFileIds()
+        );
+        validateCompletion(uploadSession, request.uploadFileIds(), files);
+
+        files.forEach(this::verifyAndMarkUploaded);
+        uploadSession.complete();
+        return UploadCompleteResponse.of(uploadSession, files.size());
+    }
+
+    private void validateCompletion(
+        UploadSession uploadSession,
+        List<Long> requestedUploadFileIds,
+        List<UploadSessionFile> files
+    ) {
+        Set<Long> requestedIds = new HashSet<>(requestedUploadFileIds);
+        if (requestedIds.size() != requestedUploadFileIds.size()) {
+            throw new UploadNotCompletedException("Upload file ids contain duplicates.");
+        }
+        if (files.size() != uploadSession.getExpectedFileCount()) {
+            throw new UploadNotCompletedException("Uploaded file count does not match upload session expectation.");
+        }
+        if (files.size() != requestedIds.size()) {
+            throw new UploadNotCompletedException("Some requested upload files do not belong to the upload session.");
+        }
+    }
+
+    private void verifyAndMarkUploaded(UploadSessionFile file) {
+        if (!objectStoragePort.exists(file.getObjectKey())) {
+            throw new UploadNotCompletedException("Uploaded object does not exist: " + file.getObjectKey());
+        }
+        file.markUploaded();
+    }
+}

--- a/backend-api/src/main/java/com/moonju/preprocess/api/domain/upload/service/UploadFileValidationService.java
+++ b/backend-api/src/main/java/com/moonju/preprocess/api/domain/upload/service/UploadFileValidationService.java
@@ -1,0 +1,45 @@
+package com.moonju.preprocess.api.domain.upload.service;
+
+import com.moonju.preprocess.api.domain.upload.dto.PresignedUploadFileRequest;
+import com.moonju.preprocess.api.domain.upload.exception.InvalidUploadFileException;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import org.springframework.stereotype.Service;
+
+@Service
+public class UploadFileValidationService {
+
+    private static final long MAX_IMAGE_SIZE_BYTES = 100L * 1024L * 1024L;
+    private static final Map<String, Set<String>> ALLOWED_CONTENT_TYPES_BY_EXTENSION = Map.of(
+        ".png", Set.of("image/png"),
+        ".jpg", Set.of("image/jpeg"),
+        ".jpeg", Set.of("image/jpeg"),
+        ".tif", Set.of("image/tiff"),
+        ".tiff", Set.of("image/tiff"),
+        ".bmp", Set.of("image/bmp", "image/x-ms-bmp"),
+        ".webp", Set.of("image/webp")
+    );
+
+    public void validate(PresignedUploadFileRequest file) {
+        String extension = extractExtension(file.fileName());
+        if (!ALLOWED_CONTENT_TYPES_BY_EXTENSION.containsKey(extension)) {
+            throw new InvalidUploadFileException("Unsupported image file extension.");
+        }
+        if (!ALLOWED_CONTENT_TYPES_BY_EXTENSION.get(extension).contains(file.contentType().toLowerCase(Locale.ROOT))) {
+            throw new InvalidUploadFileException("Content type does not match the image file extension.");
+        }
+        if (file.sizeBytes() > MAX_IMAGE_SIZE_BYTES) {
+            throw new InvalidUploadFileException("Image file size exceeds the per-file limit.");
+        }
+    }
+
+    private String extractExtension(String fileName) {
+        String normalized = fileName.toLowerCase(Locale.ROOT);
+        int lastDot = normalized.lastIndexOf('.');
+        if (lastDot < 0 || lastDot == normalized.length() - 1) {
+            throw new InvalidUploadFileException("Image file extension is required.");
+        }
+        return normalized.substring(lastDot);
+    }
+}

--- a/backend-api/src/main/java/com/moonju/preprocess/api/domain/upload/service/UploadSessionService.java
+++ b/backend-api/src/main/java/com/moonju/preprocess/api/domain/upload/service/UploadSessionService.java
@@ -1,0 +1,67 @@
+package com.moonju.preprocess.api.domain.upload.service;
+
+import com.moonju.preprocess.api.domain.project.service.ProjectPermissionService;
+import com.moonju.preprocess.api.domain.upload.dto.UploadSessionCreateRequest;
+import com.moonju.preprocess.api.domain.upload.dto.UploadSessionResponse;
+import com.moonju.preprocess.api.domain.upload.entity.UploadSession;
+import com.moonju.preprocess.api.domain.upload.exception.UploadNotCompletedException;
+import com.moonju.preprocess.api.domain.upload.exception.UploadSessionNotFoundException;
+import com.moonju.preprocess.api.domain.upload.repository.UploadSessionRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class UploadSessionService {
+
+    private final UploadSessionRepository uploadSessionRepository;
+    private final ProjectPermissionService projectPermissionService;
+
+    public UploadSessionService(
+        UploadSessionRepository uploadSessionRepository,
+        ProjectPermissionService projectPermissionService
+    ) {
+        this.uploadSessionRepository = uploadSessionRepository;
+        this.projectPermissionService = projectPermissionService;
+    }
+
+    @Transactional
+    public UploadSessionResponse create(Long currentUserId, Long projectId, UploadSessionCreateRequest request) {
+        projectPermissionService.validateEditable(currentUserId, projectId);
+        UploadSession uploadSession = uploadSessionRepository.save(UploadSession.create(
+            projectId,
+            currentUserId,
+            request.expectedFileCount(),
+            request.expectedTotalSizeBytes()
+        ));
+        return UploadSessionResponse.from(uploadSession);
+    }
+
+    @Transactional(readOnly = true)
+    public UploadSessionResponse findOne(Long currentUserId, Long sessionId) {
+        UploadSession uploadSession = findByIdAndUserId(sessionId, currentUserId);
+        projectPermissionService.validateReadable(currentUserId, uploadSession.getProjectId());
+        return UploadSessionResponse.from(uploadSession);
+    }
+
+    @Transactional
+    public void cancel(Long currentUserId, Long sessionId) {
+        UploadSession uploadSession = findByIdAndUserId(sessionId, currentUserId);
+        projectPermissionService.validateEditable(currentUserId, uploadSession.getProjectId());
+        uploadSession.cancel();
+    }
+
+    @Transactional(readOnly = true)
+    public UploadSession findOpenSession(Long sessionId) {
+        UploadSession uploadSession = uploadSessionRepository.findById(sessionId)
+            .orElseThrow(UploadSessionNotFoundException::new);
+        if (!uploadSession.isOpen()) {
+            throw new UploadNotCompletedException("Upload session is not open.");
+        }
+        return uploadSession;
+    }
+
+    private UploadSession findByIdAndUserId(Long sessionId, Long currentUserId) {
+        return uploadSessionRepository.findByIdAndUserId(sessionId, currentUserId)
+            .orElseThrow(UploadSessionNotFoundException::new);
+    }
+}

--- a/backend-api/src/main/java/com/moonju/preprocess/api/infra/storage/LocalObjectStorageAdapter.java
+++ b/backend-api/src/main/java/com/moonju/preprocess/api/infra/storage/LocalObjectStorageAdapter.java
@@ -1,0 +1,12 @@
+package com.moonju.preprocess.api.infra.storage;
+
+import org.springframework.stereotype.Component;
+
+@Component
+public class LocalObjectStorageAdapter implements ObjectStoragePort {
+
+    @Override
+    public boolean exists(String objectKey) {
+        return true;
+    }
+}

--- a/backend-api/src/main/java/com/moonju/preprocess/api/infra/storage/LocalPresignedUrlGenerator.java
+++ b/backend-api/src/main/java/com/moonju/preprocess/api/infra/storage/LocalPresignedUrlGenerator.java
@@ -1,0 +1,20 @@
+package com.moonju.preprocess.api.infra.storage;
+
+import java.time.Instant;
+import java.util.Map;
+import org.springframework.stereotype.Component;
+
+@Component
+public class LocalPresignedUrlGenerator implements PresignedUrlGenerator {
+
+    @Override
+    public PresignedUploadTarget generateUploadUrl(PresignedUploadCommand command) {
+        Instant expiresAt = Instant.now().plus(command.expiresIn());
+        return new PresignedUploadTarget(
+            command.objectKey(),
+            "http://localhost:9000/local-presigned/" + command.objectKey(),
+            expiresAt,
+            Map.of("Content-Type", command.contentType())
+        );
+    }
+}

--- a/backend-api/src/main/java/com/moonju/preprocess/api/infra/storage/ObjectStoragePort.java
+++ b/backend-api/src/main/java/com/moonju/preprocess/api/infra/storage/ObjectStoragePort.java
@@ -1,0 +1,6 @@
+package com.moonju.preprocess.api.infra.storage;
+
+public interface ObjectStoragePort {
+
+    boolean exists(String objectKey);
+}

--- a/backend-api/src/main/java/com/moonju/preprocess/api/infra/storage/PresignedUploadCommand.java
+++ b/backend-api/src/main/java/com/moonju/preprocess/api/infra/storage/PresignedUploadCommand.java
@@ -1,0 +1,11 @@
+package com.moonju.preprocess.api.infra.storage;
+
+import java.time.Duration;
+
+public record PresignedUploadCommand(
+    String objectKey,
+    String contentType,
+    long sizeBytes,
+    Duration expiresIn
+) {
+}

--- a/backend-api/src/main/java/com/moonju/preprocess/api/infra/storage/PresignedUploadTarget.java
+++ b/backend-api/src/main/java/com/moonju/preprocess/api/infra/storage/PresignedUploadTarget.java
@@ -1,0 +1,12 @@
+package com.moonju.preprocess.api.infra.storage;
+
+import java.time.Instant;
+import java.util.Map;
+
+public record PresignedUploadTarget(
+    String objectKey,
+    String uploadUrl,
+    Instant expiresAt,
+    Map<String, String> requiredHeaders
+) {
+}

--- a/backend-api/src/main/java/com/moonju/preprocess/api/infra/storage/PresignedUrlGenerator.java
+++ b/backend-api/src/main/java/com/moonju/preprocess/api/infra/storage/PresignedUrlGenerator.java
@@ -1,0 +1,6 @@
+package com.moonju.preprocess.api.infra.storage;
+
+public interface PresignedUrlGenerator {
+
+    PresignedUploadTarget generateUploadUrl(PresignedUploadCommand command);
+}

--- a/backend-api/src/test/java/com/moonju/preprocess/api/domain/upload/entity/UploadSessionFileTests.java
+++ b/backend-api/src/test/java/com/moonju/preprocess/api/domain/upload/entity/UploadSessionFileTests.java
@@ -1,0 +1,45 @@
+package com.moonju.preprocess.api.domain.upload.entity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class UploadSessionFileTests {
+
+    @Test
+    void createsIssuedUploadSessionFile() {
+        UploadSessionFile file = UploadSessionFile.issued(
+            10L,
+            20L,
+            "scan_001.png",
+            "originals/20/10/file/scan_001.png",
+            "image/png",
+            1024L,
+            "a".repeat(64)
+        );
+
+        assertThat(file.getUploadSessionId()).isEqualTo(10L);
+        assertThat(file.getProjectId()).isEqualTo(20L);
+        assertThat(file.getOriginalFileName()).isEqualTo("scan_001.png");
+        assertThat(file.getObjectKey()).isEqualTo("originals/20/10/file/scan_001.png");
+        assertThat(file.getStatus()).isEqualTo(UploadFileStatus.UPLOAD_URL_ISSUED);
+    }
+
+    @Test
+    void marksUploaded() {
+        UploadSessionFile file = UploadSessionFile.issued(
+            10L,
+            20L,
+            "scan_001.png",
+            "originals/20/10/file/scan_001.png",
+            "image/png",
+            1024L,
+            "a".repeat(64)
+        );
+
+        file.markUploaded();
+
+        assertThat(file.getStatus()).isEqualTo(UploadFileStatus.UPLOADED);
+        assertThat(file.isUploaded()).isTrue();
+    }
+}

--- a/backend-api/src/test/java/com/moonju/preprocess/api/domain/upload/entity/UploadSessionTests.java
+++ b/backend-api/src/test/java/com/moonju/preprocess/api/domain/upload/entity/UploadSessionTests.java
@@ -1,0 +1,52 @@
+package com.moonju.preprocess.api.domain.upload.entity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class UploadSessionTests {
+
+    @Test
+    void createsOpenUploadSession() {
+        UploadSession uploadSession = UploadSession.create(1L, 2L, 3, 4096L);
+
+        assertThat(uploadSession.getProjectId()).isEqualTo(1L);
+        assertThat(uploadSession.getUserId()).isEqualTo(2L);
+        assertThat(uploadSession.getExpectedFileCount()).isEqualTo(3);
+        assertThat(uploadSession.getExpectedTotalSizeBytes()).isEqualTo(4096L);
+        assertThat(uploadSession.getStatus()).isEqualTo(UploadSessionStatus.CREATED);
+        assertThat(uploadSession.isOpen()).isTrue();
+    }
+
+    @Test
+    void marksUploadUrlIssued() {
+        UploadSession uploadSession = UploadSession.create(1L, 2L, 3, 4096L);
+
+        uploadSession.markUploadUrlIssued();
+
+        assertThat(uploadSession.getStatus()).isEqualTo(UploadSessionStatus.UPLOAD_URL_ISSUED);
+        assertThat(uploadSession.isOpen()).isTrue();
+    }
+
+    @Test
+    void completesUploadSession() {
+        UploadSession uploadSession = UploadSession.create(1L, 2L, 3, 4096L);
+
+        uploadSession.complete();
+
+        assertThat(uploadSession.getStatus()).isEqualTo(UploadSessionStatus.COMPLETED);
+        assertThat(uploadSession.getCompletedAt()).isNotNull();
+        assertThat(uploadSession.isOpen()).isFalse();
+    }
+
+    @Test
+    void cancelsUploadSession() {
+        UploadSession uploadSession = UploadSession.create(1L, 2L, 3, 4096L);
+
+        uploadSession.cancel();
+
+        assertThat(uploadSession.getStatus()).isEqualTo(UploadSessionStatus.CANCELLED);
+        assertThat(uploadSession.getCancelledAt()).isNotNull();
+        assertThat(uploadSession.isOpen()).isFalse();
+    }
+}

--- a/backend-api/src/test/java/com/moonju/preprocess/api/domain/upload/service/PresignedUploadServiceTests.java
+++ b/backend-api/src/test/java/com/moonju/preprocess/api/domain/upload/service/PresignedUploadServiceTests.java
@@ -1,0 +1,133 @@
+package com.moonju.preprocess.api.domain.upload.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.when;
+
+import com.moonju.preprocess.api.domain.project.service.ProjectPermissionService;
+import com.moonju.preprocess.api.domain.upload.dto.PresignedUploadFileRequest;
+import com.moonju.preprocess.api.domain.upload.dto.PresignedUploadUrlRequest;
+import com.moonju.preprocess.api.domain.upload.dto.PresignedUploadUrlResponse;
+import com.moonju.preprocess.api.domain.upload.entity.UploadSession;
+import com.moonju.preprocess.api.domain.upload.entity.UploadSessionFile;
+import com.moonju.preprocess.api.domain.upload.entity.UploadSessionStatus;
+import com.moonju.preprocess.api.domain.upload.exception.InvalidUploadFileException;
+import com.moonju.preprocess.api.domain.upload.repository.UploadSessionFileRepository;
+import com.moonju.preprocess.api.infra.storage.PresignedUploadCommand;
+import com.moonju.preprocess.api.infra.storage.PresignedUploadTarget;
+import com.moonju.preprocess.api.infra.storage.PresignedUrlGenerator;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+class PresignedUploadServiceTests {
+
+    @Mock
+    private UploadSessionService uploadSessionService;
+
+    @Mock
+    private UploadSessionFileRepository uploadSessionFileRepository;
+
+    @Mock
+    private ProjectPermissionService projectPermissionService;
+
+    @Mock
+    private UploadFileValidationService uploadFileValidationService;
+
+    @Mock
+    private PresignedUrlGenerator presignedUrlGenerator;
+
+    @InjectMocks
+    private PresignedUploadService service;
+
+    @Test
+    void createsPresignedUploadTarget() {
+        UploadSession uploadSession = uploadSession(1L, 10L, 20L, 1, 4096L);
+        PresignedUploadFileRequest file = uploadFile("scan_001.png", "image/png", 1024L, "a".repeat(64));
+
+        when(uploadSessionService.findOpenSession(1L)).thenReturn(uploadSession);
+        doNothing().when(projectPermissionService).validateEditable(20L, 10L);
+        doNothing().when(uploadFileValidationService).validate(file);
+        when(uploadSessionFileRepository.existsByProjectIdAndChecksumSha256(10L, file.checksumSha256()))
+            .thenReturn(false);
+        when(uploadSessionFileRepository.save(any(UploadSessionFile.class))).thenAnswer(invocation -> {
+            UploadSessionFile saved = invocation.getArgument(0);
+            ReflectionTestUtils.setField(saved, "id", 100L);
+            return saved;
+        });
+        when(presignedUrlGenerator.generateUploadUrl(any(PresignedUploadCommand.class)))
+            .thenReturn(new PresignedUploadTarget(
+                "originals/10/1/file/scan_001.png",
+                "http://localhost:9000/upload",
+                Instant.parse("2026-05-03T08:00:00Z"),
+                Map.of("Content-Type", "image/png")
+            ));
+
+        PresignedUploadUrlResponse response = service.createUploadUrls(
+            20L,
+            1L,
+            new PresignedUploadUrlRequest(List.of(file))
+        );
+
+        assertThat(uploadSession.getStatus()).isEqualTo(UploadSessionStatus.UPLOAD_URL_ISSUED);
+        assertThat(response.sessionId()).isEqualTo(1L);
+        assertThat(response.uploadTargets()).hasSize(1);
+        assertThat(response.uploadTargets().getFirst().uploadFileId()).isEqualTo(100L);
+        assertThat(response.uploadTargets().getFirst().uploadUrl()).isEqualTo("http://localhost:9000/upload");
+    }
+
+    @Test
+    void rejectsDuplicateChecksumInProject() {
+        UploadSession uploadSession = uploadSession(1L, 10L, 20L, 1, 4096L);
+        PresignedUploadFileRequest file = uploadFile("scan_001.png", "image/png", 1024L, "a".repeat(64));
+
+        when(uploadSessionService.findOpenSession(1L)).thenReturn(uploadSession);
+        doNothing().when(projectPermissionService).validateEditable(20L, 10L);
+        doNothing().when(uploadFileValidationService).validate(file);
+        when(uploadSessionFileRepository.existsByProjectIdAndChecksumSha256(10L, file.checksumSha256()))
+            .thenReturn(true);
+
+        assertThatThrownBy(() -> service.createUploadUrls(
+            20L,
+            1L,
+            new PresignedUploadUrlRequest(List.of(file))
+        ))
+            .isInstanceOf(InvalidUploadFileException.class)
+            .hasMessage("Duplicate file checksum already exists in this project.");
+    }
+
+    private UploadSession uploadSession(
+        Long id,
+        Long projectId,
+        Long userId,
+        int expectedFileCount,
+        long expectedTotalSizeBytes
+    ) {
+        UploadSession uploadSession = UploadSession.create(
+            projectId,
+            userId,
+            expectedFileCount,
+            expectedTotalSizeBytes
+        );
+        ReflectionTestUtils.setField(uploadSession, "id", id);
+        return uploadSession;
+    }
+
+    private PresignedUploadFileRequest uploadFile(
+        String fileName,
+        String contentType,
+        long sizeBytes,
+        String checksumSha256
+    ) {
+        return new PresignedUploadFileRequest(fileName, contentType, sizeBytes, checksumSha256);
+    }
+}

--- a/backend-api/src/test/java/com/moonju/preprocess/api/domain/upload/service/UploadCompleteServiceTests.java
+++ b/backend-api/src/test/java/com/moonju/preprocess/api/domain/upload/service/UploadCompleteServiceTests.java
@@ -1,0 +1,114 @@
+package com.moonju.preprocess.api.domain.upload.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.when;
+
+import com.moonju.preprocess.api.domain.project.service.ProjectPermissionService;
+import com.moonju.preprocess.api.domain.upload.dto.UploadCompleteRequest;
+import com.moonju.preprocess.api.domain.upload.dto.UploadCompleteResponse;
+import com.moonju.preprocess.api.domain.upload.entity.UploadFileStatus;
+import com.moonju.preprocess.api.domain.upload.entity.UploadSession;
+import com.moonju.preprocess.api.domain.upload.entity.UploadSessionFile;
+import com.moonju.preprocess.api.domain.upload.entity.UploadSessionStatus;
+import com.moonju.preprocess.api.domain.upload.exception.UploadNotCompletedException;
+import com.moonju.preprocess.api.domain.upload.repository.UploadSessionFileRepository;
+import com.moonju.preprocess.api.infra.storage.ObjectStoragePort;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+class UploadCompleteServiceTests {
+
+    @Mock
+    private UploadSessionService uploadSessionService;
+
+    @Mock
+    private UploadSessionFileRepository uploadSessionFileRepository;
+
+    @Mock
+    private ProjectPermissionService projectPermissionService;
+
+    @Mock
+    private ObjectStoragePort objectStoragePort;
+
+    @InjectMocks
+    private UploadCompleteService service;
+
+    @Test
+    void completesUploadSessionAfterObjectExistenceVerification() {
+        UploadSession uploadSession = uploadSession(1L, 10L, 20L, 1, 4096L);
+        UploadSessionFile file = uploadSessionFile(100L, 1L, 10L, "originals/10/1/file/scan_001.png");
+
+        when(uploadSessionService.findOpenSession(1L)).thenReturn(uploadSession);
+        doNothing().when(projectPermissionService).validateEditable(20L, 10L);
+        when(uploadSessionFileRepository.findByUploadSessionIdAndIdIn(1L, List.of(100L))).thenReturn(List.of(file));
+        when(objectStoragePort.exists(file.getObjectKey())).thenReturn(true);
+
+        UploadCompleteResponse response = service.complete(20L, 1L, new UploadCompleteRequest(List.of(100L)));
+
+        assertThat(response.sessionId()).isEqualTo(1L);
+        assertThat(response.status()).isEqualTo(UploadSessionStatus.COMPLETED);
+        assertThat(response.uploadedFileCount()).isEqualTo(1);
+        assertThat(uploadSession.getStatus()).isEqualTo(UploadSessionStatus.COMPLETED);
+        assertThat(file.getStatus()).isEqualTo(UploadFileStatus.UPLOADED);
+    }
+
+    @Test
+    void rejectsCompletionWhenObjectDoesNotExist() {
+        UploadSession uploadSession = uploadSession(1L, 10L, 20L, 1, 4096L);
+        UploadSessionFile file = uploadSessionFile(100L, 1L, 10L, "originals/10/1/file/scan_001.png");
+
+        when(uploadSessionService.findOpenSession(1L)).thenReturn(uploadSession);
+        doNothing().when(projectPermissionService).validateEditable(20L, 10L);
+        when(uploadSessionFileRepository.findByUploadSessionIdAndIdIn(1L, List.of(100L))).thenReturn(List.of(file));
+        when(objectStoragePort.exists(file.getObjectKey())).thenReturn(false);
+
+        assertThatThrownBy(() -> service.complete(20L, 1L, new UploadCompleteRequest(List.of(100L))))
+            .isInstanceOf(UploadNotCompletedException.class)
+            .hasMessage("Uploaded object does not exist: originals/10/1/file/scan_001.png");
+    }
+
+    private UploadSession uploadSession(
+        Long id,
+        Long projectId,
+        Long userId,
+        int expectedFileCount,
+        long expectedTotalSizeBytes
+    ) {
+        UploadSession uploadSession = UploadSession.create(
+            projectId,
+            userId,
+            expectedFileCount,
+            expectedTotalSizeBytes
+        );
+        ReflectionTestUtils.setField(uploadSession, "id", id);
+        uploadSession.markUploadUrlIssued();
+        return uploadSession;
+    }
+
+    private UploadSessionFile uploadSessionFile(
+        Long id,
+        Long uploadSessionId,
+        Long projectId,
+        String objectKey
+    ) {
+        UploadSessionFile file = UploadSessionFile.issued(
+            uploadSessionId,
+            projectId,
+            "scan_001.png",
+            objectKey,
+            "image/png",
+            1024L,
+            "a".repeat(64)
+        );
+        ReflectionTestUtils.setField(file, "id", id);
+        return file;
+    }
+}

--- a/backend-api/src/test/java/com/moonju/preprocess/api/domain/upload/service/UploadFileValidationServiceTests.java
+++ b/backend-api/src/test/java/com/moonju/preprocess/api/domain/upload/service/UploadFileValidationServiceTests.java
@@ -1,0 +1,59 @@
+package com.moonju.preprocess.api.domain.upload.service;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.moonju.preprocess.api.domain.upload.dto.PresignedUploadFileRequest;
+import com.moonju.preprocess.api.domain.upload.exception.InvalidUploadFileException;
+import org.junit.jupiter.api.Test;
+
+class UploadFileValidationServiceTests {
+
+    private final UploadFileValidationService service = new UploadFileValidationService();
+
+    @Test
+    void acceptsSupportedImageFile() {
+        service.validate(new PresignedUploadFileRequest("scan_001.png", "image/png", 1024L, "a".repeat(64)));
+    }
+
+    @Test
+    void rejectsUnsupportedExtension() {
+        PresignedUploadFileRequest request = new PresignedUploadFileRequest(
+            "scan_001.txt",
+            "text/plain",
+            1024L,
+            "a".repeat(64)
+        );
+
+        assertThatThrownBy(() -> service.validate(request))
+            .isInstanceOf(InvalidUploadFileException.class)
+            .hasMessage("Unsupported image file extension.");
+    }
+
+    @Test
+    void rejectsMismatchedContentType() {
+        PresignedUploadFileRequest request = new PresignedUploadFileRequest(
+            "scan_001.png",
+            "image/jpeg",
+            1024L,
+            "a".repeat(64)
+        );
+
+        assertThatThrownBy(() -> service.validate(request))
+            .isInstanceOf(InvalidUploadFileException.class)
+            .hasMessage("Content type does not match the image file extension.");
+    }
+
+    @Test
+    void rejectsOversizedImage() {
+        PresignedUploadFileRequest request = new PresignedUploadFileRequest(
+            "scan_001.png",
+            "image/png",
+            101L * 1024L * 1024L,
+            "a".repeat(64)
+        );
+
+        assertThatThrownBy(() -> service.validate(request))
+            .isInstanceOf(InvalidUploadFileException.class)
+            .hasMessage("Image file size exceeds the per-file limit.");
+    }
+}

--- a/docs/api/upload-api.md
+++ b/docs/api/upload-api.md
@@ -1,0 +1,142 @@
+# Upload API
+
+## Purpose
+
+The upload API prepares large document image uploads without sending file bodies through the Spring API server.
+Clients create an upload session, request presigned object storage URLs, upload files directly to object storage, and
+then notify the API that the upload is complete.
+
+## Rules
+
+- The Spring API must not receive large image file bodies.
+- Presigned upload URLs must include an expiration time.
+- Upload completion must verify object existence through `ObjectStoragePort`.
+- Image rows are not finalized before upload completion.
+- Supported image extensions are `png`, `jpg`, `jpeg`, `tif`, `tiff`, `bmp`, and `webp`.
+- Checksums are collected as SHA-256 hex strings and are used for duplicate detection.
+
+## Endpoints
+
+| Method | Path | Purpose |
+| --- | --- | --- |
+| `POST` | `/api/v1/projects/{projectId}/upload-sessions` | Create an upload session |
+| `GET` | `/api/v1/upload-sessions/{sessionId}` | Read an upload session |
+| `POST` | `/api/v1/upload-sessions/{sessionId}/files/presigned-url` | Issue presigned upload URLs |
+| `POST` | `/api/v1/upload-sessions/{sessionId}/complete` | Complete an upload session |
+| `DELETE` | `/api/v1/upload-sessions/{sessionId}` | Cancel an upload session |
+
+## Create Upload Session
+
+Request:
+
+```json
+{
+  "expectedFileCount": 3,
+  "expectedTotalSizeBytes": 12000000
+}
+```
+
+Response:
+
+```json
+{
+  "isSuccess": true,
+  "code": "common200",
+  "message": "Request succeeded.",
+  "result": {
+    "id": 1,
+    "projectId": 10,
+    "userId": 20,
+    "status": "CREATED",
+    "expectedFileCount": 3,
+    "expectedTotalSizeBytes": 12000000,
+    "completedAt": null,
+    "cancelledAt": null
+  }
+}
+```
+
+## Issue Presigned Upload URLs
+
+Request:
+
+```json
+{
+  "files": [
+    {
+      "fileName": "scan_001.png",
+      "contentType": "image/png",
+      "sizeBytes": 4200000,
+      "checksumSha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    }
+  ]
+}
+```
+
+Response:
+
+```json
+{
+  "isSuccess": true,
+  "code": "common200",
+  "message": "Request succeeded.",
+  "result": {
+    "sessionId": 1,
+    "uploadTargets": [
+      {
+        "uploadFileId": 100,
+        "objectKey": "originals/10/1/uuid/scan_001.png",
+        "uploadUrl": "http://localhost:9000/local-presigned/originals/10/1/uuid/scan_001.png",
+        "expiresAt": "2026-05-03T08:00:00Z",
+        "requiredHeaders": {
+          "Content-Type": "image/png"
+        }
+      }
+    ]
+  }
+}
+```
+
+The response uses `uploadFileId`, not `imageId`, because the image metadata row should be finalized only after
+object storage verification succeeds.
+
+## Complete Upload Session
+
+Request:
+
+```json
+{
+  "uploadFileIds": [100, 101, 102]
+}
+```
+
+Response:
+
+```json
+{
+  "isSuccess": true,
+  "code": "common200",
+  "message": "Request succeeded.",
+  "result": {
+    "sessionId": 1,
+    "status": "COMPLETED",
+    "uploadedFileCount": 3
+  }
+}
+```
+
+## Status
+
+| Status | Meaning |
+| --- | --- |
+| `CREATED` | Session exists but no upload URL has been issued yet |
+| `UPLOAD_URL_ISSUED` | One or more presigned upload URLs have been issued |
+| `COMPLETED` | All expected files have been verified in object storage |
+| `CANCELLED` | User cancelled the upload session |
+
+## Next Work
+
+- Replace the local presigned URL generator with a MinIO/S3 adapter.
+- Create image metadata rows after upload completion.
+- Add image magic number validation after object download or metadata extraction.
+- Add ZIP upload as a separate expansion task.

--- a/docs/feature-specs/issue-21-upload-domain-skeleton.md
+++ b/docs/feature-specs/issue-21-upload-domain-skeleton.md
@@ -1,0 +1,80 @@
+# Issue 21. Upload Domain Skeleton
+
+## Goal
+
+Add a Spring domain-structured upload skeleton for large document image uploads. The API server prepares upload
+metadata and presigned URLs, while clients upload file bodies directly to object storage.
+
+## Overall Order
+
+1. Create an upload session under a project.
+2. Validate project edit permission.
+3. Request presigned upload URLs for image files.
+4. Validate file extension, content type, size, and checksum shape.
+5. Store `UploadSessionFile` metadata with an original object key.
+6. Return upload URL, expiration time, required headers, and `uploadFileId`.
+7. Client uploads directly to object storage.
+8. Client calls complete with issued `uploadFileIds`.
+9. API verifies object existence through `ObjectStoragePort`.
+10. API marks files uploaded and completes the session.
+11. Later image-domain work creates final `Image` rows from completed upload files.
+
+## Functional Units
+
+### Upload Session
+
+- `UploadSession` stores project, user, expected file count, expected total size, status, and completion timestamps.
+- `UploadSessionStatus` has `CREATED`, `UPLOAD_URL_ISSUED`, `COMPLETED`, and `CANCELLED`.
+- `UploadSessionService` creates, reads, cancels, and loads open sessions.
+
+### Upload File
+
+- `UploadSessionFile` stores file name, object key, content type, size, checksum, and file status.
+- `UploadFileStatus` has `UPLOAD_URL_ISSUED` and `UPLOADED`.
+- `UploadSessionFileRepository` supports duplicate checksum lookup and session file lookup.
+
+### Presigned URL
+
+- `PresignedUploadService` validates the request and issues upload targets.
+- `PresignedUrlGenerator` is a storage infra port.
+- `LocalPresignedUrlGenerator` is a compile-time/local skeleton only.
+- Actual MinIO/S3 signing is deferred to the storage adapter task.
+
+### Completion
+
+- `UploadCompleteService` compares requested IDs with persisted upload files.
+- Completion requires the number of uploaded files to match `expectedFileCount`.
+- Completion verifies object existence through `ObjectStoragePort`.
+- The current local adapter returns a placeholder existence result and will be replaced by MinIO/S3.
+
+### Validation
+
+- Supported extensions: `.png`, `.jpg`, `.jpeg`, `.tif`, `.tiff`, `.bmp`, `.webp`.
+- Content type must match the extension.
+- Per-file limit is 100 MiB in the skeleton.
+- SHA-256 checksum must be a 64-character hex string at the DTO level.
+- Duplicate checksum is rejected within the request and against existing files in the project.
+
+## API Surface
+
+- `POST /api/v1/projects/{projectId}/upload-sessions`
+- `GET /api/v1/upload-sessions/{sessionId}`
+- `POST /api/v1/upload-sessions/{sessionId}/files/presigned-url`
+- `POST /api/v1/upload-sessions/{sessionId}/complete`
+- `DELETE /api/v1/upload-sessions/{sessionId}`
+
+## Out Of Scope
+
+- Direct multipart upload through Spring API.
+- Actual MinIO/S3 SDK signing.
+- Image metadata row finalization.
+- Image magic number inspection.
+- ZIP extraction.
+- Frontend upload UI.
+
+## Verification
+
+- Unit tests cover upload session state transitions.
+- Unit tests cover upload file state transitions.
+- Unit tests cover extension/content type/size validation.
+- Docker Gradle test/build is required before PR creation.

--- a/docs/operation/storage-operation.md
+++ b/docs/operation/storage-operation.md
@@ -1,0 +1,80 @@
+# Storage Operation
+
+## Purpose
+
+Object storage keeps original document images and later preprocessing artifacts. The API server should issue
+temporary access URLs, while workers and storage adapters handle actual object transfer.
+
+## Buckets And Privacy
+
+- Buckets must be private by default.
+- Original images must not be publicly readable.
+- Processed images, previews, debug artifacts, and reports must be accessed through signed download URLs.
+- Object storage credentials must stay in backend/worker environment variables or Kubernetes secrets.
+
+## Original Upload Path
+
+```text
+originals/{projectId}/{uploadSessionId}/{uploadFileToken}/{originalFileName}
+```
+
+Example:
+
+```text
+originals/10/1/550e8400-e29b-41d4-a716-446655440000/scan_001.png
+```
+
+`uploadFileToken` is not the final image ID. It is an upload-time token used before image metadata is finalized.
+
+## Processed Artifact Path
+
+```text
+processed/{projectId}/{jobId}/{itemId}/processed.png
+processed/{projectId}/{jobId}/{itemId}/preview.png
+processed/{projectId}/{jobId}/{itemId}/processing-report.json
+processed/{projectId}/{jobId}/{itemId}/debug/{step}.png
+```
+
+## Presigned Upload Flow
+
+1. Client creates an upload session through Spring API.
+2. Client sends file metadata and checksum to Spring API.
+3. Spring API validates metadata and creates object keys.
+4. Spring API returns presigned upload URLs with expiration timestamps.
+5. Client uploads file bodies directly to object storage.
+6. Client calls upload complete.
+7. Spring API verifies object existence through `ObjectStoragePort`.
+8. Later image-domain logic creates `Image` rows from completed upload files.
+
+## Local Skeleton
+
+Current skeleton classes:
+
+- `PresignedUrlGenerator`
+- `ObjectStoragePort`
+- `LocalPresignedUrlGenerator`
+- `LocalObjectStorageAdapter`
+
+The local classes are placeholders so the application compiles and the domain boundary is testable. Production work
+must replace them with a MinIO/S3 adapter that uses real SDK calls and real object existence checks.
+
+## Required Environment Variables For Real Adapter
+
+```text
+MINIO_ENDPOINT
+MINIO_ACCESS_KEY
+MINIO_SECRET_KEY
+MINIO_BUCKET
+```
+
+For S3-compatible production storage, equivalent endpoint, region, access key, secret key, and bucket values are
+required.
+
+## Operational Checks
+
+- Presigned URL expiration should be short, usually 10 to 30 minutes.
+- `client_max_body_size` in NGINX is not the main protection for presigned upload because the file body bypasses
+  Spring API.
+- Object keys should include project and session identifiers for cleanup and audit.
+- Cleanup jobs should remove cancelled or expired upload session objects.
+- Debug artifacts should be disabled by default because they increase storage usage.


### PR DESCRIPTION
## 기능 설명

대용량 문서 이미지 업로드를 위해 Spring API가 파일 본문을 직접 받지 않는 upload session + presigned URL 기반 skeleton을 추가합니다.

Depends on #20
Closes #21

## 작업 상세 내용

- [x] `domain/upload` 하위에 controller, dto, entity, repository, service, exception 구조 추가
- [x] `UploadSession`, `UploadSessionFile`, 상태 enum 추가
- [x] upload session 생성/조회/취소 API skeleton 추가
- [x] presigned upload URL 발급 API skeleton 추가
- [x] upload complete API skeleton 추가
- [x] 확장자/content type/size/checksum 검증 service 추가
- [x] `ObjectStoragePort`, `PresignedUrlGenerator` infra port 추가
- [x] local skeleton adapter 추가
- [x] upload API, storage operation, issue 작업 단위 문서 추가
- [x] entity/service 단위 테스트 추가

## 변경 파일 요약

- `backend-api/src/main/java/com/moonju/preprocess/api/domain/upload/...`
- `backend-api/src/main/java/com/moonju/preprocess/api/infra/storage/...`
- `backend-api/src/test/java/com/moonju/preprocess/api/domain/upload/...`
- `docs/api/upload-api.md`
- `docs/operation/storage-operation.md`
- `docs/feature-specs/issue-21-upload-domain-skeleton.md`

## 검증 내용

- [x] `git diff --check`
- [x] Docker: `gradle test --no-daemon`
- [x] Docker: `gradle build --no-daemon`
- [ ] Swagger UI 직접 확인은 아직 미수행

## 리뷰어 확인 요청

- upload 완료 전 `Image` row를 만들지 않고 `uploadFileId`만 반환하는 방향이 맞는지 확인해주세요.
- `LocalObjectStorageAdapter`와 `LocalPresignedUrlGenerator`는 compile/local skeleton입니다. 실제 MinIO/S3 adapter는 다음 작업에서 교체해야 합니다.
- API 서버가 대용량 파일 본문을 직접 받지 않는 구조인지 확인해주세요.