### PR TITLE
✨ [Feat] Project 도메인 CRUD와 권한 검증 구현

### DIFF
--- a/backend-api/src/main/java/com/moonju/preprocess/api/BackendApiApplication.java
+++ b/backend-api/src/main/java/com/moonju/preprocess/api/BackendApiApplication.java
@@ -2,7 +2,9 @@ package com.moonju.preprocess.api;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableJpaAuditing
 @SpringBootApplication
 public class BackendApiApplication {
 

--- a/backend-api/src/main/java/com/moonju/preprocess/api/domain/project/controller/ProjectController.java
+++ b/backend-api/src/main/java/com/moonju/preprocess/api/domain/project/controller/ProjectController.java
@@ -1,0 +1,74 @@
+package com.moonju.preprocess.api.domain.project.controller;
+
+import com.moonju.preprocess.api.domain.project.dto.ProjectCreateRequest;
+import com.moonju.preprocess.api.domain.project.dto.ProjectResponse;
+import com.moonju.preprocess.api.domain.project.dto.ProjectSummaryResponse;
+import com.moonju.preprocess.api.domain.project.dto.ProjectUpdateRequest;
+import com.moonju.preprocess.api.domain.project.service.ProjectService;
+import com.moonju.preprocess.api.global.error.ErrorCode;
+import com.moonju.preprocess.api.global.response.ApiResponse;
+import com.moonju.preprocess.api.global.response.PageResponse;
+import com.moonju.preprocess.api.global.support.CurrentUser;
+import jakarta.validation.Valid;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/projects")
+public class ProjectController {
+
+    private final ProjectService projectService;
+
+    public ProjectController(ProjectService projectService) {
+        this.projectService = projectService;
+    }
+
+    @PostMapping
+    public ApiResponse<ProjectResponse> create(
+        @CurrentUser Long currentUserId,
+        @Valid @RequestBody ProjectCreateRequest request
+    ) {
+        return ApiResponse.success(ErrorCode.COMMON_CREATED, projectService.create(currentUserId, request));
+    }
+
+    @GetMapping
+    public ApiResponse<PageResponse<ProjectResponse>> findMyProjects(
+        @CurrentUser Long currentUserId,
+        @PageableDefault(size = 20) Pageable pageable
+    ) {
+        return ApiResponse.success(projectService.findMyProjects(currentUserId, pageable));
+    }
+
+    @GetMapping("/{projectId}")
+    public ApiResponse<ProjectResponse> findOne(@CurrentUser Long currentUserId, @PathVariable Long projectId) {
+        return ApiResponse.success(projectService.findOne(currentUserId, projectId));
+    }
+
+    @PatchMapping("/{projectId}")
+    public ApiResponse<ProjectResponse> update(
+        @CurrentUser Long currentUserId,
+        @PathVariable Long projectId,
+        @Valid @RequestBody ProjectUpdateRequest request
+    ) {
+        return ApiResponse.success(projectService.update(currentUserId, projectId, request));
+    }
+
+    @DeleteMapping("/{projectId}")
+    public ApiResponse<Void> delete(@CurrentUser Long currentUserId, @PathVariable Long projectId) {
+        projectService.delete(currentUserId, projectId);
+        return ApiResponse.success(ErrorCode.COMMON_NO_CONTENT, null);
+    }
+
+    @GetMapping("/{projectId}/summary")
+    public ApiResponse<ProjectSummaryResponse> summary(@CurrentUser Long currentUserId, @PathVariable Long projectId) {
+        return ApiResponse.success(projectService.summary(currentUserId, projectId));
+    }
+}

--- a/backend-api/src/main/java/com/moonju/preprocess/api/domain/project/controller/ProjectMemberController.java
+++ b/backend-api/src/main/java/com/moonju/preprocess/api/domain/project/controller/ProjectMemberController.java
@@ -1,0 +1,59 @@
+package com.moonju.preprocess.api.domain.project.controller;
+
+import com.moonju.preprocess.api.domain.project.dto.ProjectMemberInviteRequest;
+import com.moonju.preprocess.api.domain.project.dto.ProjectMemberResponse;
+import com.moonju.preprocess.api.domain.project.service.ProjectMemberService;
+import com.moonju.preprocess.api.global.error.ErrorCode;
+import com.moonju.preprocess.api.global.response.ApiResponse;
+import com.moonju.preprocess.api.global.support.CurrentUser;
+import jakarta.validation.Valid;
+import java.util.List;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/projects/{projectId}/members")
+public class ProjectMemberController {
+
+    private final ProjectMemberService projectMemberService;
+
+    public ProjectMemberController(ProjectMemberService projectMemberService) {
+        this.projectMemberService = projectMemberService;
+    }
+
+    @PostMapping
+    public ApiResponse<ProjectMemberResponse> invite(
+        @CurrentUser Long currentUserId,
+        @PathVariable Long projectId,
+        @Valid @RequestBody ProjectMemberInviteRequest request
+    ) {
+        return ApiResponse.success(ErrorCode.COMMON_CREATED, projectMemberService.invite(
+            currentUserId,
+            projectId,
+            request
+        ));
+    }
+
+    @GetMapping
+    public ApiResponse<List<ProjectMemberResponse>> findMembers(
+        @CurrentUser Long currentUserId,
+        @PathVariable Long projectId
+    ) {
+        return ApiResponse.success(projectMemberService.findMembers(currentUserId, projectId));
+    }
+
+    @DeleteMapping("/{userId}")
+    public ApiResponse<Void> remove(
+        @CurrentUser Long currentUserId,
+        @PathVariable Long projectId,
+        @PathVariable Long userId
+    ) {
+        projectMemberService.remove(currentUserId, projectId, userId);
+        return ApiResponse.success(ErrorCode.COMMON_NO_CONTENT, null);
+    }
+}

--- a/backend-api/src/main/java/com/moonju/preprocess/api/domain/project/dto/ProjectCreateRequest.java
+++ b/backend-api/src/main/java/com/moonju/preprocess/api/domain/project/dto/ProjectCreateRequest.java
@@ -1,0 +1,17 @@
+package com.moonju.preprocess.api.domain.project.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record ProjectCreateRequest(
+    @NotBlank
+    @Size(max = 120)
+    String name,
+
+    @Size(max = 1000)
+    String description,
+
+    @Size(max = 100)
+    String defaultPreset
+) {
+}

--- a/backend-api/src/main/java/com/moonju/preprocess/api/domain/project/dto/ProjectMemberInviteRequest.java
+++ b/backend-api/src/main/java/com/moonju/preprocess/api/domain/project/dto/ProjectMemberInviteRequest.java
@@ -1,0 +1,13 @@
+package com.moonju.preprocess.api.domain.project.dto;
+
+import com.moonju.preprocess.api.domain.project.entity.ProjectRole;
+import jakarta.validation.constraints.NotNull;
+
+public record ProjectMemberInviteRequest(
+    @NotNull
+    Long userId,
+
+    @NotNull
+    ProjectRole role
+) {
+}

--- a/backend-api/src/main/java/com/moonju/preprocess/api/domain/project/dto/ProjectMemberResponse.java
+++ b/backend-api/src/main/java/com/moonju/preprocess/api/domain/project/dto/ProjectMemberResponse.java
@@ -1,0 +1,26 @@
+package com.moonju.preprocess.api.domain.project.dto;
+
+import com.moonju.preprocess.api.domain.project.entity.ProjectMember;
+import com.moonju.preprocess.api.domain.project.entity.ProjectRole;
+import java.time.LocalDateTime;
+
+public record ProjectMemberResponse(
+    Long id,
+    Long userId,
+    String email,
+    String name,
+    ProjectRole role,
+    LocalDateTime createdAt
+) {
+
+    public static ProjectMemberResponse from(ProjectMember member) {
+        return new ProjectMemberResponse(
+            member.getId(),
+            member.getUser().getId(),
+            member.getUser().getEmail(),
+            member.getUser().getName(),
+            member.getRole(),
+            member.getCreatedAt()
+        );
+    }
+}

--- a/backend-api/src/main/java/com/moonju/preprocess/api/domain/project/dto/ProjectResponse.java
+++ b/backend-api/src/main/java/com/moonju/preprocess/api/domain/project/dto/ProjectResponse.java
@@ -1,0 +1,35 @@
+package com.moonju.preprocess.api.domain.project.dto;
+
+import com.moonju.preprocess.api.domain.project.entity.Project;
+import com.moonju.preprocess.api.domain.project.entity.ProjectRole;
+import com.moonju.preprocess.api.domain.project.entity.ProjectStatus;
+import java.time.LocalDateTime;
+
+public record ProjectResponse(
+    Long id,
+    String name,
+    String description,
+    String defaultPreset,
+    ProjectStatus status,
+    Long ownerId,
+    String ownerEmail,
+    ProjectRole myRole,
+    LocalDateTime createdAt,
+    LocalDateTime updatedAt
+) {
+
+    public static ProjectResponse from(Project project, ProjectRole myRole) {
+        return new ProjectResponse(
+            project.getId(),
+            project.getName(),
+            project.getDescription(),
+            project.getDefaultPreset(),
+            project.getStatus(),
+            project.getOwner().getId(),
+            project.getOwner().getEmail(),
+            myRole,
+            project.getCreatedAt(),
+            project.getUpdatedAt()
+        );
+    }
+}

--- a/backend-api/src/main/java/com/moonju/preprocess/api/domain/project/dto/ProjectSummaryResponse.java
+++ b/backend-api/src/main/java/com/moonju/preprocess/api/domain/project/dto/ProjectSummaryResponse.java
@@ -1,0 +1,10 @@
+package com.moonju.preprocess.api.domain.project.dto;
+
+public record ProjectSummaryResponse(
+    Long projectId,
+    String name,
+    long memberCount,
+    long imageCount,
+    long jobCount
+) {
+}

--- a/backend-api/src/main/java/com/moonju/preprocess/api/domain/project/dto/ProjectUpdateRequest.java
+++ b/backend-api/src/main/java/com/moonju/preprocess/api/domain/project/dto/ProjectUpdateRequest.java
@@ -1,0 +1,15 @@
+package com.moonju.preprocess.api.domain.project.dto;
+
+import jakarta.validation.constraints.Size;
+
+public record ProjectUpdateRequest(
+    @Size(max = 120)
+    String name,
+
+    @Size(max = 1000)
+    String description,
+
+    @Size(max = 100)
+    String defaultPreset
+) {
+}

--- a/backend-api/src/main/java/com/moonju/preprocess/api/domain/project/entity/Project.java
+++ b/backend-api/src/main/java/com/moonju/preprocess/api/domain/project/entity/Project.java
@@ -1,0 +1,96 @@
+package com.moonju.preprocess.api.domain.project.entity;
+
+import com.moonju.preprocess.api.domain.user.entity.User;
+import com.moonju.preprocess.api.global.support.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+
+@Entity
+@Table(name = "projects")
+public class Project extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "owner_id", nullable = false)
+    private User owner;
+
+    @Column(nullable = false, length = 120)
+    private String name;
+
+    @Column(length = 1000)
+    private String description;
+
+    @Column(length = 100)
+    private String defaultPreset;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 30)
+    private ProjectStatus status;
+
+    protected Project() {
+    }
+
+    private Project(User owner, String name, String description, String defaultPreset) {
+        this.owner = owner;
+        this.name = name;
+        this.description = description;
+        this.defaultPreset = defaultPreset;
+        this.status = ProjectStatus.ACTIVE;
+    }
+
+    public static Project create(User owner, String name, String description, String defaultPreset) {
+        return new Project(owner, name, description, defaultPreset);
+    }
+
+    public void update(String name, String description, String defaultPreset) {
+        if (name != null) {
+            this.name = name;
+        }
+        if (description != null) {
+            this.description = description;
+        }
+        if (defaultPreset != null) {
+            this.defaultPreset = defaultPreset;
+        }
+    }
+
+    public void delete() {
+        this.status = ProjectStatus.DELETED;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public User getOwner() {
+        return owner;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public String getDefaultPreset() {
+        return defaultPreset;
+    }
+
+    public ProjectStatus getStatus() {
+        return status;
+    }
+}

--- a/backend-api/src/main/java/com/moonju/preprocess/api/domain/project/entity/ProjectMember.java
+++ b/backend-api/src/main/java/com/moonju/preprocess/api/domain/project/entity/ProjectMember.java
@@ -1,0 +1,67 @@
+package com.moonju.preprocess.api.domain.project.entity;
+
+import com.moonju.preprocess.api.domain.user.entity.User;
+import com.moonju.preprocess.api.global.support.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+
+@Entity
+@Table(
+    name = "project_members",
+    uniqueConstraints = {
+        @UniqueConstraint(name = "uk_project_member_project_user", columnNames = {"project_id", "user_id"})
+    }
+)
+public class ProjectMember extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "project_id", nullable = false)
+    private Project project;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 30)
+    private ProjectRole role;
+
+    protected ProjectMember() {
+    }
+
+    public ProjectMember(Project project, User user, ProjectRole role) {
+        this.project = project;
+        this.user = user;
+        this.role = role;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public Project getProject() {
+        return project;
+    }
+
+    public User getUser() {
+        return user;
+    }
+
+    public ProjectRole getRole() {
+        return role;
+    }
+}

--- a/backend-api/src/main/java/com/moonju/preprocess/api/domain/project/entity/ProjectRole.java
+++ b/backend-api/src/main/java/com/moonju/preprocess/api/domain/project/entity/ProjectRole.java
@@ -1,0 +1,20 @@
+package com.moonju.preprocess.api.domain.project.entity;
+
+public enum ProjectRole {
+
+    OWNER,
+    EDITOR,
+    VIEWER;
+
+    public boolean canRead() {
+        return true;
+    }
+
+    public boolean canEdit() {
+        return this == OWNER || this == EDITOR;
+    }
+
+    public boolean canManageMembers() {
+        return this == OWNER;
+    }
+}

--- a/backend-api/src/main/java/com/moonju/preprocess/api/domain/project/entity/ProjectStatus.java
+++ b/backend-api/src/main/java/com/moonju/preprocess/api/domain/project/entity/ProjectStatus.java
@@ -1,0 +1,7 @@
+package com.moonju.preprocess.api.domain.project.entity;
+
+public enum ProjectStatus {
+
+    ACTIVE,
+    DELETED
+}

--- a/backend-api/src/main/java/com/moonju/preprocess/api/domain/project/exception/InvalidProjectMemberRoleException.java
+++ b/backend-api/src/main/java/com/moonju/preprocess/api/domain/project/exception/InvalidProjectMemberRoleException.java
@@ -1,0 +1,11 @@
+package com.moonju.preprocess.api.domain.project.exception;
+
+import com.moonju.preprocess.api.global.error.BusinessException;
+import com.moonju.preprocess.api.global.error.ErrorCode;
+
+public class InvalidProjectMemberRoleException extends BusinessException {
+
+    public InvalidProjectMemberRoleException(String message) {
+        super(ErrorCode.COMMON_BAD_REQUEST, message);
+    }
+}

--- a/backend-api/src/main/java/com/moonju/preprocess/api/domain/project/exception/ProjectAccessDeniedException.java
+++ b/backend-api/src/main/java/com/moonju/preprocess/api/domain/project/exception/ProjectAccessDeniedException.java
@@ -1,0 +1,11 @@
+package com.moonju.preprocess.api.domain.project.exception;
+
+import com.moonju.preprocess.api.global.error.BusinessException;
+import com.moonju.preprocess.api.global.error.ErrorCode;
+
+public class ProjectAccessDeniedException extends BusinessException {
+
+    public ProjectAccessDeniedException() {
+        super(ErrorCode.COMMON_FORBIDDEN, "Project access denied.");
+    }
+}

--- a/backend-api/src/main/java/com/moonju/preprocess/api/domain/project/exception/ProjectMemberConflictException.java
+++ b/backend-api/src/main/java/com/moonju/preprocess/api/domain/project/exception/ProjectMemberConflictException.java
@@ -1,0 +1,11 @@
+package com.moonju.preprocess.api.domain.project.exception;
+
+import com.moonju.preprocess.api.global.error.BusinessException;
+import com.moonju.preprocess.api.global.error.ErrorCode;
+
+public class ProjectMemberConflictException extends BusinessException {
+
+    public ProjectMemberConflictException() {
+        super(ErrorCode.COMMON_CONFLICT, "Project member already exists.");
+    }
+}

--- a/backend-api/src/main/java/com/moonju/preprocess/api/domain/project/exception/ProjectMemberNotFoundException.java
+++ b/backend-api/src/main/java/com/moonju/preprocess/api/domain/project/exception/ProjectMemberNotFoundException.java
@@ -1,0 +1,11 @@
+package com.moonju.preprocess.api.domain.project.exception;
+
+import com.moonju.preprocess.api.global.error.BusinessException;
+import com.moonju.preprocess.api.global.error.ErrorCode;
+
+public class ProjectMemberNotFoundException extends BusinessException {
+
+    public ProjectMemberNotFoundException() {
+        super(ErrorCode.COMMON_NOT_FOUND, "Project member not found.");
+    }
+}

--- a/backend-api/src/main/java/com/moonju/preprocess/api/domain/project/exception/ProjectNotFoundException.java
+++ b/backend-api/src/main/java/com/moonju/preprocess/api/domain/project/exception/ProjectNotFoundException.java
@@ -1,0 +1,11 @@
+package com.moonju.preprocess.api.domain.project.exception;
+
+import com.moonju.preprocess.api.global.error.BusinessException;
+import com.moonju.preprocess.api.global.error.ErrorCode;
+
+public class ProjectNotFoundException extends BusinessException {
+
+    public ProjectNotFoundException() {
+        super(ErrorCode.COMMON_NOT_FOUND, "Project not found.");
+    }
+}

--- a/backend-api/src/main/java/com/moonju/preprocess/api/domain/project/repository/ProjectMemberRepository.java
+++ b/backend-api/src/main/java/com/moonju/preprocess/api/domain/project/repository/ProjectMemberRepository.java
@@ -1,0 +1,30 @@
+package com.moonju.preprocess.api.domain.project.repository;
+
+import com.moonju.preprocess.api.domain.project.entity.ProjectMember;
+import com.moonju.preprocess.api.domain.project.entity.ProjectStatus;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.EntityGraph;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ProjectMemberRepository extends JpaRepository<ProjectMember, Long> {
+
+    @EntityGraph(attributePaths = {"project", "project.owner", "user"})
+    Optional<ProjectMember> findByProject_IdAndUser_IdAndProject_Status(
+        Long projectId,
+        Long userId,
+        ProjectStatus status
+    );
+
+    @EntityGraph(attributePaths = {"project", "project.owner", "user"})
+    Page<ProjectMember> findAllByUser_IdAndProject_Status(Long userId, ProjectStatus status, Pageable pageable);
+
+    @EntityGraph(attributePaths = {"project", "project.owner", "user"})
+    List<ProjectMember> findAllByProject_IdAndProject_StatusOrderByIdAsc(Long projectId, ProjectStatus status);
+
+    boolean existsByProject_IdAndUser_Id(Long projectId, Long userId);
+
+    long countByProject_IdAndProject_Status(Long projectId, ProjectStatus status);
+}

--- a/backend-api/src/main/java/com/moonju/preprocess/api/domain/project/repository/ProjectRepository.java
+++ b/backend-api/src/main/java/com/moonju/preprocess/api/domain/project/repository/ProjectRepository.java
@@ -1,0 +1,13 @@
+package com.moonju.preprocess.api.domain.project.repository;
+
+import com.moonju.preprocess.api.domain.project.entity.Project;
+import com.moonju.preprocess.api.domain.project.entity.ProjectStatus;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.EntityGraph;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ProjectRepository extends JpaRepository<Project, Long> {
+
+    @EntityGraph(attributePaths = "owner")
+    Optional<Project> findByIdAndStatus(Long id, ProjectStatus status);
+}

--- a/backend-api/src/main/java/com/moonju/preprocess/api/domain/project/service/ProjectMemberService.java
+++ b/backend-api/src/main/java/com/moonju/preprocess/api/domain/project/service/ProjectMemberService.java
@@ -1,0 +1,81 @@
+package com.moonju.preprocess.api.domain.project.service;
+
+import com.moonju.preprocess.api.domain.project.dto.ProjectMemberInviteRequest;
+import com.moonju.preprocess.api.domain.project.dto.ProjectMemberResponse;
+import com.moonju.preprocess.api.domain.project.entity.ProjectMember;
+import com.moonju.preprocess.api.domain.project.entity.ProjectRole;
+import com.moonju.preprocess.api.domain.project.entity.ProjectStatus;
+import com.moonju.preprocess.api.domain.project.exception.InvalidProjectMemberRoleException;
+import com.moonju.preprocess.api.domain.project.exception.ProjectMemberConflictException;
+import com.moonju.preprocess.api.domain.project.exception.ProjectMemberNotFoundException;
+import com.moonju.preprocess.api.domain.project.repository.ProjectMemberRepository;
+import com.moonju.preprocess.api.domain.user.entity.User;
+import com.moonju.preprocess.api.domain.user.repository.UserRepository;
+import java.util.List;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class ProjectMemberService {
+
+    private final ProjectMemberRepository projectMemberRepository;
+    private final UserRepository userRepository;
+    private final ProjectPermissionService projectPermissionService;
+
+    public ProjectMemberService(
+        ProjectMemberRepository projectMemberRepository,
+        UserRepository userRepository,
+        ProjectPermissionService projectPermissionService
+    ) {
+        this.projectMemberRepository = projectMemberRepository;
+        this.userRepository = userRepository;
+        this.projectPermissionService = projectPermissionService;
+    }
+
+    @Transactional
+    public ProjectMemberResponse invite(Long currentUserId, Long projectId, ProjectMemberInviteRequest request) {
+        ProjectMember ownerMember = projectPermissionService.validateOwner(projectId, currentUserId);
+        validateInvitableRole(request.role());
+        if (projectMemberRepository.existsByProject_IdAndUser_Id(projectId, request.userId())) {
+            throw new ProjectMemberConflictException();
+        }
+        User invitedUser = userRepository.findById(request.userId())
+            .orElseThrow(ProjectMemberNotFoundException::new);
+        ProjectMember invitedMember = projectMemberRepository.save(new ProjectMember(
+            ownerMember.getProject(),
+            invitedUser,
+            request.role()
+        ));
+        return ProjectMemberResponse.from(invitedMember);
+    }
+
+    @Transactional(readOnly = true)
+    public List<ProjectMemberResponse> findMembers(Long currentUserId, Long projectId) {
+        projectPermissionService.validateReadable(projectId, currentUserId);
+        return projectMemberRepository.findAllByProject_IdAndProject_StatusOrderByIdAsc(projectId, ProjectStatus.ACTIVE)
+            .stream()
+            .map(ProjectMemberResponse::from)
+            .toList();
+    }
+
+    @Transactional
+    public void remove(Long currentUserId, Long projectId, Long targetUserId) {
+        projectPermissionService.validateOwner(projectId, currentUserId);
+        ProjectMember targetMember = projectMemberRepository.findByProject_IdAndUser_IdAndProject_Status(
+                projectId,
+                targetUserId,
+                ProjectStatus.ACTIVE
+            )
+            .orElseThrow(ProjectMemberNotFoundException::new);
+        if (targetMember.getRole() == ProjectRole.OWNER) {
+            throw new InvalidProjectMemberRoleException("Project owner cannot be removed.");
+        }
+        projectMemberRepository.delete(targetMember);
+    }
+
+    private void validateInvitableRole(ProjectRole role) {
+        if (role == ProjectRole.OWNER) {
+            throw new InvalidProjectMemberRoleException("OWNER role cannot be invited.");
+        }
+    }
+}

--- a/backend-api/src/main/java/com/moonju/preprocess/api/domain/project/service/ProjectPermissionService.java
+++ b/backend-api/src/main/java/com/moonju/preprocess/api/domain/project/service/ProjectPermissionService.java
@@ -1,0 +1,54 @@
+package com.moonju.preprocess.api.domain.project.service;
+
+import com.moonju.preprocess.api.domain.project.entity.ProjectMember;
+import com.moonju.preprocess.api.domain.project.entity.ProjectStatus;
+import com.moonju.preprocess.api.domain.project.exception.ProjectAccessDeniedException;
+import com.moonju.preprocess.api.domain.project.repository.ProjectMemberRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class ProjectPermissionService {
+
+    private final ProjectMemberRepository projectMemberRepository;
+
+    public ProjectPermissionService(ProjectMemberRepository projectMemberRepository) {
+        this.projectMemberRepository = projectMemberRepository;
+    }
+
+    @Transactional(readOnly = true)
+    public ProjectMember validateReadable(Long projectId, Long userId) {
+        ProjectMember member = findActiveMember(projectId, userId);
+        if (!member.getRole().canRead()) {
+            throw new ProjectAccessDeniedException();
+        }
+        return member;
+    }
+
+    @Transactional(readOnly = true)
+    public ProjectMember validateEditable(Long projectId, Long userId) {
+        ProjectMember member = findActiveMember(projectId, userId);
+        if (!member.getRole().canEdit()) {
+            throw new ProjectAccessDeniedException();
+        }
+        return member;
+    }
+
+    @Transactional(readOnly = true)
+    public ProjectMember validateOwner(Long projectId, Long userId) {
+        ProjectMember member = findActiveMember(projectId, userId);
+        if (!member.getRole().canManageMembers()) {
+            throw new ProjectAccessDeniedException();
+        }
+        return member;
+    }
+
+    private ProjectMember findActiveMember(Long projectId, Long userId) {
+        return projectMemberRepository.findByProject_IdAndUser_IdAndProject_Status(
+                projectId,
+                userId,
+                ProjectStatus.ACTIVE
+            )
+            .orElseThrow(ProjectAccessDeniedException::new);
+    }
+}

--- a/backend-api/src/main/java/com/moonju/preprocess/api/domain/project/service/ProjectService.java
+++ b/backend-api/src/main/java/com/moonju/preprocess/api/domain/project/service/ProjectService.java
@@ -1,0 +1,112 @@
+package com.moonju.preprocess.api.domain.project.service;
+
+import com.moonju.preprocess.api.domain.project.dto.ProjectCreateRequest;
+import com.moonju.preprocess.api.domain.project.dto.ProjectResponse;
+import com.moonju.preprocess.api.domain.project.dto.ProjectSummaryResponse;
+import com.moonju.preprocess.api.domain.project.dto.ProjectUpdateRequest;
+import com.moonju.preprocess.api.domain.project.entity.Project;
+import com.moonju.preprocess.api.domain.project.entity.ProjectMember;
+import com.moonju.preprocess.api.domain.project.entity.ProjectRole;
+import com.moonju.preprocess.api.domain.project.entity.ProjectStatus;
+import com.moonju.preprocess.api.domain.project.exception.InvalidProjectMemberRoleException;
+import com.moonju.preprocess.api.domain.project.repository.ProjectMemberRepository;
+import com.moonju.preprocess.api.domain.project.repository.ProjectRepository;
+import com.moonju.preprocess.api.domain.user.entity.User;
+import com.moonju.preprocess.api.domain.user.repository.UserRepository;
+import com.moonju.preprocess.api.global.response.PageResponse;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+
+@Service
+public class ProjectService {
+
+    private final ProjectRepository projectRepository;
+    private final ProjectMemberRepository projectMemberRepository;
+    private final UserRepository userRepository;
+    private final ProjectPermissionService projectPermissionService;
+
+    public ProjectService(
+        ProjectRepository projectRepository,
+        ProjectMemberRepository projectMemberRepository,
+        UserRepository userRepository,
+        ProjectPermissionService projectPermissionService
+    ) {
+        this.projectRepository = projectRepository;
+        this.projectMemberRepository = projectMemberRepository;
+        this.userRepository = userRepository;
+        this.projectPermissionService = projectPermissionService;
+    }
+
+    @Transactional
+    public ProjectResponse create(Long currentUserId, ProjectCreateRequest request) {
+        User owner = findUser(currentUserId);
+        Project project = projectRepository.save(Project.create(
+            owner,
+            request.name().trim(),
+            request.description(),
+            request.defaultPreset()
+        ));
+        projectMemberRepository.save(new ProjectMember(project, owner, ProjectRole.OWNER));
+        return ProjectResponse.from(project, ProjectRole.OWNER);
+    }
+
+    @Transactional(readOnly = true)
+    public PageResponse<ProjectResponse> findMyProjects(Long currentUserId, Pageable pageable) {
+        return PageResponse.from(projectMemberRepository
+            .findAllByUser_IdAndProject_Status(currentUserId, ProjectStatus.ACTIVE, pageable)
+            .map(member -> ProjectResponse.from(member.getProject(), member.getRole())));
+    }
+
+    @Transactional(readOnly = true)
+    public ProjectResponse findOne(Long currentUserId, Long projectId) {
+        ProjectMember member = projectPermissionService.validateReadable(projectId, currentUserId);
+        return ProjectResponse.from(member.getProject(), member.getRole());
+    }
+
+    @Transactional
+    public ProjectResponse update(Long currentUserId, Long projectId, ProjectUpdateRequest request) {
+        ProjectMember member = projectPermissionService.validateEditable(projectId, currentUserId);
+        member.getProject().update(
+            normalizeName(request.name()),
+            request.description(),
+            request.defaultPreset()
+        );
+        return ProjectResponse.from(member.getProject(), member.getRole());
+    }
+
+    @Transactional
+    public void delete(Long currentUserId, Long projectId) {
+        ProjectMember member = projectPermissionService.validateOwner(projectId, currentUserId);
+        member.getProject().delete();
+    }
+
+    @Transactional(readOnly = true)
+    public ProjectSummaryResponse summary(Long currentUserId, Long projectId) {
+        ProjectMember member = projectPermissionService.validateReadable(projectId, currentUserId);
+        long memberCount = projectMemberRepository.countByProject_IdAndProject_Status(projectId, ProjectStatus.ACTIVE);
+        return new ProjectSummaryResponse(
+            member.getProject().getId(),
+            member.getProject().getName(),
+            memberCount,
+            0,
+            0
+        );
+    }
+
+    private User findUser(Long userId) {
+        return userRepository.findById(userId)
+            .orElseThrow(() -> new InvalidProjectMemberRoleException("Project owner user not found."));
+    }
+
+    private String normalizeName(String name) {
+        if (name == null) {
+            return null;
+        }
+        if (!StringUtils.hasText(name)) {
+            throw new InvalidProjectMemberRoleException("Project name must not be blank.");
+        }
+        return name.trim();
+    }
+}

--- a/backend-api/src/test/java/com/moonju/preprocess/api/domain/project/controller/ProjectControllerTests.java
+++ b/backend-api/src/test/java/com/moonju/preprocess/api/domain/project/controller/ProjectControllerTests.java
@@ -1,0 +1,47 @@
+package com.moonju.preprocess.api.domain.project.controller;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import com.moonju.preprocess.api.domain.project.dto.ProjectCreateRequest;
+import com.moonju.preprocess.api.domain.project.dto.ProjectResponse;
+import com.moonju.preprocess.api.domain.project.entity.ProjectRole;
+import com.moonju.preprocess.api.domain.project.entity.ProjectStatus;
+import com.moonju.preprocess.api.domain.project.service.ProjectService;
+import com.moonju.preprocess.api.global.response.ApiResponse;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ProjectControllerTests {
+
+    @Mock
+    private ProjectService projectService;
+
+    @Test
+    void createsProjectWithCommonResponse() {
+        ProjectController controller = new ProjectController(projectService);
+        ProjectCreateRequest request = new ProjectCreateRequest("Project", null, null);
+        ProjectResponse serviceResponse = new ProjectResponse(
+            10L,
+            "Project",
+            null,
+            null,
+            ProjectStatus.ACTIVE,
+            1L,
+            "owner@example.com",
+            ProjectRole.OWNER,
+            null,
+            null
+        );
+        when(projectService.create(1L, request)).thenReturn(serviceResponse);
+
+        ApiResponse<ProjectResponse> response = controller.create(1L, request);
+
+        assertThat(response.isSuccess()).isTrue();
+        assertThat(response.code()).isEqualTo("common201");
+        assertThat(response.result()).isSameAs(serviceResponse);
+    }
+}

--- a/backend-api/src/test/java/com/moonju/preprocess/api/domain/project/controller/ProjectMemberControllerTests.java
+++ b/backend-api/src/test/java/com/moonju/preprocess/api/domain/project/controller/ProjectMemberControllerTests.java
@@ -1,0 +1,42 @@
+package com.moonju.preprocess.api.domain.project.controller;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import com.moonju.preprocess.api.domain.project.dto.ProjectMemberInviteRequest;
+import com.moonju.preprocess.api.domain.project.dto.ProjectMemberResponse;
+import com.moonju.preprocess.api.domain.project.entity.ProjectRole;
+import com.moonju.preprocess.api.domain.project.service.ProjectMemberService;
+import com.moonju.preprocess.api.global.response.ApiResponse;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ProjectMemberControllerTests {
+
+    @Mock
+    private ProjectMemberService projectMemberService;
+
+    @Test
+    void invitesProjectMemberWithCommonResponse() {
+        ProjectMemberController controller = new ProjectMemberController(projectMemberService);
+        ProjectMemberInviteRequest request = new ProjectMemberInviteRequest(2L, ProjectRole.EDITOR);
+        ProjectMemberResponse serviceResponse = new ProjectMemberResponse(
+            100L,
+            2L,
+            "editor@example.com",
+            "Editor",
+            ProjectRole.EDITOR,
+            null
+        );
+        when(projectMemberService.invite(1L, 10L, request)).thenReturn(serviceResponse);
+
+        ApiResponse<ProjectMemberResponse> response = controller.invite(1L, 10L, request);
+
+        assertThat(response.isSuccess()).isTrue();
+        assertThat(response.code()).isEqualTo("common201");
+        assertThat(response.result()).isSameAs(serviceResponse);
+    }
+}

--- a/backend-api/src/test/java/com/moonju/preprocess/api/domain/project/entity/ProjectTests.java
+++ b/backend-api/src/test/java/com/moonju/preprocess/api/domain/project/entity/ProjectTests.java
@@ -1,0 +1,42 @@
+package com.moonju.preprocess.api.domain.project.entity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.moonju.preprocess.api.domain.user.entity.User;
+import org.junit.jupiter.api.Test;
+
+class ProjectTests {
+
+    @Test
+    void createsActiveProject() {
+        User owner = User.createUser("owner@example.com", "Owner", null);
+
+        Project project = Project.create(owner, "Library Scan", "Old books", "LOW_CONTRAST_SCAN");
+
+        assertThat(project.getOwner()).isSameAs(owner);
+        assertThat(project.getName()).isEqualTo("Library Scan");
+        assertThat(project.getDescription()).isEqualTo("Old books");
+        assertThat(project.getDefaultPreset()).isEqualTo("LOW_CONTRAST_SCAN");
+        assertThat(project.getStatus()).isEqualTo(ProjectStatus.ACTIVE);
+    }
+
+    @Test
+    void updatesProjectFields() {
+        Project project = Project.create(User.createUser("owner@example.com", "Owner", null), "Old", null, null);
+
+        project.update("New", "Description", "A4_SCAN_300DPI");
+
+        assertThat(project.getName()).isEqualTo("New");
+        assertThat(project.getDescription()).isEqualTo("Description");
+        assertThat(project.getDefaultPreset()).isEqualTo("A4_SCAN_300DPI");
+    }
+
+    @Test
+    void softDeletesProject() {
+        Project project = Project.create(User.createUser("owner@example.com", "Owner", null), "Project", null, null);
+
+        project.delete();
+
+        assertThat(project.getStatus()).isEqualTo(ProjectStatus.DELETED);
+    }
+}

--- a/backend-api/src/test/java/com/moonju/preprocess/api/domain/project/service/ProjectMemberServiceTests.java
+++ b/backend-api/src/test/java/com/moonju/preprocess/api/domain/project/service/ProjectMemberServiceTests.java
@@ -1,0 +1,104 @@
+package com.moonju.preprocess.api.domain.project.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.moonju.preprocess.api.domain.project.dto.ProjectMemberInviteRequest;
+import com.moonju.preprocess.api.domain.project.dto.ProjectMemberResponse;
+import com.moonju.preprocess.api.domain.project.entity.Project;
+import com.moonju.preprocess.api.domain.project.entity.ProjectMember;
+import com.moonju.preprocess.api.domain.project.entity.ProjectRole;
+import com.moonju.preprocess.api.domain.project.exception.InvalidProjectMemberRoleException;
+import com.moonju.preprocess.api.domain.project.repository.ProjectMemberRepository;
+import com.moonju.preprocess.api.domain.user.entity.User;
+import com.moonju.preprocess.api.domain.user.repository.UserRepository;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+class ProjectMemberServiceTests {
+
+    @Mock
+    private ProjectMemberRepository projectMemberRepository;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private ProjectPermissionService projectPermissionService;
+
+    @Test
+    void invitesEditorMember() {
+        ProjectMemberService memberService = memberService();
+        User owner = user(1L, "owner@example.com");
+        User editor = user(2L, "editor@example.com");
+        Project project = project(owner);
+        when(projectPermissionService.validateOwner(10L, 1L))
+            .thenReturn(new ProjectMember(project, owner, ProjectRole.OWNER));
+        when(projectMemberRepository.existsByProject_IdAndUser_Id(10L, 2L)).thenReturn(false);
+        when(userRepository.findById(2L)).thenReturn(Optional.of(editor));
+        when(projectMemberRepository.save(any(ProjectMember.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        ProjectMemberResponse response = memberService.invite(
+            1L,
+            10L,
+            new ProjectMemberInviteRequest(2L, ProjectRole.EDITOR)
+        );
+
+        assertThat(response.userId()).isEqualTo(2L);
+        assertThat(response.role()).isEqualTo(ProjectRole.EDITOR);
+    }
+
+    @Test
+    void rejectsOwnerInvite() {
+        ProjectMemberService memberService = memberService();
+        User owner = user(1L, "owner@example.com");
+        when(projectPermissionService.validateOwner(10L, 1L))
+            .thenReturn(new ProjectMember(project(owner), owner, ProjectRole.OWNER));
+
+        assertThatThrownBy(() -> memberService.invite(
+            1L,
+            10L,
+            new ProjectMemberInviteRequest(2L, ProjectRole.OWNER)
+        )).isInstanceOf(InvalidProjectMemberRoleException.class);
+    }
+
+    @Test
+    void removesNonOwnerMember() {
+        ProjectMemberService memberService = memberService();
+        User owner = user(1L, "owner@example.com");
+        User viewer = user(2L, "viewer@example.com");
+        Project project = project(owner);
+        ProjectMember viewerMember = new ProjectMember(project, viewer, ProjectRole.VIEWER);
+        when(projectMemberRepository.findByProject_IdAndUser_IdAndProject_Status(any(), any(), any()))
+            .thenReturn(Optional.of(viewerMember));
+
+        memberService.remove(1L, 10L, 2L);
+
+        verify(projectPermissionService).validateOwner(10L, 1L);
+        verify(projectMemberRepository).delete(viewerMember);
+    }
+
+    private ProjectMemberService memberService() {
+        return new ProjectMemberService(projectMemberRepository, userRepository, projectPermissionService);
+    }
+
+    private Project project(User owner) {
+        Project project = Project.create(owner, "Project", null, null);
+        ReflectionTestUtils.setField(project, "id", 10L);
+        return project;
+    }
+
+    private User user(Long id, String email) {
+        User user = User.createUser(email, "User", null);
+        ReflectionTestUtils.setField(user, "id", id);
+        return user;
+    }
+}

--- a/backend-api/src/test/java/com/moonju/preprocess/api/domain/project/service/ProjectPermissionServiceTests.java
+++ b/backend-api/src/test/java/com/moonju/preprocess/api/domain/project/service/ProjectPermissionServiceTests.java
@@ -1,0 +1,63 @@
+package com.moonju.preprocess.api.domain.project.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.when;
+
+import com.moonju.preprocess.api.domain.project.entity.Project;
+import com.moonju.preprocess.api.domain.project.entity.ProjectMember;
+import com.moonju.preprocess.api.domain.project.entity.ProjectRole;
+import com.moonju.preprocess.api.domain.project.entity.ProjectStatus;
+import com.moonju.preprocess.api.domain.project.exception.ProjectAccessDeniedException;
+import com.moonju.preprocess.api.domain.project.repository.ProjectMemberRepository;
+import com.moonju.preprocess.api.domain.user.entity.User;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ProjectPermissionServiceTests {
+
+    @Mock
+    private ProjectMemberRepository projectMemberRepository;
+
+    @Test
+    void validatesEditorEditablePermission() {
+        ProjectPermissionService permissionService = new ProjectPermissionService(projectMemberRepository);
+        ProjectMember member = member(ProjectRole.EDITOR);
+        when(projectMemberRepository.findByProject_IdAndUser_IdAndProject_Status(1L, 2L, ProjectStatus.ACTIVE))
+            .thenReturn(Optional.of(member));
+
+        ProjectMember result = permissionService.validateEditable(1L, 2L);
+
+        assertThat(result).isSameAs(member);
+    }
+
+    @Test
+    void rejectsViewerEditablePermission() {
+        ProjectPermissionService permissionService = new ProjectPermissionService(projectMemberRepository);
+        when(projectMemberRepository.findByProject_IdAndUser_IdAndProject_Status(1L, 2L, ProjectStatus.ACTIVE))
+            .thenReturn(Optional.of(member(ProjectRole.VIEWER)));
+
+        assertThatThrownBy(() -> permissionService.validateEditable(1L, 2L))
+            .isInstanceOf(ProjectAccessDeniedException.class);
+    }
+
+    @Test
+    void rejectsMissingMember() {
+        ProjectPermissionService permissionService = new ProjectPermissionService(projectMemberRepository);
+        when(projectMemberRepository.findByProject_IdAndUser_IdAndProject_Status(1L, 2L, ProjectStatus.ACTIVE))
+            .thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> permissionService.validateReadable(1L, 2L))
+            .isInstanceOf(ProjectAccessDeniedException.class);
+    }
+
+    private ProjectMember member(ProjectRole role) {
+        User user = User.createUser("user@example.com", "User", null);
+        Project project = Project.create(user, "Project", null, null);
+        return new ProjectMember(project, user, role);
+    }
+}

--- a/backend-api/src/test/java/com/moonju/preprocess/api/domain/project/service/ProjectServiceTests.java
+++ b/backend-api/src/test/java/com/moonju/preprocess/api/domain/project/service/ProjectServiceTests.java
@@ -1,0 +1,92 @@
+package com.moonju.preprocess.api.domain.project.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.moonju.preprocess.api.domain.project.dto.ProjectCreateRequest;
+import com.moonju.preprocess.api.domain.project.dto.ProjectResponse;
+import com.moonju.preprocess.api.domain.project.dto.ProjectUpdateRequest;
+import com.moonju.preprocess.api.domain.project.entity.Project;
+import com.moonju.preprocess.api.domain.project.entity.ProjectMember;
+import com.moonju.preprocess.api.domain.project.entity.ProjectRole;
+import com.moonju.preprocess.api.domain.project.repository.ProjectMemberRepository;
+import com.moonju.preprocess.api.domain.project.repository.ProjectRepository;
+import com.moonju.preprocess.api.domain.user.entity.User;
+import com.moonju.preprocess.api.domain.user.repository.UserRepository;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+class ProjectServiceTests {
+
+    @Mock
+    private ProjectRepository projectRepository;
+
+    @Mock
+    private ProjectMemberRepository projectMemberRepository;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private ProjectPermissionService projectPermissionService;
+
+    @Test
+    void createsProjectAndOwnerMember() {
+        ProjectService projectService = projectService();
+        User owner = user(1L, "owner@example.com");
+        when(userRepository.findById(1L)).thenReturn(Optional.of(owner));
+        when(projectRepository.save(any(Project.class))).thenAnswer(invocation -> {
+            Project project = invocation.getArgument(0);
+            ReflectionTestUtils.setField(project, "id", 10L);
+            return project;
+        });
+
+        ProjectResponse response = projectService.create(
+            1L,
+            new ProjectCreateRequest(" Project ", "Description", "LOW_CONTRAST_SCAN")
+        );
+
+        assertThat(response.id()).isEqualTo(10L);
+        assertThat(response.name()).isEqualTo("Project");
+        assertThat(response.myRole()).isEqualTo(ProjectRole.OWNER);
+        verify(projectMemberRepository).save(any(ProjectMember.class));
+    }
+
+    @Test
+    void updatesProjectWhenUserCanEdit() {
+        ProjectService projectService = projectService();
+        User owner = user(1L, "owner@example.com");
+        Project project = Project.create(owner, "Old", null, null);
+        ReflectionTestUtils.setField(project, "id", 10L);
+        when(projectPermissionService.validateEditable(10L, 1L))
+            .thenReturn(new ProjectMember(project, owner, ProjectRole.EDITOR));
+
+        ProjectResponse response = projectService.update(
+            1L,
+            10L,
+            new ProjectUpdateRequest("New", "Next", "A4_SCAN_300DPI")
+        );
+
+        assertThat(response.name()).isEqualTo("New");
+        assertThat(response.description()).isEqualTo("Next");
+        assertThat(response.defaultPreset()).isEqualTo("A4_SCAN_300DPI");
+        assertThat(response.myRole()).isEqualTo(ProjectRole.EDITOR);
+    }
+
+    private ProjectService projectService() {
+        return new ProjectService(projectRepository, projectMemberRepository, userRepository, projectPermissionService);
+    }
+
+    private User user(Long id, String email) {
+        User user = User.createUser(email, "User", null);
+        ReflectionTestUtils.setField(user, "id", id);
+        return user;
+    }
+}

--- a/docs/api/project-api.md
+++ b/docs/api/project-api.md
@@ -1,0 +1,126 @@
+# Project API
+
+## Purpose
+
+Project API manages the unit that groups uploaded document images and preprocessing jobs. Future image, upload, and job
+APIs should authorize access through project membership.
+
+## Roles
+
+| Role | Read | Update Project | Manage Members | Delete Project |
+| --- | --- | --- | --- | --- |
+| `OWNER` | Yes | Yes | Yes | Yes |
+| `EDITOR` | Yes | Yes | No | No |
+| `VIEWER` | Yes | No | No | No |
+
+## Endpoints
+
+All endpoints require `Authorization: Bearer <access-token>`.
+
+| Method | Path | Purpose |
+| --- | --- | --- |
+| `POST` | `/api/v1/projects` | Create a project |
+| `GET` | `/api/v1/projects` | List projects for the current user |
+| `GET` | `/api/v1/projects/{projectId}` | Read project detail |
+| `PATCH` | `/api/v1/projects/{projectId}` | Update project metadata |
+| `DELETE` | `/api/v1/projects/{projectId}` | Soft delete project |
+| `GET` | `/api/v1/projects/{projectId}/summary` | Read project summary |
+| `POST` | `/api/v1/projects/{projectId}/members` | Invite project member |
+| `GET` | `/api/v1/projects/{projectId}/members` | List project members |
+| `DELETE` | `/api/v1/projects/{projectId}/members/{userId}` | Remove project member |
+
+## Create Project
+
+Request:
+
+```json
+{
+  "name": "Library Scan Batch",
+  "description": "2026 first library document preprocessing batch",
+  "defaultPreset": "LOW_CONTRAST_SCAN"
+}
+```
+
+Response:
+
+```json
+{
+  "isSuccess": true,
+  "code": "common201",
+  "message": "Created.",
+  "result": {
+    "id": 1,
+    "name": "Library Scan Batch",
+    "description": "2026 first library document preprocessing batch",
+    "defaultPreset": "LOW_CONTRAST_SCAN",
+    "status": "ACTIVE",
+    "ownerId": 1,
+    "ownerEmail": "owner@example.com",
+    "myRole": "OWNER",
+    "createdAt": "2026-05-03T12:00:00",
+    "updatedAt": "2026-05-03T12:00:00"
+  }
+}
+```
+
+## List Projects
+
+Query parameters follow Spring pageable conventions:
+
+```text
+GET /api/v1/projects?page=0&size=20
+```
+
+The response result is `PageResponse<ProjectResponse>`.
+
+## Update Project
+
+`OWNER` and `EDITOR` can update project metadata.
+
+Request:
+
+```json
+{
+  "name": "Updated Batch",
+  "description": "Updated description",
+  "defaultPreset": "A4_SCAN_300DPI"
+}
+```
+
+## Delete Project
+
+Only `OWNER` can delete a project. Deletion is soft delete through `ProjectStatus.DELETED`.
+
+## Invite Member
+
+Only `OWNER` can invite members. `OWNER` cannot be invited through this API.
+
+Request:
+
+```json
+{
+  "userId": 2,
+  "role": "EDITOR"
+}
+```
+
+## Project Summary
+
+Response:
+
+```json
+{
+  "isSuccess": true,
+  "code": "common200",
+  "message": "Request succeeded.",
+  "result": {
+    "projectId": 1,
+    "name": "Library Scan Batch",
+    "memberCount": 2,
+    "imageCount": 0,
+    "jobCount": 0
+  }
+}
+```
+
+`imageCount` and `jobCount` are placeholders until Image and Job domains are implemented.

--- a/docs/feature-specs/issue-25-project-domain-api.md
+++ b/docs/feature-specs/issue-25-project-domain-api.md
@@ -1,0 +1,48 @@
+# Issue 25. Project Domain CRUD And Permission API
+
+## Issue
+
+- Issue: `#25`
+- Title: `Project domain CRUD and permission validation`
+
+## Goal
+
+Implement the Project domain as the authorization boundary for future image, upload, and job APIs. A project has one
+owner, multiple members, role-based permissions, soft deletion, and a summary endpoint.
+
+## Work Order
+
+1. Enable JPA auditing for `BaseEntity` timestamps.
+2. Add `Project`, `ProjectMember`, `ProjectRole`, and `ProjectStatus`.
+3. Add project repositories.
+4. Add project DTOs.
+5. Add project CRUD services.
+6. Add project member services.
+7. Add `ProjectPermissionService`.
+8. Add project and member controllers.
+9. Add Project API documentation.
+10. Add unit tests.
+
+## Functional Scope
+
+- `OWNER` can read, update, manage members, and soft delete.
+- `EDITOR` can read and update.
+- `VIEWER` can read only.
+- Project deletion uses `ProjectStatus.DELETED`.
+- Member removal deletes the membership row.
+- Project summary returns member count now and reserves image/job counts for later domains.
+
+## Out Of Scope
+
+- Project ownership transfer.
+- Email invitation.
+- Image and Job count integration.
+- Team invitation by email before account creation.
+- Audit logging.
+
+## Verification
+
+- Entity tests cover create/update/delete.
+- Permission tests cover editor/viewer/member missing cases.
+- Service tests cover create/update/invite/remove flows.
+- Backend `test` and `build` must pass.


### PR DESCRIPTION
## 기능 설명
Project 도메인 CRUD, 프로젝트 멤버 권한, summary API를 구현했습니다. 이후 Upload/Image/Job 권한 검증의 기준이 되는 프로젝트 membership 구조입니다.

Closes #25

## 작업 상세 내용
- `Project`, `ProjectMember`, `ProjectRole`, `ProjectStatus` entity를 추가했습니다.
- 프로젝트 생성/목록/상세/수정/soft delete/summary API를 추가했습니다.
- 프로젝트 멤버 초대/목록/제거 API를 추가했습니다.
- `ProjectPermissionService`로 `OWNER`, `EDITOR`, `VIEWER` 권한을 분리했습니다.
- `BaseEntity` timestamp 저장을 위해 JPA auditing을 활성화했습니다.
- `docs/api/project-api.md`, `docs/feature-specs/issue-25-project-domain-api.md`를 추가했습니다.

## 검증 내용
- `docker run --rm -v "${backendPath}:/workspace" -w /workspace gradle:8.10-jdk21 gradle test --no-daemon`: 통과
- `docker run --rm -v "${backendPath}:/workspace" -w /workspace gradle:8.10-jdk21 gradle build --no-daemon`: 통과
- backend jar Docker smoke boot 후 `GET /actuator/health`: `UP`
- Docker PostgreSQL 테이블 생성 확인: `projects`, `project_members`, `users`, `social_accounts`, `refresh_tokens`
- staged secret scan: 실제 Google OAuth secret 미포함 확인

## 리뷰어 확인 요청
- 멤버 초대는 현재 이미 가입된 `userId` 기준입니다. 이메일 초대/가입 전 초대는 별도 작업으로 남겼습니다.
- `imageCount`, `jobCount`는 Image/Job 도메인 구현 전까지 `0` placeholder로 반환합니다.