### PR TITLE
✨ [Feat] Image 도메인 업로드 완료 연동 구현

### DIFF
--- a/backend-api/src/main/java/com/moonju/preprocess/api/domain/image/controller/ImageController.java
+++ b/backend-api/src/main/java/com/moonju/preprocess/api/domain/image/controller/ImageController.java
@@ -1,0 +1,93 @@
+package com.moonju.preprocess.api.domain.image.controller;
+
+import com.moonju.preprocess.api.domain.image.dto.DebugArtifactResponse;
+import com.moonju.preprocess.api.domain.image.dto.ImageDownloadUrlResponse;
+import com.moonju.preprocess.api.domain.image.dto.ImageListResponse;
+import com.moonju.preprocess.api.domain.image.dto.ImageReportResponse;
+import com.moonju.preprocess.api.domain.image.dto.ImageResponse;
+import com.moonju.preprocess.api.domain.image.service.ImageArtifactService;
+import com.moonju.preprocess.api.domain.image.service.ImageDownloadService;
+import com.moonju.preprocess.api.domain.image.service.ImageService;
+import com.moonju.preprocess.api.global.error.ErrorCode;
+import com.moonju.preprocess.api.global.response.ApiResponse;
+import com.moonju.preprocess.api.global.response.PageResponse;
+import com.moonju.preprocess.api.global.support.CurrentUser;
+import java.util.List;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1")
+public class ImageController {
+
+    private final ImageService imageService;
+    private final ImageDownloadService imageDownloadService;
+    private final ImageArtifactService imageArtifactService;
+
+    public ImageController(
+        ImageService imageService,
+        ImageDownloadService imageDownloadService,
+        ImageArtifactService imageArtifactService
+    ) {
+        this.imageService = imageService;
+        this.imageDownloadService = imageDownloadService;
+        this.imageArtifactService = imageArtifactService;
+    }
+
+    @GetMapping("/projects/{projectId}/images")
+    public ApiResponse<PageResponse<ImageListResponse>> findProjectImages(
+        @CurrentUser Long currentUserId,
+        @PathVariable Long projectId,
+        @PageableDefault(size = 20) Pageable pageable
+    ) {
+        return ApiResponse.success(imageService.findProjectImages(currentUserId, projectId, pageable));
+    }
+
+    @GetMapping("/images/{imageId}")
+    public ApiResponse<ImageResponse> findOne(
+        @CurrentUser Long currentUserId,
+        @PathVariable Long imageId
+    ) {
+        return ApiResponse.success(imageService.findOne(currentUserId, imageId));
+    }
+
+    @DeleteMapping("/images/{imageId}")
+    public ApiResponse<Void> delete(
+        @CurrentUser Long currentUserId,
+        @PathVariable Long imageId
+    ) {
+        imageService.delete(currentUserId, imageId);
+        return ApiResponse.success(ErrorCode.COMMON_NO_CONTENT, null);
+    }
+
+    @GetMapping("/images/{imageId}/download")
+    public ApiResponse<ImageDownloadUrlResponse> createDownloadUrl(
+        @CurrentUser Long currentUserId,
+        @PathVariable Long imageId,
+        @RequestParam(defaultValue = "original") String type
+    ) {
+        return ApiResponse.success(imageDownloadService.createDownloadUrl(currentUserId, imageId, type));
+    }
+
+    @GetMapping("/images/{imageId}/report")
+    public ApiResponse<ImageReportResponse> findReport(
+        @CurrentUser Long currentUserId,
+        @PathVariable Long imageId
+    ) {
+        return ApiResponse.success(imageArtifactService.findReport(currentUserId, imageId));
+    }
+
+    @GetMapping("/images/{imageId}/debug-artifacts")
+    public ApiResponse<List<DebugArtifactResponse>> findDebugArtifacts(
+        @CurrentUser Long currentUserId,
+        @PathVariable Long imageId
+    ) {
+        return ApiResponse.success(imageArtifactService.findDebugArtifacts(currentUserId, imageId));
+    }
+}

--- a/backend-api/src/main/java/com/moonju/preprocess/api/domain/image/dto/DebugArtifactResponse.java
+++ b/backend-api/src/main/java/com/moonju/preprocess/api/domain/image/dto/DebugArtifactResponse.java
@@ -1,0 +1,27 @@
+package com.moonju.preprocess.api.domain.image.dto;
+
+import com.moonju.preprocess.api.domain.image.entity.ImageArtifact;
+import com.moonju.preprocess.api.infra.storage.PresignedDownloadTarget;
+import java.time.Instant;
+import java.util.Map;
+
+public record DebugArtifactResponse(
+    Long artifactId,
+    String debugStep,
+    String objectKey,
+    String downloadUrl,
+    Instant expiresAt,
+    Map<String, String> requiredHeaders
+) {
+
+    public static DebugArtifactResponse of(ImageArtifact artifact, PresignedDownloadTarget target) {
+        return new DebugArtifactResponse(
+            artifact.getId(),
+            artifact.getDebugStep(),
+            target.objectKey(),
+            target.downloadUrl(),
+            target.expiresAt(),
+            target.requiredHeaders()
+        );
+    }
+}

--- a/backend-api/src/main/java/com/moonju/preprocess/api/domain/image/dto/ImageDownloadUrlResponse.java
+++ b/backend-api/src/main/java/com/moonju/preprocess/api/domain/image/dto/ImageDownloadUrlResponse.java
@@ -1,0 +1,31 @@
+package com.moonju.preprocess.api.domain.image.dto;
+
+import com.moonju.preprocess.api.domain.image.entity.ImageDownloadType;
+import com.moonju.preprocess.api.infra.storage.PresignedDownloadTarget;
+import java.time.Instant;
+import java.util.Map;
+
+public record ImageDownloadUrlResponse(
+    Long imageId,
+    ImageDownloadType type,
+    String objectKey,
+    String downloadUrl,
+    Instant expiresAt,
+    Map<String, String> requiredHeaders
+) {
+
+    public static ImageDownloadUrlResponse of(
+        Long imageId,
+        ImageDownloadType type,
+        PresignedDownloadTarget target
+    ) {
+        return new ImageDownloadUrlResponse(
+            imageId,
+            type,
+            target.objectKey(),
+            target.downloadUrl(),
+            target.expiresAt(),
+            target.requiredHeaders()
+        );
+    }
+}

--- a/backend-api/src/main/java/com/moonju/preprocess/api/domain/image/dto/ImageListResponse.java
+++ b/backend-api/src/main/java/com/moonju/preprocess/api/domain/image/dto/ImageListResponse.java
@@ -1,0 +1,31 @@
+package com.moonju.preprocess.api.domain.image.dto;
+
+import com.moonju.preprocess.api.domain.image.entity.Image;
+import com.moonju.preprocess.api.domain.image.entity.ImageFormat;
+import com.moonju.preprocess.api.domain.image.entity.ImageStatus;
+import java.time.LocalDateTime;
+
+public record ImageListResponse(
+    Long id,
+    Long projectId,
+    String originalFileName,
+    String contentType,
+    long sizeBytes,
+    ImageFormat format,
+    ImageStatus status,
+    LocalDateTime createdAt
+) {
+
+    public static ImageListResponse from(Image image) {
+        return new ImageListResponse(
+            image.getId(),
+            image.getProjectId(),
+            image.getOriginalFileName(),
+            image.getContentType(),
+            image.getSizeBytes(),
+            image.getFormat(),
+            image.getStatus(),
+            image.getCreatedAt()
+        );
+    }
+}

--- a/backend-api/src/main/java/com/moonju/preprocess/api/domain/image/dto/ImageReportResponse.java
+++ b/backend-api/src/main/java/com/moonju/preprocess/api/domain/image/dto/ImageReportResponse.java
@@ -1,0 +1,26 @@
+package com.moonju.preprocess.api.domain.image.dto;
+
+import com.moonju.preprocess.api.infra.storage.PresignedDownloadTarget;
+import java.time.Instant;
+import java.util.Map;
+
+public record ImageReportResponse(
+    Long imageId,
+    Long artifactId,
+    String objectKey,
+    String downloadUrl,
+    Instant expiresAt,
+    Map<String, String> requiredHeaders
+) {
+
+    public static ImageReportResponse of(Long imageId, Long artifactId, PresignedDownloadTarget target) {
+        return new ImageReportResponse(
+            imageId,
+            artifactId,
+            target.objectKey(),
+            target.downloadUrl(),
+            target.expiresAt(),
+            target.requiredHeaders()
+        );
+    }
+}

--- a/backend-api/src/main/java/com/moonju/preprocess/api/domain/image/dto/ImageResponse.java
+++ b/backend-api/src/main/java/com/moonju/preprocess/api/domain/image/dto/ImageResponse.java
@@ -1,0 +1,49 @@
+package com.moonju.preprocess.api.domain.image.dto;
+
+import com.moonju.preprocess.api.domain.image.entity.Image;
+import com.moonju.preprocess.api.domain.image.entity.ImageFormat;
+import com.moonju.preprocess.api.domain.image.entity.ImageStatus;
+import java.time.LocalDateTime;
+
+public record ImageResponse(
+    Long id,
+    Long projectId,
+    Long uploadSessionId,
+    Long uploadSessionFileId,
+    Long uploaderId,
+    String originalFileName,
+    String originalObjectKey,
+    String contentType,
+    long sizeBytes,
+    String checksumSha256,
+    ImageFormat format,
+    ImageStatus status,
+    Integer width,
+    Integer height,
+    Integer dpiX,
+    Integer dpiY,
+    LocalDateTime createdAt
+) {
+
+    public static ImageResponse from(Image image) {
+        return new ImageResponse(
+            image.getId(),
+            image.getProjectId(),
+            image.getUploadSessionId(),
+            image.getUploadSessionFileId(),
+            image.getUploaderId(),
+            image.getOriginalFileName(),
+            image.getOriginalObjectKey(),
+            image.getContentType(),
+            image.getSizeBytes(),
+            image.getChecksumSha256(),
+            image.getFormat(),
+            image.getStatus(),
+            image.getWidth(),
+            image.getHeight(),
+            image.getDpiX(),
+            image.getDpiY(),
+            image.getCreatedAt()
+        );
+    }
+}

--- a/backend-api/src/main/java/com/moonju/preprocess/api/domain/image/entity/Image.java
+++ b/backend-api/src/main/java/com/moonju/preprocess/api/domain/image/entity/Image.java
@@ -1,0 +1,190 @@
+package com.moonju.preprocess.api.domain.image.entity;
+
+import com.moonju.preprocess.api.domain.upload.entity.UploadSession;
+import com.moonju.preprocess.api.domain.upload.entity.UploadSessionFile;
+import com.moonju.preprocess.api.global.support.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "images")
+public class Image extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private Long projectId;
+
+    @Column(nullable = false)
+    private Long uploadSessionId;
+
+    @Column(nullable = false, unique = true)
+    private Long uploadSessionFileId;
+
+    @Column(nullable = false)
+    private Long uploaderId;
+
+    @Column(nullable = false, length = 255)
+    private String originalFileName;
+
+    @Column(nullable = false, length = 1000)
+    private String originalObjectKey;
+
+    @Column(nullable = false, length = 100)
+    private String contentType;
+
+    @Column(nullable = false)
+    private long sizeBytes;
+
+    @Column(nullable = false, length = 64)
+    private String checksumSha256;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private ImageFormat format;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 30)
+    private ImageStatus status;
+
+    private Integer width;
+
+    private Integer height;
+
+    private Integer dpiX;
+
+    private Integer dpiY;
+
+    private LocalDateTime deletedAt;
+
+    protected Image() {
+    }
+
+    public Image(
+        Long projectId,
+        Long uploadSessionId,
+        Long uploadSessionFileId,
+        Long uploaderId,
+        String originalFileName,
+        String originalObjectKey,
+        String contentType,
+        long sizeBytes,
+        String checksumSha256,
+        ImageFormat format,
+        ImageStatus status
+    ) {
+        this.projectId = projectId;
+        this.uploadSessionId = uploadSessionId;
+        this.uploadSessionFileId = uploadSessionFileId;
+        this.uploaderId = uploaderId;
+        this.originalFileName = originalFileName;
+        this.originalObjectKey = originalObjectKey;
+        this.contentType = contentType;
+        this.sizeBytes = sizeBytes;
+        this.checksumSha256 = checksumSha256;
+        this.format = format;
+        this.status = status;
+    }
+
+    public static Image fromUpload(UploadSession uploadSession, UploadSessionFile file) {
+        return new Image(
+            uploadSession.getProjectId(),
+            uploadSession.getId(),
+            file.getId(),
+            uploadSession.getUserId(),
+            file.getOriginalFileName(),
+            file.getObjectKey(),
+            file.getContentType(),
+            file.getSizeBytes(),
+            file.getChecksumSha256(),
+            ImageFormat.fromFileName(file.getOriginalFileName()),
+            ImageStatus.UPLOADED
+        );
+    }
+
+    public void delete() {
+        status = ImageStatus.DELETED;
+        deletedAt = LocalDateTime.now();
+    }
+
+    public boolean isDeleted() {
+        return status == ImageStatus.DELETED;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public Long getProjectId() {
+        return projectId;
+    }
+
+    public Long getUploadSessionId() {
+        return uploadSessionId;
+    }
+
+    public Long getUploadSessionFileId() {
+        return uploadSessionFileId;
+    }
+
+    public Long getUploaderId() {
+        return uploaderId;
+    }
+
+    public String getOriginalFileName() {
+        return originalFileName;
+    }
+
+    public String getOriginalObjectKey() {
+        return originalObjectKey;
+    }
+
+    public String getContentType() {
+        return contentType;
+    }
+
+    public long getSizeBytes() {
+        return sizeBytes;
+    }
+
+    public String getChecksumSha256() {
+        return checksumSha256;
+    }
+
+    public ImageFormat getFormat() {
+        return format;
+    }
+
+    public ImageStatus getStatus() {
+        return status;
+    }
+
+    public Integer getWidth() {
+        return width;
+    }
+
+    public Integer getHeight() {
+        return height;
+    }
+
+    public Integer getDpiX() {
+        return dpiX;
+    }
+
+    public Integer getDpiY() {
+        return dpiY;
+    }
+
+    public LocalDateTime getDeletedAt() {
+        return deletedAt;
+    }
+}

--- a/backend-api/src/main/java/com/moonju/preprocess/api/domain/image/entity/ImageArtifact.java
+++ b/backend-api/src/main/java/com/moonju/preprocess/api/domain/image/entity/ImageArtifact.java
@@ -1,0 +1,114 @@
+package com.moonju.preprocess.api.domain.image.entity;
+
+import com.moonju.preprocess.api.global.support.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+@Entity
+@Table(name = "image_artifacts")
+public class ImageArtifact extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private Long imageId;
+
+    private Long jobId;
+
+    private Long jobItemId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 30)
+    private ImageArtifactType type;
+
+    @Column(nullable = false, length = 1000)
+    private String objectKey;
+
+    @Column(nullable = false, length = 100)
+    private String contentType;
+
+    private Long sizeBytes;
+
+    @Column(length = 100)
+    private String debugStep;
+
+    protected ImageArtifact() {
+    }
+
+    public ImageArtifact(
+        Long imageId,
+        Long jobId,
+        Long jobItemId,
+        ImageArtifactType type,
+        String objectKey,
+        String contentType,
+        Long sizeBytes,
+        String debugStep
+    ) {
+        this.imageId = imageId;
+        this.jobId = jobId;
+        this.jobItemId = jobItemId;
+        this.type = type;
+        this.objectKey = objectKey;
+        this.contentType = contentType;
+        this.sizeBytes = sizeBytes;
+        this.debugStep = debugStep;
+    }
+
+    public static ImageArtifact original(Image image) {
+        return new ImageArtifact(
+            image.getId(),
+            null,
+            null,
+            ImageArtifactType.ORIGINAL,
+            image.getOriginalObjectKey(),
+            image.getContentType(),
+            image.getSizeBytes(),
+            null
+        );
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public Long getImageId() {
+        return imageId;
+    }
+
+    public Long getJobId() {
+        return jobId;
+    }
+
+    public Long getJobItemId() {
+        return jobItemId;
+    }
+
+    public ImageArtifactType getType() {
+        return type;
+    }
+
+    public String getObjectKey() {
+        return objectKey;
+    }
+
+    public String getContentType() {
+        return contentType;
+    }
+
+    public Long getSizeBytes() {
+        return sizeBytes;
+    }
+
+    public String getDebugStep() {
+        return debugStep;
+    }
+}

--- a/backend-api/src/main/java/com/moonju/preprocess/api/domain/image/entity/ImageArtifactType.java
+++ b/backend-api/src/main/java/com/moonju/preprocess/api/domain/image/entity/ImageArtifactType.java
@@ -1,0 +1,9 @@
+package com.moonju.preprocess.api.domain.image.entity;
+
+public enum ImageArtifactType {
+    ORIGINAL,
+    PROCESSED,
+    PREVIEW,
+    PROCESSING_REPORT,
+    DEBUG
+}

--- a/backend-api/src/main/java/com/moonju/preprocess/api/domain/image/entity/ImageDownloadType.java
+++ b/backend-api/src/main/java/com/moonju/preprocess/api/domain/image/entity/ImageDownloadType.java
@@ -1,0 +1,27 @@
+package com.moonju.preprocess.api.domain.image.entity;
+
+import java.util.Locale;
+
+public enum ImageDownloadType {
+    ORIGINAL(ImageArtifactType.ORIGINAL),
+    PROCESSED(ImageArtifactType.PROCESSED),
+    PREVIEW(ImageArtifactType.PREVIEW);
+
+    private final ImageArtifactType artifactType;
+
+    ImageDownloadType(ImageArtifactType artifactType) {
+        this.artifactType = artifactType;
+    }
+
+    public static ImageDownloadType from(String value) {
+        try {
+            return ImageDownloadType.valueOf(value.toUpperCase(Locale.ROOT));
+        } catch (IllegalArgumentException | NullPointerException exception) {
+            throw new IllegalArgumentException("Unsupported image download type.");
+        }
+    }
+
+    public ImageArtifactType getArtifactType() {
+        return artifactType;
+    }
+}

--- a/backend-api/src/main/java/com/moonju/preprocess/api/domain/image/entity/ImageFormat.java
+++ b/backend-api/src/main/java/com/moonju/preprocess/api/domain/image/entity/ImageFormat.java
@@ -1,0 +1,31 @@
+package com.moonju.preprocess.api.domain.image.entity;
+
+import java.util.Locale;
+
+public enum ImageFormat {
+    PNG,
+    JPG,
+    JPEG,
+    TIF,
+    TIFF,
+    BMP,
+    WEBP;
+
+    public static ImageFormat fromFileName(String fileName) {
+        String normalized = fileName.toLowerCase(Locale.ROOT);
+        int lastDot = normalized.lastIndexOf('.');
+        if (lastDot < 0 || lastDot == normalized.length() - 1) {
+            throw new IllegalArgumentException("Image file extension is required.");
+        }
+        return switch (normalized.substring(lastDot + 1)) {
+            case "png" -> PNG;
+            case "jpg" -> JPG;
+            case "jpeg" -> JPEG;
+            case "tif" -> TIF;
+            case "tiff" -> TIFF;
+            case "bmp" -> BMP;
+            case "webp" -> WEBP;
+            default -> throw new IllegalArgumentException("Unsupported image file extension.");
+        };
+    }
+}

--- a/backend-api/src/main/java/com/moonju/preprocess/api/domain/image/entity/ImageStatus.java
+++ b/backend-api/src/main/java/com/moonju/preprocess/api/domain/image/entity/ImageStatus.java
@@ -1,0 +1,9 @@
+package com.moonju.preprocess.api.domain.image.entity;
+
+public enum ImageStatus {
+    UPLOADED,
+    PROCESSING,
+    PROCESSED,
+    FAILED,
+    DELETED
+}

--- a/backend-api/src/main/java/com/moonju/preprocess/api/domain/image/exception/ImageArtifactNotFoundException.java
+++ b/backend-api/src/main/java/com/moonju/preprocess/api/domain/image/exception/ImageArtifactNotFoundException.java
@@ -1,0 +1,11 @@
+package com.moonju.preprocess.api.domain.image.exception;
+
+import com.moonju.preprocess.api.global.error.BusinessException;
+import com.moonju.preprocess.api.global.error.ErrorCode;
+
+public class ImageArtifactNotFoundException extends BusinessException {
+
+    public ImageArtifactNotFoundException(String message) {
+        super(ErrorCode.COMMON_NOT_FOUND, message);
+    }
+}

--- a/backend-api/src/main/java/com/moonju/preprocess/api/domain/image/exception/ImageNotFoundException.java
+++ b/backend-api/src/main/java/com/moonju/preprocess/api/domain/image/exception/ImageNotFoundException.java
@@ -1,0 +1,11 @@
+package com.moonju.preprocess.api.domain.image.exception;
+
+import com.moonju.preprocess.api.global.error.BusinessException;
+import com.moonju.preprocess.api.global.error.ErrorCode;
+
+public class ImageNotFoundException extends BusinessException {
+
+    public ImageNotFoundException() {
+        super(ErrorCode.COMMON_NOT_FOUND, "Image not found.");
+    }
+}

--- a/backend-api/src/main/java/com/moonju/preprocess/api/domain/image/exception/UnsupportedImageDownloadTypeException.java
+++ b/backend-api/src/main/java/com/moonju/preprocess/api/domain/image/exception/UnsupportedImageDownloadTypeException.java
@@ -1,0 +1,11 @@
+package com.moonju.preprocess.api.domain.image.exception;
+
+import com.moonju.preprocess.api.global.error.BusinessException;
+import com.moonju.preprocess.api.global.error.ErrorCode;
+
+public class UnsupportedImageDownloadTypeException extends BusinessException {
+
+    public UnsupportedImageDownloadTypeException() {
+        super(ErrorCode.VALIDATION_ERROR, "Unsupported image download type.");
+    }
+}

--- a/backend-api/src/main/java/com/moonju/preprocess/api/domain/image/repository/ImageArtifactRepository.java
+++ b/backend-api/src/main/java/com/moonju/preprocess/api/domain/image/repository/ImageArtifactRepository.java
@@ -1,0 +1,14 @@
+package com.moonju.preprocess.api.domain.image.repository;
+
+import com.moonju.preprocess.api.domain.image.entity.ImageArtifact;
+import com.moonju.preprocess.api.domain.image.entity.ImageArtifactType;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ImageArtifactRepository extends JpaRepository<ImageArtifact, Long> {
+
+    Optional<ImageArtifact> findFirstByImageIdAndTypeOrderByIdDesc(Long imageId, ImageArtifactType type);
+
+    List<ImageArtifact> findAllByImageIdAndTypeOrderByIdAsc(Long imageId, ImageArtifactType type);
+}

--- a/backend-api/src/main/java/com/moonju/preprocess/api/domain/image/repository/ImageRepository.java
+++ b/backend-api/src/main/java/com/moonju/preprocess/api/domain/image/repository/ImageRepository.java
@@ -1,0 +1,19 @@
+package com.moonju.preprocess.api.domain.image.repository;
+
+import com.moonju.preprocess.api.domain.image.entity.Image;
+import com.moonju.preprocess.api.domain.image.entity.ImageStatus;
+import java.util.Optional;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ImageRepository extends JpaRepository<Image, Long> {
+
+    boolean existsByUploadSessionFileId(Long uploadSessionFileId);
+
+    long countByProjectIdAndStatusNot(Long projectId, ImageStatus status);
+
+    Optional<Image> findByIdAndStatusNot(Long id, ImageStatus status);
+
+    Page<Image> findAllByProjectIdAndStatusNot(Long projectId, ImageStatus status, Pageable pageable);
+}

--- a/backend-api/src/main/java/com/moonju/preprocess/api/domain/image/service/ImageArtifactService.java
+++ b/backend-api/src/main/java/com/moonju/preprocess/api/domain/image/service/ImageArtifactService.java
@@ -1,0 +1,71 @@
+package com.moonju.preprocess.api.domain.image.service;
+
+import com.moonju.preprocess.api.domain.image.dto.DebugArtifactResponse;
+import com.moonju.preprocess.api.domain.image.dto.ImageReportResponse;
+import com.moonju.preprocess.api.domain.image.entity.Image;
+import com.moonju.preprocess.api.domain.image.entity.ImageArtifact;
+import com.moonju.preprocess.api.domain.image.entity.ImageArtifactType;
+import com.moonju.preprocess.api.domain.image.exception.ImageArtifactNotFoundException;
+import com.moonju.preprocess.api.domain.image.repository.ImageArtifactRepository;
+import com.moonju.preprocess.api.domain.project.service.ProjectPermissionService;
+import com.moonju.preprocess.api.infra.storage.PresignedDownloadCommand;
+import com.moonju.preprocess.api.infra.storage.PresignedDownloadTarget;
+import com.moonju.preprocess.api.infra.storage.PresignedDownloadUrlGenerator;
+import java.time.Duration;
+import java.util.List;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class ImageArtifactService {
+
+    private static final Duration ARTIFACT_URL_EXPIRES_IN = Duration.ofMinutes(10);
+
+    private final ImageService imageService;
+    private final ImageArtifactRepository imageArtifactRepository;
+    private final ProjectPermissionService projectPermissionService;
+    private final PresignedDownloadUrlGenerator presignedDownloadUrlGenerator;
+
+    public ImageArtifactService(
+        ImageService imageService,
+        ImageArtifactRepository imageArtifactRepository,
+        ProjectPermissionService projectPermissionService,
+        PresignedDownloadUrlGenerator presignedDownloadUrlGenerator
+    ) {
+        this.imageService = imageService;
+        this.imageArtifactRepository = imageArtifactRepository;
+        this.projectPermissionService = projectPermissionService;
+        this.presignedDownloadUrlGenerator = presignedDownloadUrlGenerator;
+    }
+
+    @Transactional(readOnly = true)
+    public ImageReportResponse findReport(Long currentUserId, Long imageId) {
+        Image image = findReadableImage(currentUserId, imageId);
+        ImageArtifact artifact = imageArtifactRepository
+            .findFirstByImageIdAndTypeOrderByIdDesc(imageId, ImageArtifactType.PROCESSING_REPORT)
+            .orElseThrow(() -> new ImageArtifactNotFoundException("Processing report not found."));
+        PresignedDownloadTarget target = createDownloadTarget(artifact);
+        return ImageReportResponse.of(image.getId(), artifact.getId(), target);
+    }
+
+    @Transactional(readOnly = true)
+    public List<DebugArtifactResponse> findDebugArtifacts(Long currentUserId, Long imageId) {
+        findReadableImage(currentUserId, imageId);
+        return imageArtifactRepository.findAllByImageIdAndTypeOrderByIdAsc(imageId, ImageArtifactType.DEBUG)
+            .stream()
+            .map(artifact -> DebugArtifactResponse.of(artifact, createDownloadTarget(artifact)))
+            .toList();
+    }
+
+    private Image findReadableImage(Long currentUserId, Long imageId) {
+        Image image = imageService.findActiveImage(imageId);
+        projectPermissionService.validateReadable(image.getProjectId(), currentUserId);
+        return image;
+    }
+
+    private PresignedDownloadTarget createDownloadTarget(ImageArtifact artifact) {
+        return presignedDownloadUrlGenerator.generateDownloadUrl(
+            new PresignedDownloadCommand(artifact.getObjectKey(), ARTIFACT_URL_EXPIRES_IN)
+        );
+    }
+}

--- a/backend-api/src/main/java/com/moonju/preprocess/api/domain/image/service/ImageCreateService.java
+++ b/backend-api/src/main/java/com/moonju/preprocess/api/domain/image/service/ImageCreateService.java
@@ -1,0 +1,41 @@
+package com.moonju.preprocess.api.domain.image.service;
+
+import com.moonju.preprocess.api.domain.image.entity.Image;
+import com.moonju.preprocess.api.domain.image.entity.ImageArtifact;
+import com.moonju.preprocess.api.domain.image.repository.ImageArtifactRepository;
+import com.moonju.preprocess.api.domain.image.repository.ImageRepository;
+import com.moonju.preprocess.api.domain.upload.entity.UploadSession;
+import com.moonju.preprocess.api.domain.upload.entity.UploadSessionFile;
+import java.util.ArrayList;
+import java.util.List;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class ImageCreateService {
+
+    private final ImageRepository imageRepository;
+    private final ImageArtifactRepository imageArtifactRepository;
+
+    public ImageCreateService(
+        ImageRepository imageRepository,
+        ImageArtifactRepository imageArtifactRepository
+    ) {
+        this.imageRepository = imageRepository;
+        this.imageArtifactRepository = imageArtifactRepository;
+    }
+
+    @Transactional
+    public List<Image> createFromCompletedUpload(UploadSession uploadSession, List<UploadSessionFile> files) {
+        List<Image> createdImages = new ArrayList<>();
+        for (UploadSessionFile file : files) {
+            if (imageRepository.existsByUploadSessionFileId(file.getId())) {
+                continue;
+            }
+            Image image = imageRepository.save(Image.fromUpload(uploadSession, file));
+            imageArtifactRepository.save(ImageArtifact.original(image));
+            createdImages.add(image);
+        }
+        return createdImages;
+    }
+}

--- a/backend-api/src/main/java/com/moonju/preprocess/api/domain/image/service/ImageDownloadService.java
+++ b/backend-api/src/main/java/com/moonju/preprocess/api/domain/image/service/ImageDownloadService.java
@@ -1,0 +1,62 @@
+package com.moonju.preprocess.api.domain.image.service;
+
+import com.moonju.preprocess.api.domain.image.dto.ImageDownloadUrlResponse;
+import com.moonju.preprocess.api.domain.image.entity.Image;
+import com.moonju.preprocess.api.domain.image.entity.ImageArtifact;
+import com.moonju.preprocess.api.domain.image.entity.ImageDownloadType;
+import com.moonju.preprocess.api.domain.image.exception.ImageArtifactNotFoundException;
+import com.moonju.preprocess.api.domain.image.exception.UnsupportedImageDownloadTypeException;
+import com.moonju.preprocess.api.domain.image.repository.ImageArtifactRepository;
+import com.moonju.preprocess.api.domain.project.service.ProjectPermissionService;
+import com.moonju.preprocess.api.infra.storage.PresignedDownloadCommand;
+import com.moonju.preprocess.api.infra.storage.PresignedDownloadTarget;
+import com.moonju.preprocess.api.infra.storage.PresignedDownloadUrlGenerator;
+import java.time.Duration;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class ImageDownloadService {
+
+    private static final Duration DOWNLOAD_URL_EXPIRES_IN = Duration.ofMinutes(10);
+
+    private final ImageService imageService;
+    private final ImageArtifactRepository imageArtifactRepository;
+    private final ProjectPermissionService projectPermissionService;
+    private final PresignedDownloadUrlGenerator presignedDownloadUrlGenerator;
+
+    public ImageDownloadService(
+        ImageService imageService,
+        ImageArtifactRepository imageArtifactRepository,
+        ProjectPermissionService projectPermissionService,
+        PresignedDownloadUrlGenerator presignedDownloadUrlGenerator
+    ) {
+        this.imageService = imageService;
+        this.imageArtifactRepository = imageArtifactRepository;
+        this.projectPermissionService = projectPermissionService;
+        this.presignedDownloadUrlGenerator = presignedDownloadUrlGenerator;
+    }
+
+    @Transactional(readOnly = true)
+    public ImageDownloadUrlResponse createDownloadUrl(Long currentUserId, Long imageId, String typeValue) {
+        ImageDownloadType type = parseDownloadType(typeValue);
+        Image image = imageService.findActiveImage(imageId);
+        projectPermissionService.validateReadable(image.getProjectId(), currentUserId);
+
+        ImageArtifact artifact = imageArtifactRepository
+            .findFirstByImageIdAndTypeOrderByIdDesc(imageId, type.getArtifactType())
+            .orElseThrow(() -> new ImageArtifactNotFoundException("Image artifact not found."));
+        PresignedDownloadTarget target = presignedDownloadUrlGenerator.generateDownloadUrl(
+            new PresignedDownloadCommand(artifact.getObjectKey(), DOWNLOAD_URL_EXPIRES_IN)
+        );
+        return ImageDownloadUrlResponse.of(imageId, type, target);
+    }
+
+    private ImageDownloadType parseDownloadType(String typeValue) {
+        try {
+            return ImageDownloadType.from(typeValue);
+        } catch (IllegalArgumentException exception) {
+            throw new UnsupportedImageDownloadTypeException();
+        }
+    }
+}

--- a/backend-api/src/main/java/com/moonju/preprocess/api/domain/image/service/ImageService.java
+++ b/backend-api/src/main/java/com/moonju/preprocess/api/domain/image/service/ImageService.java
@@ -1,0 +1,56 @@
+package com.moonju.preprocess.api.domain.image.service;
+
+import com.moonju.preprocess.api.domain.image.dto.ImageListResponse;
+import com.moonju.preprocess.api.domain.image.dto.ImageResponse;
+import com.moonju.preprocess.api.domain.image.entity.Image;
+import com.moonju.preprocess.api.domain.image.entity.ImageStatus;
+import com.moonju.preprocess.api.domain.image.exception.ImageNotFoundException;
+import com.moonju.preprocess.api.domain.image.repository.ImageRepository;
+import com.moonju.preprocess.api.domain.project.service.ProjectPermissionService;
+import com.moonju.preprocess.api.global.response.PageResponse;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class ImageService {
+
+    private final ImageRepository imageRepository;
+    private final ProjectPermissionService projectPermissionService;
+
+    public ImageService(
+        ImageRepository imageRepository,
+        ProjectPermissionService projectPermissionService
+    ) {
+        this.imageRepository = imageRepository;
+        this.projectPermissionService = projectPermissionService;
+    }
+
+    @Transactional(readOnly = true)
+    public PageResponse<ImageListResponse> findProjectImages(Long currentUserId, Long projectId, Pageable pageable) {
+        projectPermissionService.validateReadable(projectId, currentUserId);
+        return PageResponse.from(imageRepository
+            .findAllByProjectIdAndStatusNot(projectId, ImageStatus.DELETED, pageable)
+            .map(ImageListResponse::from));
+    }
+
+    @Transactional(readOnly = true)
+    public ImageResponse findOne(Long currentUserId, Long imageId) {
+        Image image = findActiveImage(imageId);
+        projectPermissionService.validateReadable(image.getProjectId(), currentUserId);
+        return ImageResponse.from(image);
+    }
+
+    @Transactional
+    public void delete(Long currentUserId, Long imageId) {
+        Image image = findActiveImage(imageId);
+        projectPermissionService.validateEditable(image.getProjectId(), currentUserId);
+        image.delete();
+    }
+
+    @Transactional(readOnly = true)
+    public Image findActiveImage(Long imageId) {
+        return imageRepository.findByIdAndStatusNot(imageId, ImageStatus.DELETED)
+            .orElseThrow(ImageNotFoundException::new);
+    }
+}

--- a/backend-api/src/main/java/com/moonju/preprocess/api/domain/project/service/ProjectService.java
+++ b/backend-api/src/main/java/com/moonju/preprocess/api/domain/project/service/ProjectService.java
@@ -1,5 +1,7 @@
 package com.moonju.preprocess.api.domain.project.service;
 
+import com.moonju.preprocess.api.domain.image.entity.ImageStatus;
+import com.moonju.preprocess.api.domain.image.repository.ImageRepository;
 import com.moonju.preprocess.api.domain.project.dto.ProjectCreateRequest;
 import com.moonju.preprocess.api.domain.project.dto.ProjectResponse;
 import com.moonju.preprocess.api.domain.project.dto.ProjectSummaryResponse;
@@ -26,17 +28,20 @@ public class ProjectService {
     private final ProjectMemberRepository projectMemberRepository;
     private final UserRepository userRepository;
     private final ProjectPermissionService projectPermissionService;
+    private final ImageRepository imageRepository;
 
     public ProjectService(
         ProjectRepository projectRepository,
         ProjectMemberRepository projectMemberRepository,
         UserRepository userRepository,
-        ProjectPermissionService projectPermissionService
+        ProjectPermissionService projectPermissionService,
+        ImageRepository imageRepository
     ) {
         this.projectRepository = projectRepository;
         this.projectMemberRepository = projectMemberRepository;
         this.userRepository = userRepository;
         this.projectPermissionService = projectPermissionService;
+        this.imageRepository = imageRepository;
     }
 
     @Transactional
@@ -86,11 +91,12 @@ public class ProjectService {
     public ProjectSummaryResponse summary(Long currentUserId, Long projectId) {
         ProjectMember member = projectPermissionService.validateReadable(projectId, currentUserId);
         long memberCount = projectMemberRepository.countByProject_IdAndProject_Status(projectId, ProjectStatus.ACTIVE);
+        long imageCount = imageRepository.countByProjectIdAndStatusNot(projectId, ImageStatus.DELETED);
         return new ProjectSummaryResponse(
             member.getProject().getId(),
             member.getProject().getName(),
             memberCount,
-            0,
+            imageCount,
             0
         );
     }

--- a/backend-api/src/main/java/com/moonju/preprocess/api/domain/upload/service/UploadCompleteService.java
+++ b/backend-api/src/main/java/com/moonju/preprocess/api/domain/upload/service/UploadCompleteService.java
@@ -1,5 +1,6 @@
 package com.moonju.preprocess.api.domain.upload.service;
 
+import com.moonju.preprocess.api.domain.image.service.ImageCreateService;
 import com.moonju.preprocess.api.domain.project.service.ProjectPermissionService;
 import com.moonju.preprocess.api.domain.upload.dto.UploadCompleteRequest;
 import com.moonju.preprocess.api.domain.upload.dto.UploadCompleteResponse;
@@ -21,17 +22,20 @@ public class UploadCompleteService {
     private final UploadSessionFileRepository uploadSessionFileRepository;
     private final ProjectPermissionService projectPermissionService;
     private final ObjectStoragePort objectStoragePort;
+    private final ImageCreateService imageCreateService;
 
     public UploadCompleteService(
         UploadSessionService uploadSessionService,
         UploadSessionFileRepository uploadSessionFileRepository,
         ProjectPermissionService projectPermissionService,
-        ObjectStoragePort objectStoragePort
+        ObjectStoragePort objectStoragePort,
+        ImageCreateService imageCreateService
     ) {
         this.uploadSessionService = uploadSessionService;
         this.uploadSessionFileRepository = uploadSessionFileRepository;
         this.projectPermissionService = projectPermissionService;
         this.objectStoragePort = objectStoragePort;
+        this.imageCreateService = imageCreateService;
     }
 
     @Transactional
@@ -47,6 +51,7 @@ public class UploadCompleteService {
 
         files.forEach(this::verifyAndMarkUploaded);
         uploadSession.complete();
+        imageCreateService.createFromCompletedUpload(uploadSession, files);
         return UploadCompleteResponse.of(uploadSession, files.size());
     }
 

--- a/backend-api/src/main/java/com/moonju/preprocess/api/infra/storage/LocalPresignedDownloadUrlGenerator.java
+++ b/backend-api/src/main/java/com/moonju/preprocess/api/infra/storage/LocalPresignedDownloadUrlGenerator.java
@@ -1,0 +1,20 @@
+package com.moonju.preprocess.api.infra.storage;
+
+import java.time.Instant;
+import java.util.Map;
+import org.springframework.stereotype.Component;
+
+@Component
+public class LocalPresignedDownloadUrlGenerator implements PresignedDownloadUrlGenerator {
+
+    @Override
+    public PresignedDownloadTarget generateDownloadUrl(PresignedDownloadCommand command) {
+        Instant expiresAt = Instant.now().plus(command.expiresIn());
+        return new PresignedDownloadTarget(
+            command.objectKey(),
+            "http://localhost:9000/local-download/" + command.objectKey(),
+            expiresAt,
+            Map.of()
+        );
+    }
+}

--- a/backend-api/src/main/java/com/moonju/preprocess/api/infra/storage/PresignedDownloadCommand.java
+++ b/backend-api/src/main/java/com/moonju/preprocess/api/infra/storage/PresignedDownloadCommand.java
@@ -1,0 +1,9 @@
+package com.moonju.preprocess.api.infra.storage;
+
+import java.time.Duration;
+
+public record PresignedDownloadCommand(
+    String objectKey,
+    Duration expiresIn
+) {
+}

--- a/backend-api/src/main/java/com/moonju/preprocess/api/infra/storage/PresignedDownloadTarget.java
+++ b/backend-api/src/main/java/com/moonju/preprocess/api/infra/storage/PresignedDownloadTarget.java
@@ -1,0 +1,12 @@
+package com.moonju.preprocess.api.infra.storage;
+
+import java.time.Instant;
+import java.util.Map;
+
+public record PresignedDownloadTarget(
+    String objectKey,
+    String downloadUrl,
+    Instant expiresAt,
+    Map<String, String> requiredHeaders
+) {
+}

--- a/backend-api/src/main/java/com/moonju/preprocess/api/infra/storage/PresignedDownloadUrlGenerator.java
+++ b/backend-api/src/main/java/com/moonju/preprocess/api/infra/storage/PresignedDownloadUrlGenerator.java
@@ -1,0 +1,6 @@
+package com.moonju.preprocess.api.infra.storage;
+
+public interface PresignedDownloadUrlGenerator {
+
+    PresignedDownloadTarget generateDownloadUrl(PresignedDownloadCommand command);
+}

--- a/backend-api/src/test/java/com/moonju/preprocess/api/domain/image/controller/ImageControllerTests.java
+++ b/backend-api/src/test/java/com/moonju/preprocess/api/domain/image/controller/ImageControllerTests.java
@@ -1,0 +1,37 @@
+package com.moonju.preprocess.api.domain.image.controller;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+
+import com.moonju.preprocess.api.domain.image.service.ImageArtifactService;
+import com.moonju.preprocess.api.domain.image.service.ImageDownloadService;
+import com.moonju.preprocess.api.domain.image.service.ImageService;
+import com.moonju.preprocess.api.global.response.ApiResponse;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ImageControllerTests {
+
+    @Mock
+    private ImageService imageService;
+
+    @Mock
+    private ImageDownloadService imageDownloadService;
+
+    @Mock
+    private ImageArtifactService imageArtifactService;
+
+    @Test
+    void deletesImageWithCommonNoContentResponse() {
+        ImageController controller = new ImageController(imageService, imageDownloadService, imageArtifactService);
+
+        ApiResponse<Void> response = controller.delete(20L, 200L);
+
+        assertThat(response.isSuccess()).isTrue();
+        assertThat(response.code()).isEqualTo("common204");
+        verify(imageService).delete(20L, 200L);
+    }
+}

--- a/backend-api/src/test/java/com/moonju/preprocess/api/domain/image/entity/ImageArtifactTests.java
+++ b/backend-api/src/test/java/com/moonju/preprocess/api/domain/image/entity/ImageArtifactTests.java
@@ -1,0 +1,35 @@
+package com.moonju.preprocess.api.domain.image.entity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+class ImageArtifactTests {
+
+    @Test
+    void createsOriginalArtifactFromImage() {
+        Image image = new Image(
+            10L,
+            1L,
+            100L,
+            20L,
+            "scan_001.png",
+            "originals/10/1/file/scan_001.png",
+            "image/png",
+            1024L,
+            "a".repeat(64),
+            ImageFormat.PNG,
+            ImageStatus.UPLOADED
+        );
+        ReflectionTestUtils.setField(image, "id", 200L);
+
+        ImageArtifact artifact = ImageArtifact.original(image);
+
+        assertThat(artifact.getImageId()).isEqualTo(200L);
+        assertThat(artifact.getType()).isEqualTo(ImageArtifactType.ORIGINAL);
+        assertThat(artifact.getObjectKey()).isEqualTo("originals/10/1/file/scan_001.png");
+        assertThat(artifact.getContentType()).isEqualTo("image/png");
+        assertThat(artifact.getSizeBytes()).isEqualTo(1024L);
+    }
+}

--- a/backend-api/src/test/java/com/moonju/preprocess/api/domain/image/entity/ImageTests.java
+++ b/backend-api/src/test/java/com/moonju/preprocess/api/domain/image/entity/ImageTests.java
@@ -1,0 +1,58 @@
+package com.moonju.preprocess.api.domain.image.entity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.moonju.preprocess.api.domain.upload.entity.UploadSession;
+import com.moonju.preprocess.api.domain.upload.entity.UploadSessionFile;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+class ImageTests {
+
+    @Test
+    void createsImageFromUploadedFile() {
+        UploadSession uploadSession = UploadSession.create(10L, 20L, 1, 4096L);
+        ReflectionTestUtils.setField(uploadSession, "id", 1L);
+        UploadSessionFile file = UploadSessionFile.issued(
+            1L,
+            10L,
+            "scan_001.png",
+            "originals/10/1/file/scan_001.png",
+            "image/png",
+            1024L,
+            "a".repeat(64)
+        );
+        ReflectionTestUtils.setField(file, "id", 100L);
+
+        Image image = Image.fromUpload(uploadSession, file);
+
+        assertThat(image.getProjectId()).isEqualTo(10L);
+        assertThat(image.getUploadSessionId()).isEqualTo(1L);
+        assertThat(image.getUploadSessionFileId()).isEqualTo(100L);
+        assertThat(image.getUploaderId()).isEqualTo(20L);
+        assertThat(image.getFormat()).isEqualTo(ImageFormat.PNG);
+        assertThat(image.getStatus()).isEqualTo(ImageStatus.UPLOADED);
+    }
+
+    @Test
+    void marksImageAsDeleted() {
+        Image image = new Image(
+            10L,
+            1L,
+            100L,
+            20L,
+            "scan_001.png",
+            "originals/10/1/file/scan_001.png",
+            "image/png",
+            1024L,
+            "a".repeat(64),
+            ImageFormat.PNG,
+            ImageStatus.UPLOADED
+        );
+
+        image.delete();
+
+        assertThat(image.isDeleted()).isTrue();
+        assertThat(image.getDeletedAt()).isNotNull();
+    }
+}

--- a/backend-api/src/test/java/com/moonju/preprocess/api/domain/image/service/ImageArtifactServiceTests.java
+++ b/backend-api/src/test/java/com/moonju/preprocess/api/domain/image/service/ImageArtifactServiceTests.java
@@ -1,0 +1,123 @@
+package com.moonju.preprocess.api.domain.image.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import com.moonju.preprocess.api.domain.image.dto.DebugArtifactResponse;
+import com.moonju.preprocess.api.domain.image.dto.ImageReportResponse;
+import com.moonju.preprocess.api.domain.image.entity.Image;
+import com.moonju.preprocess.api.domain.image.entity.ImageArtifact;
+import com.moonju.preprocess.api.domain.image.entity.ImageArtifactType;
+import com.moonju.preprocess.api.domain.image.entity.ImageFormat;
+import com.moonju.preprocess.api.domain.image.entity.ImageStatus;
+import com.moonju.preprocess.api.domain.image.repository.ImageArtifactRepository;
+import com.moonju.preprocess.api.domain.project.service.ProjectPermissionService;
+import com.moonju.preprocess.api.infra.storage.PresignedDownloadCommand;
+import com.moonju.preprocess.api.infra.storage.PresignedDownloadTarget;
+import com.moonju.preprocess.api.infra.storage.PresignedDownloadUrlGenerator;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+class ImageArtifactServiceTests {
+
+    @Mock
+    private ImageService imageService;
+
+    @Mock
+    private ImageArtifactRepository imageArtifactRepository;
+
+    @Mock
+    private ProjectPermissionService projectPermissionService;
+
+    @Mock
+    private PresignedDownloadUrlGenerator presignedDownloadUrlGenerator;
+
+    @InjectMocks
+    private ImageArtifactService service;
+
+    @Test
+    void findsProcessingReportDownloadUrl() {
+        Image image = image();
+        ImageArtifact artifact = artifact(300L, ImageArtifactType.PROCESSING_REPORT, null);
+        when(imageService.findActiveImage(200L)).thenReturn(image);
+        when(projectPermissionService.validateReadable(10L, 20L)).thenReturn(null);
+        when(imageArtifactRepository.findFirstByImageIdAndTypeOrderByIdDesc(200L, ImageArtifactType.PROCESSING_REPORT))
+            .thenReturn(Optional.of(artifact));
+        when(presignedDownloadUrlGenerator.generateDownloadUrl(any(PresignedDownloadCommand.class)))
+            .thenReturn(downloadTarget(artifact));
+
+        ImageReportResponse response = service.findReport(20L, 200L);
+
+        assertThat(response.artifactId()).isEqualTo(300L);
+        assertThat(response.downloadUrl()).contains("/local-download/");
+    }
+
+    @Test
+    void listsDebugArtifactDownloadUrls() {
+        Image image = image();
+        ImageArtifact artifact = artifact(301L, ImageArtifactType.DEBUG, "02_deskew");
+        when(imageService.findActiveImage(200L)).thenReturn(image);
+        when(projectPermissionService.validateReadable(10L, 20L)).thenReturn(null);
+        when(imageArtifactRepository.findAllByImageIdAndTypeOrderByIdAsc(200L, ImageArtifactType.DEBUG))
+            .thenReturn(List.of(artifact));
+        when(presignedDownloadUrlGenerator.generateDownloadUrl(any(PresignedDownloadCommand.class)))
+            .thenReturn(downloadTarget(artifact));
+
+        List<DebugArtifactResponse> response = service.findDebugArtifacts(20L, 200L);
+
+        assertThat(response).hasSize(1);
+        assertThat(response.getFirst().debugStep()).isEqualTo("02_deskew");
+    }
+
+    private Image image() {
+        Image image = new Image(
+            10L,
+            1L,
+            100L,
+            20L,
+            "scan_001.png",
+            "originals/scan_001.png",
+            "image/png",
+            1024L,
+            "a".repeat(64),
+            ImageFormat.PNG,
+            ImageStatus.PROCESSED
+        );
+        ReflectionTestUtils.setField(image, "id", 200L);
+        return image;
+    }
+
+    private ImageArtifact artifact(Long artifactId, ImageArtifactType type, String debugStep) {
+        ImageArtifact artifact = new ImageArtifact(
+            200L,
+            10L,
+            100L,
+            type,
+            "processed/10/100/artifact",
+            "application/json",
+            512L,
+            debugStep
+        );
+        ReflectionTestUtils.setField(artifact, "id", artifactId);
+        return artifact;
+    }
+
+    private PresignedDownloadTarget downloadTarget(ImageArtifact artifact) {
+        return new PresignedDownloadTarget(
+            artifact.getObjectKey(),
+            "http://localhost:9000/local-download/" + artifact.getObjectKey(),
+            Instant.parse("2026-05-09T10:00:00Z"),
+            Map.of()
+        );
+    }
+}

--- a/backend-api/src/test/java/com/moonju/preprocess/api/domain/image/service/ImageCreateServiceTests.java
+++ b/backend-api/src/test/java/com/moonju/preprocess/api/domain/image/service/ImageCreateServiceTests.java
@@ -1,0 +1,90 @@
+package com.moonju.preprocess.api.domain.image.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.moonju.preprocess.api.domain.image.entity.Image;
+import com.moonju.preprocess.api.domain.image.entity.ImageArtifact;
+import com.moonju.preprocess.api.domain.image.entity.ImageArtifactType;
+import com.moonju.preprocess.api.domain.image.repository.ImageArtifactRepository;
+import com.moonju.preprocess.api.domain.image.repository.ImageRepository;
+import com.moonju.preprocess.api.domain.upload.entity.UploadSession;
+import com.moonju.preprocess.api.domain.upload.entity.UploadSessionFile;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+class ImageCreateServiceTests {
+
+    @Mock
+    private ImageRepository imageRepository;
+
+    @Mock
+    private ImageArtifactRepository imageArtifactRepository;
+
+    @InjectMocks
+    private ImageCreateService service;
+
+    @Test
+    void createsImageAndOriginalArtifactFromCompletedUpload() {
+        UploadSession uploadSession = uploadSession();
+        UploadSessionFile file = uploadSessionFile(100L);
+        when(imageRepository.existsByUploadSessionFileId(100L)).thenReturn(false);
+        when(imageRepository.save(any(Image.class))).thenAnswer(invocation -> {
+            Image image = invocation.getArgument(0);
+            ReflectionTestUtils.setField(image, "id", 200L);
+            return image;
+        });
+
+        List<Image> images = service.createFromCompletedUpload(uploadSession, List.of(file));
+
+        assertThat(images).hasSize(1);
+        assertThat(images.getFirst().getUploadSessionFileId()).isEqualTo(100L);
+        ArgumentCaptor<ImageArtifact> artifactCaptor = ArgumentCaptor.forClass(ImageArtifact.class);
+        verify(imageArtifactRepository).save(artifactCaptor.capture());
+        assertThat(artifactCaptor.getValue().getImageId()).isEqualTo(200L);
+        assertThat(artifactCaptor.getValue().getType()).isEqualTo(ImageArtifactType.ORIGINAL);
+    }
+
+    @Test
+    void skipsAlreadyFinalizedUploadFile() {
+        UploadSession uploadSession = uploadSession();
+        UploadSessionFile file = uploadSessionFile(100L);
+        when(imageRepository.existsByUploadSessionFileId(100L)).thenReturn(true);
+
+        List<Image> images = service.createFromCompletedUpload(uploadSession, List.of(file));
+
+        assertThat(images).isEmpty();
+        verify(imageRepository, never()).save(any(Image.class));
+        verify(imageArtifactRepository, never()).save(any(ImageArtifact.class));
+    }
+
+    private UploadSession uploadSession() {
+        UploadSession uploadSession = UploadSession.create(10L, 20L, 1, 4096L);
+        ReflectionTestUtils.setField(uploadSession, "id", 1L);
+        return uploadSession;
+    }
+
+    private UploadSessionFile uploadSessionFile(Long id) {
+        UploadSessionFile file = UploadSessionFile.issued(
+            1L,
+            10L,
+            "scan_001.png",
+            "originals/10/1/file/scan_001.png",
+            "image/png",
+            1024L,
+            "a".repeat(64)
+        );
+        ReflectionTestUtils.setField(file, "id", id);
+        return file;
+    }
+}

--- a/backend-api/src/test/java/com/moonju/preprocess/api/domain/image/service/ImageDownloadServiceTests.java
+++ b/backend-api/src/test/java/com/moonju/preprocess/api/domain/image/service/ImageDownloadServiceTests.java
@@ -1,0 +1,111 @@
+package com.moonju.preprocess.api.domain.image.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import com.moonju.preprocess.api.domain.image.dto.ImageDownloadUrlResponse;
+import com.moonju.preprocess.api.domain.image.entity.Image;
+import com.moonju.preprocess.api.domain.image.entity.ImageArtifact;
+import com.moonju.preprocess.api.domain.image.entity.ImageArtifactType;
+import com.moonju.preprocess.api.domain.image.entity.ImageDownloadType;
+import com.moonju.preprocess.api.domain.image.entity.ImageFormat;
+import com.moonju.preprocess.api.domain.image.entity.ImageStatus;
+import com.moonju.preprocess.api.domain.image.exception.UnsupportedImageDownloadTypeException;
+import com.moonju.preprocess.api.domain.image.repository.ImageArtifactRepository;
+import com.moonju.preprocess.api.domain.project.service.ProjectPermissionService;
+import com.moonju.preprocess.api.infra.storage.PresignedDownloadCommand;
+import com.moonju.preprocess.api.infra.storage.PresignedDownloadTarget;
+import com.moonju.preprocess.api.infra.storage.PresignedDownloadUrlGenerator;
+import java.time.Instant;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+class ImageDownloadServiceTests {
+
+    @Mock
+    private ImageService imageService;
+
+    @Mock
+    private ImageArtifactRepository imageArtifactRepository;
+
+    @Mock
+    private ProjectPermissionService projectPermissionService;
+
+    @Mock
+    private PresignedDownloadUrlGenerator presignedDownloadUrlGenerator;
+
+    @InjectMocks
+    private ImageDownloadService service;
+
+    @Test
+    void createsOriginalDownloadUrlWithLowercaseType() {
+        Image image = image();
+        ImageArtifact artifact = artifact(300L, ImageArtifactType.ORIGINAL);
+        when(imageService.findActiveImage(200L)).thenReturn(image);
+        when(projectPermissionService.validateReadable(10L, 20L)).thenReturn(null);
+        when(imageArtifactRepository.findFirstByImageIdAndTypeOrderByIdDesc(200L, ImageArtifactType.ORIGINAL))
+            .thenReturn(Optional.of(artifact));
+        when(presignedDownloadUrlGenerator.generateDownloadUrl(any(PresignedDownloadCommand.class)))
+            .thenReturn(new PresignedDownloadTarget(
+                artifact.getObjectKey(),
+                "http://localhost:9000/local-download/originals/scan_001.png",
+                Instant.parse("2026-05-09T10:00:00Z"),
+                Map.of()
+            ));
+
+        ImageDownloadUrlResponse response = service.createDownloadUrl(20L, 200L, "original");
+
+        assertThat(response.imageId()).isEqualTo(200L);
+        assertThat(response.type()).isEqualTo(ImageDownloadType.ORIGINAL);
+        assertThat(response.downloadUrl()).contains("/local-download/");
+    }
+
+    @Test
+    void rejectsUnsupportedDownloadType() {
+        assertThatThrownBy(() -> service.createDownloadUrl(20L, 200L, "report"))
+            .isInstanceOf(UnsupportedImageDownloadTypeException.class)
+            .hasMessage("Unsupported image download type.");
+    }
+
+    private Image image() {
+        Image image = new Image(
+            10L,
+            1L,
+            100L,
+            20L,
+            "scan_001.png",
+            "originals/scan_001.png",
+            "image/png",
+            1024L,
+            "a".repeat(64),
+            ImageFormat.PNG,
+            ImageStatus.UPLOADED
+        );
+        ReflectionTestUtils.setField(image, "id", 200L);
+        return image;
+    }
+
+    private ImageArtifact artifact(Long artifactId, ImageArtifactType type) {
+        ImageArtifact artifact = new ImageArtifact(
+            200L,
+            null,
+            null,
+            type,
+            "originals/scan_001.png",
+            "image/png",
+            1024L,
+            null
+        );
+        ReflectionTestUtils.setField(artifact, "id", artifactId);
+        return artifact;
+    }
+}

--- a/backend-api/src/test/java/com/moonju/preprocess/api/domain/image/service/ImageServiceTests.java
+++ b/backend-api/src/test/java/com/moonju/preprocess/api/domain/image/service/ImageServiceTests.java
@@ -1,0 +1,93 @@
+package com.moonju.preprocess.api.domain.image.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.moonju.preprocess.api.domain.image.dto.ImageListResponse;
+import com.moonju.preprocess.api.domain.image.dto.ImageResponse;
+import com.moonju.preprocess.api.domain.image.entity.Image;
+import com.moonju.preprocess.api.domain.image.entity.ImageFormat;
+import com.moonju.preprocess.api.domain.image.entity.ImageStatus;
+import com.moonju.preprocess.api.domain.image.repository.ImageRepository;
+import com.moonju.preprocess.api.domain.project.service.ProjectPermissionService;
+import com.moonju.preprocess.api.global.response.PageResponse;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+class ImageServiceTests {
+
+    @Mock
+    private ImageRepository imageRepository;
+
+    @Mock
+    private ProjectPermissionService projectPermissionService;
+
+    @InjectMocks
+    private ImageService service;
+
+    @Test
+    void listsProjectImagesAfterReadPermissionValidation() {
+        Image image = image(200L, 10L);
+        when(projectPermissionService.validateReadable(10L, 20L)).thenReturn(null);
+        when(imageRepository.findAllByProjectIdAndStatusNot(10L, ImageStatus.DELETED, PageRequest.of(0, 20)))
+            .thenReturn(new PageImpl<>(java.util.List.of(image)));
+
+        PageResponse<ImageListResponse> response = service.findProjectImages(20L, 10L, PageRequest.of(0, 20));
+
+        assertThat(response.content()).hasSize(1);
+        assertThat(response.content().getFirst().id()).isEqualTo(200L);
+        verify(projectPermissionService).validateReadable(10L, 20L);
+    }
+
+    @Test
+    void findsImageDetailAfterReadPermissionValidation() {
+        Image image = image(200L, 10L);
+        when(imageRepository.findByIdAndStatusNot(200L, ImageStatus.DELETED)).thenReturn(Optional.of(image));
+        when(projectPermissionService.validateReadable(10L, 20L)).thenReturn(null);
+
+        ImageResponse response = service.findOne(20L, 200L);
+
+        assertThat(response.id()).isEqualTo(200L);
+        assertThat(response.originalFileName()).isEqualTo("scan_001.png");
+        verify(projectPermissionService).validateReadable(10L, 20L);
+    }
+
+    @Test
+    void softDeletesImageAfterEditPermissionValidation() {
+        Image image = image(200L, 10L);
+        when(imageRepository.findByIdAndStatusNot(200L, ImageStatus.DELETED)).thenReturn(Optional.of(image));
+        when(projectPermissionService.validateEditable(10L, 20L)).thenReturn(null);
+
+        service.delete(20L, 200L);
+
+        assertThat(image.isDeleted()).isTrue();
+        verify(projectPermissionService).validateEditable(10L, 20L);
+    }
+
+    private Image image(Long imageId, Long projectId) {
+        Image image = new Image(
+            projectId,
+            1L,
+            100L,
+            20L,
+            "scan_001.png",
+            "originals/10/1/file/scan_001.png",
+            "image/png",
+            1024L,
+            "a".repeat(64),
+            ImageFormat.PNG,
+            ImageStatus.UPLOADED
+        );
+        ReflectionTestUtils.setField(image, "id", imageId);
+        return image;
+    }
+}

--- a/backend-api/src/test/java/com/moonju/preprocess/api/domain/project/service/ProjectServiceTests.java
+++ b/backend-api/src/test/java/com/moonju/preprocess/api/domain/project/service/ProjectServiceTests.java
@@ -5,12 +5,16 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.moonju.preprocess.api.domain.image.entity.ImageStatus;
+import com.moonju.preprocess.api.domain.image.repository.ImageRepository;
 import com.moonju.preprocess.api.domain.project.dto.ProjectCreateRequest;
 import com.moonju.preprocess.api.domain.project.dto.ProjectResponse;
+import com.moonju.preprocess.api.domain.project.dto.ProjectSummaryResponse;
 import com.moonju.preprocess.api.domain.project.dto.ProjectUpdateRequest;
 import com.moonju.preprocess.api.domain.project.entity.Project;
 import com.moonju.preprocess.api.domain.project.entity.ProjectMember;
 import com.moonju.preprocess.api.domain.project.entity.ProjectRole;
+import com.moonju.preprocess.api.domain.project.entity.ProjectStatus;
 import com.moonju.preprocess.api.domain.project.repository.ProjectMemberRepository;
 import com.moonju.preprocess.api.domain.project.repository.ProjectRepository;
 import com.moonju.preprocess.api.domain.user.entity.User;
@@ -36,6 +40,9 @@ class ProjectServiceTests {
 
     @Mock
     private ProjectPermissionService projectPermissionService;
+
+    @Mock
+    private ImageRepository imageRepository;
 
     @Test
     void createsProjectAndOwnerMember() {
@@ -80,8 +87,32 @@ class ProjectServiceTests {
         assertThat(response.myRole()).isEqualTo(ProjectRole.EDITOR);
     }
 
+    @Test
+    void summarizesProjectWithImageCount() {
+        ProjectService projectService = projectService();
+        User owner = user(1L, "owner@example.com");
+        Project project = Project.create(owner, "Project", null, null);
+        ReflectionTestUtils.setField(project, "id", 10L);
+        when(projectPermissionService.validateReadable(10L, 1L))
+            .thenReturn(new ProjectMember(project, owner, ProjectRole.OWNER));
+        when(projectMemberRepository.countByProject_IdAndProject_Status(10L, ProjectStatus.ACTIVE)).thenReturn(2L);
+        when(imageRepository.countByProjectIdAndStatusNot(10L, ImageStatus.DELETED)).thenReturn(5L);
+
+        ProjectSummaryResponse response = projectService.summary(1L, 10L);
+
+        assertThat(response.memberCount()).isEqualTo(2L);
+        assertThat(response.imageCount()).isEqualTo(5L);
+        assertThat(response.jobCount()).isZero();
+    }
+
     private ProjectService projectService() {
-        return new ProjectService(projectRepository, projectMemberRepository, userRepository, projectPermissionService);
+        return new ProjectService(
+            projectRepository,
+            projectMemberRepository,
+            userRepository,
+            projectPermissionService,
+            imageRepository
+        );
     }
 
     private User user(Long id, String email) {

--- a/backend-api/src/test/java/com/moonju/preprocess/api/domain/upload/service/UploadCompleteServiceTests.java
+++ b/backend-api/src/test/java/com/moonju/preprocess/api/domain/upload/service/UploadCompleteServiceTests.java
@@ -2,8 +2,10 @@ package com.moonju.preprocess.api.domain.upload.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.moonju.preprocess.api.domain.image.service.ImageCreateService;
 import com.moonju.preprocess.api.domain.project.service.ProjectPermissionService;
 import com.moonju.preprocess.api.domain.upload.dto.UploadCompleteRequest;
 import com.moonju.preprocess.api.domain.upload.dto.UploadCompleteResponse;
@@ -37,6 +39,9 @@ class UploadCompleteServiceTests {
     @Mock
     private ObjectStoragePort objectStoragePort;
 
+    @Mock
+    private ImageCreateService imageCreateService;
+
     @InjectMocks
     private UploadCompleteService service;
 
@@ -57,6 +62,7 @@ class UploadCompleteServiceTests {
         assertThat(response.uploadedFileCount()).isEqualTo(1);
         assertThat(uploadSession.getStatus()).isEqualTo(UploadSessionStatus.COMPLETED);
         assertThat(file.getStatus()).isEqualTo(UploadFileStatus.UPLOADED);
+        verify(imageCreateService).createFromCompletedUpload(uploadSession, List.of(file));
     }
 
     @Test

--- a/docs/api/image-api.md
+++ b/docs/api/image-api.md
@@ -1,0 +1,149 @@
+# Image API
+
+## Purpose
+
+Image API manages finalized image metadata after upload completion. The API exposes project image lists, image detail,
+soft delete, original/processed/preview download URLs, processing report lookup, and debug artifact lookup.
+
+## Rules
+
+- `Image` rows are created only after upload completion verifies object existence.
+- The Spring API does not expose public object storage URLs.
+- Download endpoints return temporary signed URLs through `PresignedDownloadUrlGenerator`.
+- Original files and preprocessing artifacts are stored separately as `ImageArtifact` rows.
+- Access is controlled by project membership through `ProjectPermissionService`.
+- Deleting an image is a soft delete and does not immediately remove Object Storage objects.
+
+## Endpoints
+
+| Method | Path | Purpose |
+| --- | --- | --- |
+| `GET` | `/api/v1/projects/{projectId}/images` | List project images |
+| `GET` | `/api/v1/images/{imageId}` | Read image detail |
+| `DELETE` | `/api/v1/images/{imageId}` | Soft delete image |
+| `GET` | `/api/v1/images/{imageId}/download?type=original` | Get original download URL |
+| `GET` | `/api/v1/images/{imageId}/download?type=processed` | Get processed download URL |
+| `GET` | `/api/v1/images/{imageId}/download?type=preview` | Get preview download URL |
+| `GET` | `/api/v1/images/{imageId}/report` | Get processing report download URL |
+| `GET` | `/api/v1/images/{imageId}/debug-artifacts` | List debug artifact download URLs |
+
+## List Images
+
+Response:
+
+```json
+{
+  "isSuccess": true,
+  "code": "common200",
+  "message": "Request succeeded.",
+  "result": {
+    "content": [
+      {
+        "id": 200,
+        "projectId": 10,
+        "originalFileName": "scan_001.png",
+        "contentType": "image/png",
+        "sizeBytes": 1024,
+        "format": "PNG",
+        "status": "UPLOADED",
+        "createdAt": "2026-05-09T21:00:00"
+      }
+    ],
+    "page": 0,
+    "size": 20,
+    "totalElements": 1,
+    "totalPages": 1,
+    "hasNext": false
+  }
+}
+```
+
+## Image Detail
+
+Response:
+
+```json
+{
+  "isSuccess": true,
+  "code": "common200",
+  "message": "Request succeeded.",
+  "result": {
+    "id": 200,
+    "projectId": 10,
+    "uploadSessionId": 1,
+    "uploadSessionFileId": 100,
+    "uploaderId": 20,
+    "originalFileName": "scan_001.png",
+    "originalObjectKey": "originals/10/1/file/scan_001.png",
+    "contentType": "image/png",
+    "sizeBytes": 1024,
+    "checksumSha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "format": "PNG",
+    "status": "UPLOADED",
+    "width": null,
+    "height": null,
+    "dpiX": null,
+    "dpiY": null,
+    "createdAt": "2026-05-09T21:00:00"
+  }
+}
+```
+
+## Download URL
+
+Request:
+
+```text
+GET /api/v1/images/200/download?type=original
+```
+
+Supported `type` values:
+
+- `original`
+- `processed`
+- `preview`
+
+Response:
+
+```json
+{
+  "isSuccess": true,
+  "code": "common200",
+  "message": "Request succeeded.",
+  "result": {
+    "imageId": 200,
+    "type": "ORIGINAL",
+    "objectKey": "originals/10/1/file/scan_001.png",
+    "downloadUrl": "http://localhost:9000/local-download/originals/10/1/file/scan_001.png",
+    "expiresAt": "2026-05-09T12:10:00Z",
+    "requiredHeaders": {}
+  }
+}
+```
+
+## Report And Debug Artifacts
+
+`/report` returns the latest `PROCESSING_REPORT` artifact download URL.
+
+`/debug-artifacts` returns all `DEBUG` artifacts for the image. Debug artifacts are expected to be created later by the
+worker/report task and are empty until worker integration exists.
+
+## Upload Completion Integration
+
+When `POST /api/v1/upload-sessions/{sessionId}/complete` succeeds:
+
+1. API verifies the original objects exist.
+2. API marks upload files as `UPLOADED`.
+3. API marks the upload session as `COMPLETED`.
+4. API creates one `Image` row per uploaded file.
+5. API creates one `ORIGINAL` `ImageArtifact` row per image.
+
+The `Image` row is idempotent by `uploadSessionFileId`, so repeated internal finalization does not create duplicate
+images.
+
+## Next Work
+
+- Replace local download URL generator with a MinIO/S3 adapter.
+- Add metadata extraction for width, height, and DPI.
+- Add worker internal artifact registration for processed, preview, report, and debug files.
+- Add image magic number validation after object download.

--- a/docs/api/project-api.md
+++ b/docs/api/project-api.md
@@ -117,10 +117,10 @@ Response:
     "projectId": 1,
     "name": "Library Scan Batch",
     "memberCount": 2,
-    "imageCount": 0,
+    "imageCount": 15,
     "jobCount": 0
   }
 }
 ```
 
-`imageCount` and `jobCount` are placeholders until Image and Job domains are implemented.
+`imageCount` counts non-deleted `Image` rows. `jobCount` remains a placeholder until the Job domain is implemented.

--- a/docs/api/upload-api.md
+++ b/docs/api/upload-api.md
@@ -141,6 +141,5 @@ Response:
 ## Next Work
 
 - Replace the local presigned URL generator with a MinIO/S3 adapter.
-- Create image metadata rows after upload completion.
 - Add image magic number validation after object download or metadata extraction.
 - Add ZIP upload as a separate expansion task.

--- a/docs/feature-specs/issue-33-image-domain.md
+++ b/docs/feature-specs/issue-33-image-domain.md
@@ -1,0 +1,68 @@
+# Issue 33. Image Domain Upload Completion Integration
+
+## Goal
+
+Finalize uploaded files as `Image` metadata after upload completion and expose read/download APIs for original and
+future preprocessing artifacts.
+
+## Overall Order
+
+1. Upload domain verifies uploaded object existence.
+2. Upload domain marks `UploadSessionFile` rows as `UPLOADED`.
+3. Upload domain marks the session as `COMPLETED`.
+4. Image domain creates one `Image` row for each uploaded file.
+5. Image domain creates one `ORIGINAL` `ImageArtifact` row for each image.
+6. User lists project images.
+7. User opens image detail.
+8. User requests temporary download URLs for original, processed, or preview artifacts.
+9. User requests processing report or debug artifact URLs after worker integration creates them.
+
+## Functional Units
+
+### Image Metadata
+
+- `Image` stores project, upload session, upload file, uploader, original object key, content type, size, checksum,
+  format, status, and future metadata fields.
+- `ImageStatus` has `UPLOADED`, `PROCESSING`, `PROCESSED`, `FAILED`, and `DELETED`.
+- `ImageFormat` supports `PNG`, `JPG`, `JPEG`, `TIF`, `TIFF`, `BMP`, and `WEBP`.
+- `uploadSessionFileId` is unique to prevent duplicate finalization.
+
+### Artifact Metadata
+
+- `ImageArtifact` stores image, optional job/job item IDs, artifact type, object key, content type, size, and debug
+  step.
+- `ImageArtifactType` has `ORIGINAL`, `PROCESSED`, `PREVIEW`, `PROCESSING_REPORT`, and `DEBUG`.
+- Original artifact rows are created immediately after upload completion.
+- Processed, preview, report, and debug artifact rows are reserved for worker/internal API integration.
+
+### APIs
+
+- `GET /api/v1/projects/{projectId}/images`
+- `GET /api/v1/images/{imageId}`
+- `DELETE /api/v1/images/{imageId}`
+- `GET /api/v1/images/{imageId}/download?type=original`
+- `GET /api/v1/images/{imageId}/download?type=processed`
+- `GET /api/v1/images/{imageId}/download?type=preview`
+- `GET /api/v1/images/{imageId}/report`
+- `GET /api/v1/images/{imageId}/debug-artifacts`
+
+### Access Control
+
+- Project read permission is required for list, detail, download, report, and debug artifact APIs.
+- Project edit permission is required for image soft delete.
+- Object Storage URLs remain private and are exposed only through temporary download URL responses.
+
+## Out Of Scope
+
+- Real MinIO/S3 presigned download implementation.
+- Metadata extraction for width, height, and DPI.
+- Worker artifact registration.
+- Object deletion cleanup.
+- ZIP download.
+
+## Verification
+
+- Entity tests cover `Image` creation from upload and original artifact creation.
+- Service tests cover upload finalization, list/detail/delete, download URL creation, report, and debug artifact lookup.
+- Upload completion tests verify image finalization is invoked after object existence verification.
+- Controller test covers common no-content delete response.

--- a/docs/operation/storage-operation.md
+++ b/docs/operation/storage-operation.md
@@ -44,15 +44,17 @@ processed/{projectId}/{jobId}/{itemId}/debug/{step}.png
 5. Client uploads file bodies directly to object storage.
 6. Client calls upload complete.
 7. Spring API verifies object existence through `ObjectStoragePort`.
-8. Later image-domain logic creates `Image` rows from completed upload files.
+8. Image domain creates `Image` and `ORIGINAL` `ImageArtifact` rows from completed upload files.
 
 ## Local Skeleton
 
 Current skeleton classes:
 
 - `PresignedUrlGenerator`
+- `PresignedDownloadUrlGenerator`
 - `ObjectStoragePort`
 - `LocalPresignedUrlGenerator`
+- `LocalPresignedDownloadUrlGenerator`
 - `LocalObjectStorageAdapter`
 
 The local classes are placeholders so the application compiles and the domain boundary is testable. Production work


### PR DESCRIPTION
## #️⃣ 기능 설명

업로드 완료된 `UploadSessionFile`을 최종 `Image` 메타데이터와 `ORIGINAL` artifact로 확정하고, 이미지 목록/상세/다운로드 URL 조회 API skeleton을 추가합니다.

Closes #33

## 🛠️ 작업 상세 내용

- [x] `Image`, `ImageArtifact`, status/format/type enum 추가
- [x] 업로드 완료 시 `ImageCreateService`를 호출해 `Image` row와 `ORIGINAL` artifact 생성
- [x] 프로젝트 이미지 목록/상세/soft delete API 추가
- [x] original/processed/preview download URL 응답 구조 추가
- [x] report/debug artifact 조회 skeleton 추가
- [x] project summary의 `imageCount`를 non-deleted image count로 연결
- [x] local presigned download URL generator skeleton 추가
- [x] API/기능 명세 문서 작성
- [x] entity/service/controller 테스트 추가

## 📁 변경 파일 요약

- `backend-api/src/main/java/com/moonju/preprocess/api/domain/image/...`
- `backend-api/src/main/java/com/moonju/preprocess/api/domain/upload/service/UploadCompleteService.java`
- `backend-api/src/main/java/com/moonju/preprocess/api/domain/project/service/ProjectService.java`
- `backend-api/src/main/java/com/moonju/preprocess/api/infra/storage/PresignedDownload...`
- `backend-api/src/test/java/com/moonju/preprocess/api/domain/image/...`
- `docs/api/image-api.md`
- `docs/feature-specs/issue-33-image-domain.md`

## ✅ 검증 내용

- [x] `docker run --rm -v "${PWD}\\backend-api:/workspace" -w /workspace gradle:8.12.1-jdk21 gradle clean test --no-daemon`: 통과
- [x] `docker run --rm -v "${PWD}\\backend-api:/workspace" -w /workspace gradle:8.12.1-jdk21 gradle build --no-daemon`: 통과
- [x] `git diff --check`: 통과
- [x] secret scan: 실제 Google OAuth secret 미포함 확인

## 🔎 리뷰어가 확인해야 할 부분

- 이 PR은 `#32` Upload 도메인 PR 위에 쌓은 stacked PR입니다. `#32` merge 후 base를 `main`으로 변경해야 합니다.
- 실제 MinIO/S3 presigned download 구현은 아직 local skeleton이며 별도 adapter 작업으로 남겼습니다.
- `processed`, `preview`, `report`, `debug` artifact는 Worker/internal API 작업에서 등록될 예정입니다.

## 💬 기타 공유사항 to 리뷰어

- 이번 작업에서 새로 필요한 환경변수는 없습니다.
- 리뷰 승인 전 merge하지 않습니다.