### PR TITLE
✨ [Feat] Swagger/OpenAPI 문서와 JWT Bearer 설정 추가

### DIFF
--- a/backend-api/build.gradle
+++ b/backend-api/build.gradle
@@ -27,6 +27,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.5'
 
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'org.postgresql:postgresql'
@@ -40,4 +41,8 @@ dependencies {
 
 tasks.named('test') {
     useJUnitPlatform()
+}
+
+tasks.withType(JavaCompile).configureEach {
+    options.compilerArgs += '-parameters'
 }

--- a/backend-api/src/main/java/com/moonju/preprocess/api/domain/auth/controller/AuthController.java
+++ b/backend-api/src/main/java/com/moonju/preprocess/api/domain/auth/controller/AuthController.java
@@ -7,6 +7,10 @@ import com.moonju.preprocess.api.domain.auth.service.AuthService;
 import com.moonju.preprocess.api.domain.auth.service.RefreshTokenCookieService;
 import com.moonju.preprocess.api.global.response.ApiResponse;
 import com.moonju.preprocess.api.global.support.CurrentUser;
+import com.moonju.preprocess.api.infra.openapi.OpenApiConfig;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.http.HttpHeaders;
@@ -17,6 +21,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/api/v1/auth")
+@Tag(name = "Auth", description = "Google OAuth login, current user, refresh token, and logout APIs")
 public class AuthController {
 
     private final AuthService authService;
@@ -28,11 +33,13 @@ public class AuthController {
     }
 
     @GetMapping("/me")
+    @Operation(summary = "Read current user", security = @SecurityRequirement(name = OpenApiConfig.BEARER_AUTH))
     public ApiResponse<AuthMeResponse> me(@CurrentUser Long currentUserId) {
         return ApiResponse.success(authService.me(currentUserId));
     }
 
     @PostMapping("/refresh")
+    @Operation(summary = "Refresh access token with HttpOnly refresh cookie")
     public ApiResponse<TokenRefreshResponse> refresh(HttpServletRequest request, HttpServletResponse response) {
         String refreshToken = refreshTokenCookieService.resolveRefreshToken(request);
         TokenRefreshResponse tokenResponse = authService.refresh(refreshToken);
@@ -44,6 +51,7 @@ public class AuthController {
     }
 
     @PostMapping("/logout")
+    @Operation(summary = "Logout and revoke refresh token")
     public ApiResponse<LogoutResponse> logout(HttpServletRequest request, HttpServletResponse response) {
         String refreshToken = refreshTokenCookieService.resolveRefreshToken(request);
         authService.logout(refreshToken);

--- a/backend-api/src/main/java/com/moonju/preprocess/api/domain/project/controller/ProjectController.java
+++ b/backend-api/src/main/java/com/moonju/preprocess/api/domain/project/controller/ProjectController.java
@@ -9,6 +9,10 @@ import com.moonju.preprocess.api.global.error.ErrorCode;
 import com.moonju.preprocess.api.global.response.ApiResponse;
 import com.moonju.preprocess.api.global.response.PageResponse;
 import com.moonju.preprocess.api.global.support.CurrentUser;
+import com.moonju.preprocess.api.infra.openapi.OpenApiConfig;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
@@ -23,6 +27,8 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/api/v1/projects")
+@Tag(name = "Projects", description = "Project CRUD, metadata, and summary APIs")
+@SecurityRequirement(name = OpenApiConfig.BEARER_AUTH)
 public class ProjectController {
 
     private final ProjectService projectService;
@@ -32,6 +38,7 @@ public class ProjectController {
     }
 
     @PostMapping
+    @Operation(summary = "Create project")
     public ApiResponse<ProjectResponse> create(
         @CurrentUser Long currentUserId,
         @Valid @RequestBody ProjectCreateRequest request
@@ -40,6 +47,7 @@ public class ProjectController {
     }
 
     @GetMapping
+    @Operation(summary = "List current user's projects")
     public ApiResponse<PageResponse<ProjectResponse>> findMyProjects(
         @CurrentUser Long currentUserId,
         @PageableDefault(size = 20) Pageable pageable
@@ -48,11 +56,13 @@ public class ProjectController {
     }
 
     @GetMapping("/{projectId}")
+    @Operation(summary = "Read project detail")
     public ApiResponse<ProjectResponse> findOne(@CurrentUser Long currentUserId, @PathVariable Long projectId) {
         return ApiResponse.success(projectService.findOne(currentUserId, projectId));
     }
 
     @PatchMapping("/{projectId}")
+    @Operation(summary = "Update project")
     public ApiResponse<ProjectResponse> update(
         @CurrentUser Long currentUserId,
         @PathVariable Long projectId,
@@ -62,12 +72,14 @@ public class ProjectController {
     }
 
     @DeleteMapping("/{projectId}")
+    @Operation(summary = "Soft delete project")
     public ApiResponse<Void> delete(@CurrentUser Long currentUserId, @PathVariable Long projectId) {
         projectService.delete(currentUserId, projectId);
         return ApiResponse.success(ErrorCode.COMMON_NO_CONTENT, null);
     }
 
     @GetMapping("/{projectId}/summary")
+    @Operation(summary = "Read project summary")
     public ApiResponse<ProjectSummaryResponse> summary(@CurrentUser Long currentUserId, @PathVariable Long projectId) {
         return ApiResponse.success(projectService.summary(currentUserId, projectId));
     }

--- a/backend-api/src/main/java/com/moonju/preprocess/api/domain/project/controller/ProjectMemberController.java
+++ b/backend-api/src/main/java/com/moonju/preprocess/api/domain/project/controller/ProjectMemberController.java
@@ -6,6 +6,10 @@ import com.moonju.preprocess.api.domain.project.service.ProjectMemberService;
 import com.moonju.preprocess.api.global.error.ErrorCode;
 import com.moonju.preprocess.api.global.response.ApiResponse;
 import com.moonju.preprocess.api.global.support.CurrentUser;
+import com.moonju.preprocess.api.infra.openapi.OpenApiConfig;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import java.util.List;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -18,6 +22,8 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/api/v1/projects/{projectId}/members")
+@Tag(name = "Project Members", description = "Project member invitation, listing, and removal APIs")
+@SecurityRequirement(name = OpenApiConfig.BEARER_AUTH)
 public class ProjectMemberController {
 
     private final ProjectMemberService projectMemberService;
@@ -27,6 +33,7 @@ public class ProjectMemberController {
     }
 
     @PostMapping
+    @Operation(summary = "Invite project member")
     public ApiResponse<ProjectMemberResponse> invite(
         @CurrentUser Long currentUserId,
         @PathVariable Long projectId,
@@ -40,6 +47,7 @@ public class ProjectMemberController {
     }
 
     @GetMapping
+    @Operation(summary = "List project members")
     public ApiResponse<List<ProjectMemberResponse>> findMembers(
         @CurrentUser Long currentUserId,
         @PathVariable Long projectId
@@ -48,6 +56,7 @@ public class ProjectMemberController {
     }
 
     @DeleteMapping("/{userId}")
+    @Operation(summary = "Remove project member")
     public ApiResponse<Void> remove(
         @CurrentUser Long currentUserId,
         @PathVariable Long projectId,

--- a/backend-api/src/main/java/com/moonju/preprocess/api/infra/openapi/OpenApiConfig.java
+++ b/backend-api/src/main/java/com/moonju/preprocess/api/infra/openapi/OpenApiConfig.java
@@ -1,0 +1,37 @@
+package com.moonju.preprocess.api.infra.openapi;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import io.swagger.v3.oas.models.servers.Server;
+import java.util.List;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class OpenApiConfig {
+
+    public static final String BEARER_AUTH = "bearerAuth";
+
+    @Bean
+    public OpenAPI openAPI() {
+        return new OpenAPI()
+            .info(new Info()
+                .title("Image Preprocess Platform API")
+                .version("v1")
+                .description("REST API for OAuth login, projects, uploads, jobs, and image preprocessing."))
+            .servers(List.of(new Server().url("http://localhost:8080").description("Local backend")))
+            .components(new Components().addSecuritySchemes(BEARER_AUTH, bearerSecurityScheme()))
+            .addSecurityItem(new SecurityRequirement().addList(BEARER_AUTH));
+    }
+
+    private SecurityScheme bearerSecurityScheme() {
+        return new SecurityScheme()
+            .type(SecurityScheme.Type.HTTP)
+            .scheme("bearer")
+            .bearerFormat("JWT")
+            .description("Paste only the JWT access token value. Do not include the Bearer prefix.");
+    }
+}

--- a/backend-api/src/main/java/com/moonju/preprocess/api/infra/security/SecurityConfig.java
+++ b/backend-api/src/main/java/com/moonju/preprocess/api/infra/security/SecurityConfig.java
@@ -9,6 +9,8 @@ import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
+import static org.springframework.security.web.util.matcher.AntPathRequestMatcher.antMatcher;
+
 @Configuration
 @EnableWebSecurity
 public class SecurityConfig {
@@ -31,16 +33,16 @@ public class SecurityConfig {
             .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
             .authorizeHttpRequests(authorize -> authorize
                 .requestMatchers(
-                    "/",
-                    "/error",
-                    "/actuator/health",
-                    "/actuator/info",
-                    "/oauth2/**",
-                    "/login/oauth2/**",
-                    "/api/v1/auth/refresh",
-                    "/api/v1/auth/logout",
-                    "/swagger-ui/**",
-                    "/v3/api-docs/**"
+                    antMatcher("/"),
+                    antMatcher("/error"),
+                    antMatcher("/actuator/health"),
+                    antMatcher("/actuator/info"),
+                    antMatcher("/oauth2/**"),
+                    antMatcher("/login/oauth2/**"),
+                    antMatcher("/api/v1/auth/refresh"),
+                    antMatcher("/api/v1/auth/logout"),
+                    antMatcher("/swagger-ui/**"),
+                    antMatcher("/v3/api-docs/**")
                 ).permitAll()
                 .anyRequest().authenticated()
             )

--- a/backend-api/src/main/resources/application.yml
+++ b/backend-api/src/main/resources/application.yml
@@ -40,6 +40,14 @@ app:
   cors:
     allowed-origins: ${CORS_ALLOWED_ORIGINS:http://localhost:5173}
 
+springdoc:
+  api-docs:
+    path: /v3/api-docs
+  swagger-ui:
+    path: /swagger-ui.html
+    operations-sorter: method
+    tags-sorter: alpha
+
 management:
   health:
     rabbit:

--- a/backend-api/src/test/java/com/moonju/preprocess/api/infra/openapi/OpenApiConfigTests.java
+++ b/backend-api/src/test/java/com/moonju/preprocess/api/infra/openapi/OpenApiConfigTests.java
@@ -1,0 +1,25 @@
+package com.moonju.preprocess.api.infra.openapi;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import org.junit.jupiter.api.Test;
+
+class OpenApiConfigTests {
+
+    @Test
+    void configuresJwtBearerSecurityScheme() {
+        OpenAPI openAPI = new OpenApiConfig().openAPI();
+
+        SecurityScheme securityScheme = openAPI.getComponents()
+            .getSecuritySchemes()
+            .get(OpenApiConfig.BEARER_AUTH);
+
+        assertThat(openAPI.getInfo().getTitle()).isEqualTo("Image Preprocess Platform API");
+        assertThat(securityScheme.getType()).isEqualTo(SecurityScheme.Type.HTTP);
+        assertThat(securityScheme.getScheme()).isEqualTo("bearer");
+        assertThat(securityScheme.getBearerFormat()).isEqualTo("JWT");
+        assertThat(openAPI.getSecurity()).hasSize(1);
+    }
+}

--- a/docs/api/swagger-openapi.md
+++ b/docs/api/swagger-openapi.md
@@ -17,10 +17,49 @@ OpenAPI JSON: http://localhost:8080/v3/api-docs
 The backend uses:
 
 ```gradle
+id 'org.springframework.boot' version '3.4.5'
 implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.5'
 ```
 
-Spring Boot is `3.4.5`, so the springdoc `2.8.x` line is used.
+Spring Boot stays on `3.4.5`. `springdoc-openapi` uses the `2.8.x` line because it is the Spring Boot 3 compatible
+line. The locally verified Swagger UI version is `2.8.5`.
+
+## Local Docker Test
+
+The local backend needs PostgreSQL. If the PostgreSQL container is already running, keep it running.
+
+```powershell
+docker ps
+```
+
+Start the backend from the repository root:
+
+```powershell
+$backendPath = Join-Path (Get-Location) 'backend-api'
+docker run --rm `
+  --name backend-swagger-test `
+  --env-file backend-api\.env `
+  -e DB_URL=jdbc:postgresql://host.docker.internal:5432/image_preprocess `
+  -e RABBIT_HEALTH_ENABLED=false `
+  -p 8080:8080 `
+  -v "${backendPath}:/workspace" `
+  -w /workspace `
+  gradle:8.10-jdk21 gradle bootRun --no-daemon
+```
+
+In another PowerShell window, verify the backend and Swagger endpoints:
+
+```powershell
+Invoke-RestMethod http://localhost:8080/actuator/health
+Invoke-RestMethod http://localhost:8080/v3/api-docs
+Invoke-WebRequest http://localhost:8080/swagger-ui/index.html
+```
+
+Expected result:
+
+- `/actuator/health` returns `status: UP`.
+- `/v3/api-docs` returns OpenAPI JSON with `bearerAuth`.
+- `/swagger-ui/index.html` returns HTTP `200`.
 
 ## JWT Bearer Test Flow
 

--- a/docs/api/swagger-openapi.md
+++ b/docs/api/swagger-openapi.md
@@ -1,0 +1,66 @@
+# Swagger And OpenAPI
+
+## Purpose
+
+Swagger UI is enabled for local API testing and OpenAPI schema inspection. It is not a replacement for automated tests,
+but it is the fastest way to manually verify Auth and Project endpoints while the frontend is still incomplete.
+
+## Local URLs
+
+```text
+Swagger UI: http://localhost:8080/swagger-ui/index.html
+OpenAPI JSON: http://localhost:8080/v3/api-docs
+```
+
+## Dependency
+
+The backend uses:
+
+```gradle
+implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.5'
+```
+
+Spring Boot is `3.4.5`, so the springdoc `2.8.x` line is used.
+
+## JWT Bearer Test Flow
+
+1. Start the backend.
+2. Open `http://localhost:8080/oauth2/authorization/google`.
+3. Complete Google login.
+4. Copy the `accessToken` query parameter from the OAuth success redirect URL.
+5. Open `http://localhost:8080/swagger-ui/index.html`.
+6. Click `Authorize`.
+7. Paste only the access token value.
+8. Run protected endpoints such as `GET /api/v1/auth/me` or `GET /api/v1/projects`.
+
+Do not paste the `Bearer ` prefix. Swagger applies the Bearer scheme automatically.
+
+## Public And Protected Endpoints
+
+Public endpoints:
+
+- `GET /swagger-ui/index.html`
+- `GET /v3/api-docs`
+- `GET /oauth2/authorization/google`
+- `GET /login/oauth2/code/google`
+- `POST /api/v1/auth/refresh`
+- `POST /api/v1/auth/logout`
+
+Protected endpoints:
+
+- `GET /api/v1/auth/me`
+- `POST /api/v1/projects`
+- `GET /api/v1/projects`
+- `GET /api/v1/projects/{projectId}`
+- `PATCH /api/v1/projects/{projectId}`
+- `DELETE /api/v1/projects/{projectId}`
+- `GET /api/v1/projects/{projectId}/summary`
+- Project member APIs
+
+## Notes
+
+- Refresh and logout use the HttpOnly refresh cookie, so they are easier to verify in a browser flow than with a raw
+  Swagger request.
+- `-parameters` is enabled in Gradle so Springdoc can infer method parameter names reliably on Spring Boot 3.4.
+- `springdoc.swagger-ui.path=/swagger-ui.html` is configured as the stable Swagger UI entry point. It also serves the
+  actual UI at `/swagger-ui/index.html`.

--- a/docs/feature-specs/issue-27-swagger-openapi.md
+++ b/docs/feature-specs/issue-27-swagger-openapi.md
@@ -1,0 +1,43 @@
+# Issue 27. Swagger OpenAPI And JWT Bearer
+
+## Issue
+
+- Issue: `#27`
+- Title: `Swagger/OpenAPI documentation and JWT Bearer configuration`
+
+## Goal
+
+Enable local Swagger UI so Auth and Project APIs can be manually tested before the frontend is complete.
+
+## Work Order
+
+1. Add `springdoc-openapi-starter-webmvc-ui`.
+2. Add OpenAPI metadata and local server config.
+3. Add JWT Bearer security scheme.
+4. Add Swagger UI and API docs paths.
+5. Tag Auth and Project controllers.
+6. Add OpenAPI configuration test.
+7. Add Swagger usage documentation.
+8. Verify test, build, `/v3/api-docs`, and Swagger UI.
+
+## Functional Scope
+
+- Swagger UI is available at `/swagger-ui/index.html`.
+- OpenAPI JSON is available at `/v3/api-docs`.
+- Swagger UI exposes JWT Bearer authorization.
+- Auth and Project APIs are grouped with tags.
+
+## Out Of Scope
+
+- Full operation-level success/failure examples for every endpoint.
+- Generated client SDK.
+- Swagger behind NGINX.
+- Production auth policy for Swagger.
+
+## Verification
+
+- Backend tests pass.
+- Backend build passes.
+- Local Docker boot returns `UP` from `/actuator/health`.
+- `/v3/api-docs` returns OpenAPI JSON with `bearerAuth`.
+- Swagger UI HTML is reachable.


### PR DESCRIPTION
## 기능 설명
Swagger UI와 OpenAPI JSON을 추가해서 프론트 완성 전에도 Auth/Project API를 직접 테스트할 수 있게 했습니다.

Closes #27

## 작업 상세 내용
- `springdoc-openapi-starter-webmvc-ui`를 추가했습니다.
- OpenAPI metadata, local server, JWT Bearer security scheme을 `infra.openapi`에 추가했습니다.
- Auth/Project/Project Member controller에 Swagger tag와 operation summary를 추가했습니다.
- Swagger/OpenAPI endpoint를 security permit 경로에 추가했습니다.
- Springdoc parameter name 추론을 위해 Gradle `-parameters` 옵션을 추가했습니다.
- Swagger 사용 방법과 issue 작업 명세를 `docs/`에 추가했습니다.

## 변경 파일 요약
- `backend-api/build.gradle`
- `backend-api/src/main/java/com/moonju/preprocess/api/infra/openapi/OpenApiConfig.java`
- `backend-api/src/main/java/com/moonju/preprocess/api/infra/security/SecurityConfig.java`
- `backend-api/src/main/java/com/moonju/preprocess/api/domain/auth/controller/AuthController.java`
- `backend-api/src/main/java/com/moonju/preprocess/api/domain/project/controller/ProjectController.java`
- `backend-api/src/main/java/com/moonju/preprocess/api/domain/project/controller/ProjectMemberController.java`
- `docs/api/swagger-openapi.md`
- `docs/feature-specs/issue-27-swagger-openapi.md`

## 검증 내용
- `docker run --rm -v "${backendPath}:/workspace" -w /workspace gradle:8.10-jdk21 gradle test --no-daemon`: 통과
- `docker run --rm -v "${backendPath}:/workspace" -w /workspace gradle:8.10-jdk21 gradle build --no-daemon`: 통과
- Docker smoke boot 후 `GET /actuator/health`: `UP`
- Docker smoke `GET /v3/api-docs`: OpenAPI 3.1.0 JSON 반환, `bearerAuth` 포함 확인
- Docker smoke `GET /swagger-ui/index.html`: 200
- Docker smoke `GET /swagger-ui.html`: 200
- `git diff --cached --check`: 통과
- staged secret scan: 실제 Google OAuth secret 미포함 확인

## 리뷰어 확인 요청
- 이 PR은 #26 Project API PR 위에 쌓여 있어서 base가 `feat/som/25`입니다. #26이 main에 머지되면 이 PR base를 `main`으로 retarget하면 됩니다.
- `springdoc 2.8.17`은 Spring Boot 3.4.5에서 Swagger UI resource pattern 충돌로 부팅 실패가 발생해, smoke 검증이 통과한 `2.8.5`를 사용했습니다.
- Swagger 인증창에는 `Bearer ` prefix 없이 access token 값만 붙여 넣으면 됩니다.