### PR TITLE
✨ [Feat] Preprocess Preset 도메인 구현

### DIFF
--- a/backend-api/src/main/java/com/moonju/preprocess/api/domain/preprocess/controller/PreprocessPresetController.java
+++ b/backend-api/src/main/java/com/moonju/preprocess/api/domain/preprocess/controller/PreprocessPresetController.java
@@ -1,0 +1,75 @@
+package com.moonju.preprocess.api.domain.preprocess.controller;
+
+import com.moonju.preprocess.api.domain.preprocess.dto.CustomPresetCreateRequest;
+import com.moonju.preprocess.api.domain.preprocess.dto.CustomPresetResponse;
+import com.moonju.preprocess.api.domain.preprocess.dto.PresetDetailResponse;
+import com.moonju.preprocess.api.domain.preprocess.dto.PresetResponse;
+import com.moonju.preprocess.api.domain.preprocess.dto.PresetValidateRequest;
+import com.moonju.preprocess.api.domain.preprocess.dto.PresetValidateResponse;
+import com.moonju.preprocess.api.domain.preprocess.service.CustomPreprocessPresetService;
+import com.moonju.preprocess.api.domain.preprocess.service.PreprocessPresetService;
+import com.moonju.preprocess.api.global.error.ErrorCode;
+import com.moonju.preprocess.api.global.response.ApiResponse;
+import com.moonju.preprocess.api.global.support.CurrentUser;
+import jakarta.validation.Valid;
+import java.util.List;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/preprocess/presets")
+public class PreprocessPresetController {
+
+    private final PreprocessPresetService presetService;
+    private final CustomPreprocessPresetService customPresetService;
+
+    public PreprocessPresetController(
+        PreprocessPresetService presetService,
+        CustomPreprocessPresetService customPresetService
+    ) {
+        this.presetService = presetService;
+        this.customPresetService = customPresetService;
+    }
+
+    @GetMapping
+    public ApiResponse<List<PresetResponse>> findBuiltInPresets() {
+        return ApiResponse.success(presetService.findBuiltInPresets());
+    }
+
+    @GetMapping("/{presetName}")
+    public ApiResponse<PresetDetailResponse> findDetail(@PathVariable String presetName) {
+        return ApiResponse.success(presetService.findDetail(presetName));
+    }
+
+    @PostMapping("/validate")
+    public ApiResponse<PresetValidateResponse> validate(@Valid @RequestBody PresetValidateRequest request) {
+        return ApiResponse.success(presetService.validate(request));
+    }
+
+    @PostMapping("/custom")
+    public ApiResponse<CustomPresetResponse> createCustomPreset(
+        @CurrentUser Long currentUserId,
+        @Valid @RequestBody CustomPresetCreateRequest request
+    ) {
+        return ApiResponse.success(ErrorCode.COMMON_CREATED, customPresetService.create(currentUserId, request));
+    }
+
+    @GetMapping("/custom")
+    public ApiResponse<List<CustomPresetResponse>> findMyCustomPresets(@CurrentUser Long currentUserId) {
+        return ApiResponse.success(customPresetService.findMyPresets(currentUserId));
+    }
+
+    @DeleteMapping("/custom/{presetId}")
+    public ApiResponse<Void> deleteCustomPreset(
+        @CurrentUser Long currentUserId,
+        @PathVariable Long presetId
+    ) {
+        customPresetService.delete(currentUserId, presetId);
+        return ApiResponse.success(ErrorCode.COMMON_NO_CONTENT, null);
+    }
+}

--- a/backend-api/src/main/java/com/moonju/preprocess/api/domain/preprocess/dto/CustomPresetCreateRequest.java
+++ b/backend-api/src/main/java/com/moonju/preprocess/api/domain/preprocess/dto/CustomPresetCreateRequest.java
@@ -1,0 +1,23 @@
+package com.moonju.preprocess.api.domain.preprocess.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import java.util.Map;
+
+public record CustomPresetCreateRequest(
+    @NotBlank
+    @Size(max = 120)
+    String name,
+
+    @Size(max = 1000)
+    String description,
+
+    @NotBlank
+    String basePresetName,
+
+    @NotNull
+    @Size(max = 100)
+    Map<String, String> parameters
+) {
+}

--- a/backend-api/src/main/java/com/moonju/preprocess/api/domain/preprocess/dto/CustomPresetResponse.java
+++ b/backend-api/src/main/java/com/moonju/preprocess/api/domain/preprocess/dto/CustomPresetResponse.java
@@ -1,0 +1,26 @@
+package com.moonju.preprocess.api.domain.preprocess.dto;
+
+import com.moonju.preprocess.api.domain.preprocess.entity.CustomPreprocessPreset;
+import java.time.LocalDateTime;
+import java.util.Map;
+
+public record CustomPresetResponse(
+    Long id,
+    String name,
+    String description,
+    String basePresetName,
+    Map<String, String> parameters,
+    LocalDateTime createdAt
+) {
+
+    public static CustomPresetResponse from(CustomPreprocessPreset preset) {
+        return new CustomPresetResponse(
+            preset.getId(),
+            preset.getName(),
+            preset.getDescription(),
+            preset.getBasePresetName().name(),
+            preset.getParameters(),
+            preset.getCreatedAt()
+        );
+    }
+}

--- a/backend-api/src/main/java/com/moonju/preprocess/api/domain/preprocess/dto/PresetDetailResponse.java
+++ b/backend-api/src/main/java/com/moonju/preprocess/api/domain/preprocess/dto/PresetDetailResponse.java
@@ -1,0 +1,30 @@
+package com.moonju.preprocess.api.domain.preprocess.dto;
+
+import com.moonju.preprocess.api.domain.preprocess.entity.PreprocessPreset;
+import com.moonju.preprocess.api.domain.preprocess.entity.PresetType;
+import java.util.List;
+
+public record PresetDetailResponse(
+    String name,
+    PresetType type,
+    String displayName,
+    String description,
+    boolean supportsDebug,
+    List<String> steps,
+    List<PresetParameterDefinitionResponse> parameters
+) {
+
+    public static PresetDetailResponse from(PreprocessPreset preset) {
+        return new PresetDetailResponse(
+            preset.getName().name(),
+            preset.getType(),
+            preset.getDisplayName(),
+            preset.getDescription(),
+            preset.isSupportsDebug(),
+            preset.getSteps(),
+            preset.getParameters().stream()
+                .map(PresetParameterDefinitionResponse::from)
+                .toList()
+        );
+    }
+}

--- a/backend-api/src/main/java/com/moonju/preprocess/api/domain/preprocess/dto/PresetParameterDefinitionResponse.java
+++ b/backend-api/src/main/java/com/moonju/preprocess/api/domain/preprocess/dto/PresetParameterDefinitionResponse.java
@@ -1,0 +1,30 @@
+package com.moonju.preprocess.api.domain.preprocess.dto;
+
+import com.moonju.preprocess.api.domain.preprocess.entity.PresetParameterDefinition;
+import com.moonju.preprocess.api.domain.preprocess.entity.PresetParameterType;
+import java.util.Set;
+
+public record PresetParameterDefinitionResponse(
+    String name,
+    String description,
+    PresetParameterType type,
+    boolean required,
+    String defaultValue,
+    String minValue,
+    String maxValue,
+    Set<String> allowedValues
+) {
+
+    public static PresetParameterDefinitionResponse from(PresetParameterDefinition definition) {
+        return new PresetParameterDefinitionResponse(
+            definition.name(),
+            definition.description(),
+            definition.type(),
+            definition.required(),
+            definition.defaultValue(),
+            definition.minValue(),
+            definition.maxValue(),
+            definition.allowedValues()
+        );
+    }
+}

--- a/backend-api/src/main/java/com/moonju/preprocess/api/domain/preprocess/dto/PresetResponse.java
+++ b/backend-api/src/main/java/com/moonju/preprocess/api/domain/preprocess/dto/PresetResponse.java
@@ -1,0 +1,23 @@
+package com.moonju.preprocess.api.domain.preprocess.dto;
+
+import com.moonju.preprocess.api.domain.preprocess.entity.PreprocessPreset;
+import com.moonju.preprocess.api.domain.preprocess.entity.PresetType;
+
+public record PresetResponse(
+    String name,
+    PresetType type,
+    String displayName,
+    String description,
+    boolean supportsDebug
+) {
+
+    public static PresetResponse from(PreprocessPreset preset) {
+        return new PresetResponse(
+            preset.getName().name(),
+            preset.getType(),
+            preset.getDisplayName(),
+            preset.getDescription(),
+            preset.isSupportsDebug()
+        );
+    }
+}

--- a/backend-api/src/main/java/com/moonju/preprocess/api/domain/preprocess/dto/PresetValidateRequest.java
+++ b/backend-api/src/main/java/com/moonju/preprocess/api/domain/preprocess/dto/PresetValidateRequest.java
@@ -1,0 +1,16 @@
+package com.moonju.preprocess.api.domain.preprocess.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import java.util.Map;
+
+public record PresetValidateRequest(
+    @NotBlank
+    String presetName,
+
+    @NotNull
+    @Size(max = 100)
+    Map<String, String> parameters
+) {
+}

--- a/backend-api/src/main/java/com/moonju/preprocess/api/domain/preprocess/dto/PresetValidateResponse.java
+++ b/backend-api/src/main/java/com/moonju/preprocess/api/domain/preprocess/dto/PresetValidateResponse.java
@@ -1,0 +1,24 @@
+package com.moonju.preprocess.api.domain.preprocess.dto;
+
+import java.util.List;
+import java.util.Map;
+
+public record PresetValidateResponse(
+    String presetName,
+    boolean valid,
+    List<String> errors,
+    Map<String, String> resolvedParameters
+) {
+
+    public static PresetValidateResponse valid(String presetName, Map<String, String> resolvedParameters) {
+        return new PresetValidateResponse(presetName, true, List.of(), resolvedParameters);
+    }
+
+    public static PresetValidateResponse invalid(
+        String presetName,
+        List<String> errors,
+        Map<String, String> resolvedParameters
+    ) {
+        return new PresetValidateResponse(presetName, false, errors, resolvedParameters);
+    }
+}

--- a/backend-api/src/main/java/com/moonju/preprocess/api/domain/preprocess/entity/CustomPreprocessPreset.java
+++ b/backend-api/src/main/java/com/moonju/preprocess/api/domain/preprocess/entity/CustomPreprocessPreset.java
@@ -1,0 +1,109 @@
+package com.moonju.preprocess.api.domain.preprocess.entity;
+
+import com.moonju.preprocess.api.global.support.BaseEntity;
+import jakarta.persistence.CollectionTable;
+import jakarta.persistence.Column;
+import jakarta.persistence.ElementCollection;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.MapKeyColumn;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+@Entity
+@Table(name = "custom_preprocess_presets")
+public class CustomPreprocessPreset extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private Long userId;
+
+    @Column(nullable = false, length = 120)
+    private String name;
+
+    @Column(length = 1000)
+    private String description;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 50)
+    private PreprocessPresetName basePresetName;
+
+    @ElementCollection
+    @CollectionTable(
+        name = "custom_preprocess_preset_parameters",
+        joinColumns = @JoinColumn(name = "custom_preset_id")
+    )
+    @MapKeyColumn(name = "parameter_name", length = 100)
+    @Column(name = "parameter_value", length = 500)
+    private Map<String, String> parameters = new LinkedHashMap<>();
+
+    @Column(nullable = false)
+    private boolean deleted;
+
+    private LocalDateTime deletedAt;
+
+    protected CustomPreprocessPreset() {
+    }
+
+    public CustomPreprocessPreset(
+        Long userId,
+        String name,
+        String description,
+        PreprocessPresetName basePresetName,
+        Map<String, String> parameters
+    ) {
+        this.userId = userId;
+        this.name = name;
+        this.description = description;
+        this.basePresetName = basePresetName;
+        this.parameters = new LinkedHashMap<>(parameters);
+        this.deleted = false;
+    }
+
+    public void delete() {
+        this.deleted = true;
+        this.deletedAt = LocalDateTime.now();
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public Long getUserId() {
+        return userId;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public PreprocessPresetName getBasePresetName() {
+        return basePresetName;
+    }
+
+    public Map<String, String> getParameters() {
+        return Map.copyOf(parameters);
+    }
+
+    public boolean isDeleted() {
+        return deleted;
+    }
+
+    public LocalDateTime getDeletedAt() {
+        return deletedAt;
+    }
+}

--- a/backend-api/src/main/java/com/moonju/preprocess/api/domain/preprocess/entity/PreprocessPreset.java
+++ b/backend-api/src/main/java/com/moonju/preprocess/api/domain/preprocess/entity/PreprocessPreset.java
@@ -1,0 +1,60 @@
+package com.moonju.preprocess.api.domain.preprocess.entity;
+
+import java.util.List;
+
+public class PreprocessPreset {
+
+    private final PreprocessPresetName name;
+    private final PresetType type;
+    private final String displayName;
+    private final String description;
+    private final boolean supportsDebug;
+    private final List<String> steps;
+    private final List<PresetParameterDefinition> parameters;
+
+    public PreprocessPreset(
+        PreprocessPresetName name,
+        PresetType type,
+        String displayName,
+        String description,
+        boolean supportsDebug,
+        List<String> steps,
+        List<PresetParameterDefinition> parameters
+    ) {
+        this.name = name;
+        this.type = type;
+        this.displayName = displayName;
+        this.description = description;
+        this.supportsDebug = supportsDebug;
+        this.steps = List.copyOf(steps);
+        this.parameters = List.copyOf(parameters);
+    }
+
+    public PreprocessPresetName getName() {
+        return name;
+    }
+
+    public PresetType getType() {
+        return type;
+    }
+
+    public String getDisplayName() {
+        return displayName;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public boolean isSupportsDebug() {
+        return supportsDebug;
+    }
+
+    public List<String> getSteps() {
+        return steps;
+    }
+
+    public List<PresetParameterDefinition> getParameters() {
+        return parameters;
+    }
+}

--- a/backend-api/src/main/java/com/moonju/preprocess/api/domain/preprocess/entity/PreprocessPresetName.java
+++ b/backend-api/src/main/java/com/moonju/preprocess/api/domain/preprocess/entity/PreprocessPresetName.java
@@ -1,0 +1,15 @@
+package com.moonju.preprocess.api.domain.preprocess.entity;
+
+import java.util.Locale;
+
+public enum PreprocessPresetName {
+    A4_SCAN_300DPI,
+    LOW_CONTRAST_SCAN,
+    RECEIPT,
+    NOISY_SCAN,
+    AUTO;
+
+    public static PreprocessPresetName from(String value) {
+        return PreprocessPresetName.valueOf(value.toUpperCase(Locale.ROOT));
+    }
+}

--- a/backend-api/src/main/java/com/moonju/preprocess/api/domain/preprocess/entity/PresetParameterDefinition.java
+++ b/backend-api/src/main/java/com/moonju/preprocess/api/domain/preprocess/entity/PresetParameterDefinition.java
@@ -1,0 +1,87 @@
+package com.moonju.preprocess.api.domain.preprocess.entity;
+
+import java.util.Set;
+
+public record PresetParameterDefinition(
+    String name,
+    String description,
+    PresetParameterType type,
+    boolean required,
+    String defaultValue,
+    String minValue,
+    String maxValue,
+    Set<String> allowedValues
+) {
+
+    public static PresetParameterDefinition integer(
+        String name,
+        String description,
+        boolean required,
+        int defaultValue,
+        int minValue,
+        int maxValue
+    ) {
+        return new PresetParameterDefinition(
+            name,
+            description,
+            PresetParameterType.INTEGER,
+            required,
+            String.valueOf(defaultValue),
+            String.valueOf(minValue),
+            String.valueOf(maxValue),
+            Set.of()
+        );
+    }
+
+    public static PresetParameterDefinition decimal(
+        String name,
+        String description,
+        boolean required,
+        double defaultValue,
+        double minValue,
+        double maxValue
+    ) {
+        return new PresetParameterDefinition(
+            name,
+            description,
+            PresetParameterType.DECIMAL,
+            required,
+            String.valueOf(defaultValue),
+            String.valueOf(minValue),
+            String.valueOf(maxValue),
+            Set.of()
+        );
+    }
+
+    public static PresetParameterDefinition bool(String name, String description, boolean defaultValue) {
+        return new PresetParameterDefinition(
+            name,
+            description,
+            PresetParameterType.BOOLEAN,
+            false,
+            String.valueOf(defaultValue),
+            null,
+            null,
+            Set.of()
+        );
+    }
+
+    public static PresetParameterDefinition option(
+        String name,
+        String description,
+        boolean required,
+        String defaultValue,
+        Set<String> allowedValues
+    ) {
+        return new PresetParameterDefinition(
+            name,
+            description,
+            PresetParameterType.ENUM,
+            required,
+            defaultValue,
+            null,
+            null,
+            allowedValues
+        );
+    }
+}

--- a/backend-api/src/main/java/com/moonju/preprocess/api/domain/preprocess/entity/PresetParameterType.java
+++ b/backend-api/src/main/java/com/moonju/preprocess/api/domain/preprocess/entity/PresetParameterType.java
@@ -1,0 +1,9 @@
+package com.moonju.preprocess.api.domain.preprocess.entity;
+
+public enum PresetParameterType {
+    INTEGER,
+    DECIMAL,
+    BOOLEAN,
+    STRING,
+    ENUM
+}

--- a/backend-api/src/main/java/com/moonju/preprocess/api/domain/preprocess/entity/PresetType.java
+++ b/backend-api/src/main/java/com/moonju/preprocess/api/domain/preprocess/entity/PresetType.java
@@ -1,0 +1,6 @@
+package com.moonju.preprocess.api.domain.preprocess.entity;
+
+public enum PresetType {
+    BUILT_IN,
+    CUSTOM
+}

--- a/backend-api/src/main/java/com/moonju/preprocess/api/domain/preprocess/exception/InvalidPresetParameterException.java
+++ b/backend-api/src/main/java/com/moonju/preprocess/api/domain/preprocess/exception/InvalidPresetParameterException.java
@@ -1,0 +1,11 @@
+package com.moonju.preprocess.api.domain.preprocess.exception;
+
+import com.moonju.preprocess.api.global.error.BusinessException;
+import com.moonju.preprocess.api.global.error.ErrorCode;
+
+public class InvalidPresetParameterException extends BusinessException {
+
+    public InvalidPresetParameterException(String message) {
+        super(ErrorCode.VALIDATION_ERROR, message);
+    }
+}

--- a/backend-api/src/main/java/com/moonju/preprocess/api/domain/preprocess/exception/PresetNotFoundException.java
+++ b/backend-api/src/main/java/com/moonju/preprocess/api/domain/preprocess/exception/PresetNotFoundException.java
@@ -1,0 +1,11 @@
+package com.moonju.preprocess.api.domain.preprocess.exception;
+
+import com.moonju.preprocess.api.global.error.BusinessException;
+import com.moonju.preprocess.api.global.error.ErrorCode;
+
+public class PresetNotFoundException extends BusinessException {
+
+    public PresetNotFoundException() {
+        super(ErrorCode.COMMON_NOT_FOUND, "Preprocess preset not found.");
+    }
+}

--- a/backend-api/src/main/java/com/moonju/preprocess/api/domain/preprocess/repository/CustomPreprocessPresetRepository.java
+++ b/backend-api/src/main/java/com/moonju/preprocess/api/domain/preprocess/repository/CustomPreprocessPresetRepository.java
@@ -1,0 +1,13 @@
+package com.moonju.preprocess.api.domain.preprocess.repository;
+
+import com.moonju.preprocess.api.domain.preprocess.entity.CustomPreprocessPreset;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CustomPreprocessPresetRepository extends JpaRepository<CustomPreprocessPreset, Long> {
+
+    List<CustomPreprocessPreset> findAllByUserIdAndDeletedFalseOrderByIdDesc(Long userId);
+
+    Optional<CustomPreprocessPreset> findByIdAndUserIdAndDeletedFalse(Long id, Long userId);
+}

--- a/backend-api/src/main/java/com/moonju/preprocess/api/domain/preprocess/service/CustomPreprocessPresetService.java
+++ b/backend-api/src/main/java/com/moonju/preprocess/api/domain/preprocess/service/CustomPreprocessPresetService.java
@@ -1,0 +1,82 @@
+package com.moonju.preprocess.api.domain.preprocess.service;
+
+import com.moonju.preprocess.api.domain.preprocess.dto.CustomPresetCreateRequest;
+import com.moonju.preprocess.api.domain.preprocess.dto.CustomPresetResponse;
+import com.moonju.preprocess.api.domain.preprocess.dto.PresetValidateResponse;
+import com.moonju.preprocess.api.domain.preprocess.entity.CustomPreprocessPreset;
+import com.moonju.preprocess.api.domain.preprocess.entity.PreprocessPreset;
+import com.moonju.preprocess.api.domain.preprocess.entity.PreprocessPresetName;
+import com.moonju.preprocess.api.domain.preprocess.exception.InvalidPresetParameterException;
+import com.moonju.preprocess.api.domain.preprocess.exception.PresetNotFoundException;
+import com.moonju.preprocess.api.domain.preprocess.repository.CustomPreprocessPresetRepository;
+import java.util.List;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+
+@Service
+public class CustomPreprocessPresetService {
+
+    private final CustomPreprocessPresetRepository customPresetRepository;
+    private final PreprocessPresetRegistry presetRegistry;
+    private final PreprocessParameterValidator parameterValidator;
+
+    public CustomPreprocessPresetService(
+        CustomPreprocessPresetRepository customPresetRepository,
+        PreprocessPresetRegistry presetRegistry,
+        PreprocessParameterValidator parameterValidator
+    ) {
+        this.customPresetRepository = customPresetRepository;
+        this.presetRegistry = presetRegistry;
+        this.parameterValidator = parameterValidator;
+    }
+
+    @Transactional
+    public CustomPresetResponse create(Long currentUserId, CustomPresetCreateRequest request) {
+        PreprocessPreset basePreset = presetRegistry.findByName(request.basePresetName());
+        PresetValidateResponse validation = parameterValidator.validate(basePreset, request.parameters());
+        if (!validation.valid()) {
+            throw new InvalidPresetParameterException(String.join(", ", validation.errors()));
+        }
+
+        CustomPreprocessPreset customPreset = customPresetRepository.save(new CustomPreprocessPreset(
+            currentUserId,
+            normalizeName(request.name()),
+            request.description(),
+            parseBasePresetName(request.basePresetName()),
+            validation.resolvedParameters()
+        ));
+        return CustomPresetResponse.from(customPreset);
+    }
+
+    @Transactional(readOnly = true)
+    public List<CustomPresetResponse> findMyPresets(Long currentUserId) {
+        return customPresetRepository.findAllByUserIdAndDeletedFalseOrderByIdDesc(currentUserId)
+            .stream()
+            .map(CustomPresetResponse::from)
+            .toList();
+    }
+
+    @Transactional
+    public void delete(Long currentUserId, Long presetId) {
+        CustomPreprocessPreset preset = customPresetRepository
+            .findByIdAndUserIdAndDeletedFalse(presetId, currentUserId)
+            .orElseThrow(PresetNotFoundException::new);
+        preset.delete();
+    }
+
+    private String normalizeName(String name) {
+        if (!StringUtils.hasText(name)) {
+            throw new InvalidPresetParameterException("Custom preset name must not be blank.");
+        }
+        return name.trim();
+    }
+
+    private PreprocessPresetName parseBasePresetName(String basePresetName) {
+        try {
+            return PreprocessPresetName.from(basePresetName);
+        } catch (IllegalArgumentException exception) {
+            throw new PresetNotFoundException();
+        }
+    }
+}

--- a/backend-api/src/main/java/com/moonju/preprocess/api/domain/preprocess/service/PreprocessParameterValidator.java
+++ b/backend-api/src/main/java/com/moonju/preprocess/api/domain/preprocess/service/PreprocessParameterValidator.java
@@ -1,0 +1,111 @@
+package com.moonju.preprocess.api.domain.preprocess.service;
+
+import com.moonju.preprocess.api.domain.preprocess.dto.PresetValidateResponse;
+import com.moonju.preprocess.api.domain.preprocess.entity.PreprocessPreset;
+import com.moonju.preprocess.api.domain.preprocess.entity.PresetParameterDefinition;
+import com.moonju.preprocess.api.domain.preprocess.entity.PresetParameterType;
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+
+@Service
+public class PreprocessParameterValidator {
+
+    public PresetValidateResponse validate(PreprocessPreset preset, Map<String, String> requestedParameters) {
+        List<String> errors = new ArrayList<>();
+        Map<String, String> resolvedParameters = new LinkedHashMap<>();
+        Set<String> knownParameterNames = preset.getParameters()
+            .stream()
+            .map(PresetParameterDefinition::name)
+            .collect(Collectors.toSet());
+
+        for (String requestedName : requestedParameters.keySet()) {
+            if (!knownParameterNames.contains(requestedName)) {
+                errors.add("Unknown parameter: " + requestedName);
+            }
+        }
+
+        for (PresetParameterDefinition definition : preset.getParameters()) {
+            String value = requestedParameters.get(definition.name());
+            if (!StringUtils.hasText(value)) {
+                if (definition.required() && !StringUtils.hasText(definition.defaultValue())) {
+                    errors.add("Required parameter is missing: " + definition.name());
+                    continue;
+                }
+                if (StringUtils.hasText(definition.defaultValue())) {
+                    resolvedParameters.put(definition.name(), definition.defaultValue());
+                }
+                continue;
+            }
+            validateValue(definition, value, errors);
+            resolvedParameters.put(definition.name(), value);
+        }
+
+        if (errors.isEmpty()) {
+            return PresetValidateResponse.valid(preset.getName().name(), resolvedParameters);
+        }
+        return PresetValidateResponse.invalid(preset.getName().name(), errors, resolvedParameters);
+    }
+
+    private void validateValue(PresetParameterDefinition definition, String value, List<String> errors) {
+        if (definition.type() == PresetParameterType.INTEGER) {
+            validateInteger(definition, value, errors);
+            return;
+        }
+        if (definition.type() == PresetParameterType.DECIMAL) {
+            validateDecimal(definition, value, errors);
+            return;
+        }
+        if (definition.type() == PresetParameterType.BOOLEAN) {
+            validateBoolean(definition, value, errors);
+            return;
+        }
+        if (definition.type() == PresetParameterType.ENUM) {
+            validateEnum(definition, value, errors);
+        }
+    }
+
+    private void validateInteger(PresetParameterDefinition definition, String value, List<String> errors) {
+        try {
+            int parsed = Integer.parseInt(value);
+            if (parsed < Integer.parseInt(definition.minValue()) || parsed > Integer.parseInt(definition.maxValue())) {
+                errors.add(definition.name() + " must be between " + definition.minValue() + " and "
+                    + definition.maxValue() + ".");
+            }
+        } catch (NumberFormatException exception) {
+            errors.add(definition.name() + " must be an integer.");
+        }
+    }
+
+    private void validateDecimal(PresetParameterDefinition definition, String value, List<String> errors) {
+        try {
+            BigDecimal parsed = new BigDecimal(value);
+            BigDecimal min = new BigDecimal(definition.minValue());
+            BigDecimal max = new BigDecimal(definition.maxValue());
+            if (parsed.compareTo(min) < 0 || parsed.compareTo(max) > 0) {
+                errors.add(definition.name() + " must be between " + definition.minValue() + " and "
+                    + definition.maxValue() + ".");
+            }
+        } catch (NumberFormatException exception) {
+            errors.add(definition.name() + " must be a decimal.");
+        }
+    }
+
+    private void validateBoolean(PresetParameterDefinition definition, String value, List<String> errors) {
+        if (!"true".equalsIgnoreCase(value) && !"false".equalsIgnoreCase(value)) {
+            errors.add(definition.name() + " must be true or false.");
+        }
+    }
+
+    private void validateEnum(PresetParameterDefinition definition, String value, List<String> errors) {
+        if (!definition.allowedValues().contains(value)) {
+            errors.add(definition.name() + " must be one of " + definition.allowedValues() + ".");
+        }
+    }
+}

--- a/backend-api/src/main/java/com/moonju/preprocess/api/domain/preprocess/service/PreprocessPresetRegistry.java
+++ b/backend-api/src/main/java/com/moonju/preprocess/api/domain/preprocess/service/PreprocessPresetRegistry.java
@@ -1,0 +1,164 @@
+package com.moonju.preprocess.api.domain.preprocess.service;
+
+import com.moonju.preprocess.api.domain.preprocess.entity.PreprocessPreset;
+import com.moonju.preprocess.api.domain.preprocess.entity.PreprocessPresetName;
+import com.moonju.preprocess.api.domain.preprocess.entity.PresetParameterDefinition;
+import com.moonju.preprocess.api.domain.preprocess.entity.PresetType;
+import com.moonju.preprocess.api.domain.preprocess.exception.PresetNotFoundException;
+import java.util.EnumMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.springframework.stereotype.Component;
+
+@Component
+public class PreprocessPresetRegistry {
+
+    private static final List<String> DOCUMENT_PIPELINE_STEPS = List.of(
+        "DECODE",
+        "COLOR_NORMALIZE",
+        "ORIENTATION_NORMALIZE",
+        "DESKEW",
+        "CROP",
+        "DENOISE",
+        "CONTRAST_NORMALIZE",
+        "BINARIZATION",
+        "MORPHOLOGY_CLEANUP",
+        "DPI_NORMALIZE",
+        "OPTIONAL_SHARPEN"
+    );
+
+    private final Map<PreprocessPresetName, PreprocessPreset> presets;
+
+    public PreprocessPresetRegistry() {
+        this.presets = new EnumMap<>(PreprocessPresetName.class);
+        registerBuiltInPresets();
+    }
+
+    public List<PreprocessPreset> findAll() {
+        return List.copyOf(presets.values());
+    }
+
+    public PreprocessPreset findByName(String presetName) {
+        try {
+            return findByName(PreprocessPresetName.from(presetName));
+        } catch (IllegalArgumentException exception) {
+            throw new PresetNotFoundException();
+        }
+    }
+
+    public PreprocessPreset findByName(PreprocessPresetName presetName) {
+        PreprocessPreset preset = presets.get(presetName);
+        if (preset == null) {
+            throw new PresetNotFoundException();
+        }
+        return preset;
+    }
+
+    private void registerBuiltInPresets() {
+        register(new PreprocessPreset(
+            PreprocessPresetName.A4_SCAN_300DPI,
+            PresetType.BUILT_IN,
+            "A4 300 DPI scan",
+            "General A4 document scan preset for OCR preprocessing.",
+            true,
+            DOCUMENT_PIPELINE_STEPS,
+            commonParameters(300, "otsu", 1.2, false)
+        ));
+        register(new PreprocessPreset(
+            PreprocessPresetName.LOW_CONTRAST_SCAN,
+            PresetType.BUILT_IN,
+            "Low contrast scan",
+            "Improves low contrast scans using stronger contrast normalization before binarization.",
+            true,
+            DOCUMENT_PIPELINE_STEPS,
+            commonParameters(300, "adaptive", 1.6, true)
+        ));
+        register(new PreprocessPreset(
+            PreprocessPresetName.RECEIPT,
+            PresetType.BUILT_IN,
+            "Receipt",
+            "Narrow receipt-like document preset with adaptive thresholding and light morphology cleanup.",
+            true,
+            DOCUMENT_PIPELINE_STEPS,
+            commonParameters(300, "adaptive", 1.4, true)
+        ));
+        register(new PreprocessPreset(
+            PreprocessPresetName.NOISY_SCAN,
+            PresetType.BUILT_IN,
+            "Noisy scan",
+            "Preset for scans with strong background noise and more aggressive denoise settings.",
+            true,
+            DOCUMENT_PIPELINE_STEPS,
+            commonParameters(300, "adaptive", 1.5, false)
+        ));
+        register(new PreprocessPreset(
+            PreprocessPresetName.AUTO,
+            PresetType.BUILT_IN,
+            "Auto",
+            "Delegates preset selection to the worker based on image characteristics.",
+            true,
+            List.of("DECODE", "COLOR_NORMALIZE", "AUTO_PRESET_SELECT", "RUN_SELECTED_PIPELINE"),
+            List.of(PresetParameterDefinition.bool(
+                "debugArtifacts",
+                "Whether worker should save intermediate debug artifacts.",
+                false
+            ))
+        ));
+    }
+
+    private void register(PreprocessPreset preset) {
+        presets.put(preset.getName(), preset);
+    }
+
+    private List<PresetParameterDefinition> commonParameters(
+        int targetDpi,
+        String binarizationMode,
+        double contrastClipLimit,
+        boolean sharpen
+    ) {
+        return List.of(
+            PresetParameterDefinition.integer(
+                "targetDpi",
+                "Target DPI for OCR-oriented DPI normalization.",
+                true,
+                targetDpi,
+                150,
+                600
+            ),
+            PresetParameterDefinition.decimal(
+                "maxDeskewAngle",
+                "Maximum allowed deskew correction angle in degrees.",
+                true,
+                40.0,
+                0.0,
+                45.0
+            ),
+            PresetParameterDefinition.option(
+                "binarizationMode",
+                "Binarization strategy used by the worker.",
+                true,
+                binarizationMode,
+                Set.of("otsu", "adaptive")
+            ),
+            PresetParameterDefinition.decimal(
+                "contrastClipLimit",
+                "CLAHE-like contrast normalization strength.",
+                true,
+                contrastClipLimit,
+                1.0,
+                4.0
+            ),
+            PresetParameterDefinition.bool(
+                "sharpen",
+                "Whether optional sharpen step should run after DPI normalization.",
+                sharpen
+            ),
+            PresetParameterDefinition.bool(
+                "debugArtifacts",
+                "Whether worker should save intermediate debug artifacts.",
+                false
+            )
+        );
+    }
+}

--- a/backend-api/src/main/java/com/moonju/preprocess/api/domain/preprocess/service/PreprocessPresetService.java
+++ b/backend-api/src/main/java/com/moonju/preprocess/api/domain/preprocess/service/PreprocessPresetService.java
@@ -1,0 +1,44 @@
+package com.moonju.preprocess.api.domain.preprocess.service;
+
+import com.moonju.preprocess.api.domain.preprocess.dto.PresetDetailResponse;
+import com.moonju.preprocess.api.domain.preprocess.dto.PresetResponse;
+import com.moonju.preprocess.api.domain.preprocess.dto.PresetValidateRequest;
+import com.moonju.preprocess.api.domain.preprocess.dto.PresetValidateResponse;
+import com.moonju.preprocess.api.domain.preprocess.entity.PreprocessPreset;
+import java.util.List;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class PreprocessPresetService {
+
+    private final PreprocessPresetRegistry presetRegistry;
+    private final PreprocessParameterValidator parameterValidator;
+
+    public PreprocessPresetService(
+        PreprocessPresetRegistry presetRegistry,
+        PreprocessParameterValidator parameterValidator
+    ) {
+        this.presetRegistry = presetRegistry;
+        this.parameterValidator = parameterValidator;
+    }
+
+    @Transactional(readOnly = true)
+    public List<PresetResponse> findBuiltInPresets() {
+        return presetRegistry.findAll()
+            .stream()
+            .map(PresetResponse::from)
+            .toList();
+    }
+
+    @Transactional(readOnly = true)
+    public PresetDetailResponse findDetail(String presetName) {
+        return PresetDetailResponse.from(presetRegistry.findByName(presetName));
+    }
+
+    @Transactional(readOnly = true)
+    public PresetValidateResponse validate(PresetValidateRequest request) {
+        PreprocessPreset preset = presetRegistry.findByName(request.presetName());
+        return parameterValidator.validate(preset, request.parameters());
+    }
+}

--- a/backend-api/src/test/java/com/moonju/preprocess/api/domain/preprocess/controller/PreprocessPresetControllerTests.java
+++ b/backend-api/src/test/java/com/moonju/preprocess/api/domain/preprocess/controller/PreprocessPresetControllerTests.java
@@ -1,0 +1,63 @@
+package com.moonju.preprocess.api.domain.preprocess.controller;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.moonju.preprocess.api.domain.preprocess.dto.CustomPresetCreateRequest;
+import com.moonju.preprocess.api.domain.preprocess.dto.CustomPresetResponse;
+import com.moonju.preprocess.api.domain.preprocess.service.CustomPreprocessPresetService;
+import com.moonju.preprocess.api.domain.preprocess.service.PreprocessPresetService;
+import com.moonju.preprocess.api.global.response.ApiResponse;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class PreprocessPresetControllerTests {
+
+    @Mock
+    private PreprocessPresetService presetService;
+
+    @Mock
+    private CustomPreprocessPresetService customPresetService;
+
+    @Test
+    void createsCustomPresetWithCommonCreatedResponse() {
+        PreprocessPresetController controller = new PreprocessPresetController(presetService, customPresetService);
+        CustomPresetCreateRequest request = new CustomPresetCreateRequest(
+            "Low contrast",
+            null,
+            "LOW_CONTRAST_SCAN",
+            Map.of("targetDpi", "300")
+        );
+        CustomPresetResponse serviceResponse = new CustomPresetResponse(
+            10L,
+            "Low contrast",
+            null,
+            "LOW_CONTRAST_SCAN",
+            Map.of("targetDpi", "300"),
+            null
+        );
+        when(customPresetService.create(1L, request)).thenReturn(serviceResponse);
+
+        ApiResponse<CustomPresetResponse> response = controller.createCustomPreset(1L, request);
+
+        assertThat(response.isSuccess()).isTrue();
+        assertThat(response.code()).isEqualTo("common201");
+        assertThat(response.result()).isSameAs(serviceResponse);
+    }
+
+    @Test
+    void deletesCustomPresetWithCommonNoContentResponse() {
+        PreprocessPresetController controller = new PreprocessPresetController(presetService, customPresetService);
+
+        ApiResponse<Void> response = controller.deleteCustomPreset(1L, 10L);
+
+        assertThat(response.isSuccess()).isTrue();
+        assertThat(response.code()).isEqualTo("common204");
+        verify(customPresetService).delete(1L, 10L);
+    }
+}

--- a/backend-api/src/test/java/com/moonju/preprocess/api/domain/preprocess/entity/CustomPreprocessPresetTests.java
+++ b/backend-api/src/test/java/com/moonju/preprocess/api/domain/preprocess/entity/CustomPreprocessPresetTests.java
@@ -1,0 +1,41 @@
+package com.moonju.preprocess.api.domain.preprocess.entity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class CustomPreprocessPresetTests {
+
+    @Test
+    void createsCustomPresetFromBasePreset() {
+        CustomPreprocessPreset preset = new CustomPreprocessPreset(
+            1L,
+            "Library low contrast",
+            "For old scans",
+            PreprocessPresetName.LOW_CONTRAST_SCAN,
+            Map.of("targetDpi", "300")
+        );
+
+        assertThat(preset.getUserId()).isEqualTo(1L);
+        assertThat(preset.getBasePresetName()).isEqualTo(PreprocessPresetName.LOW_CONTRAST_SCAN);
+        assertThat(preset.getParameters()).containsEntry("targetDpi", "300");
+        assertThat(preset.isDeleted()).isFalse();
+    }
+
+    @Test
+    void softDeletesCustomPreset() {
+        CustomPreprocessPreset preset = new CustomPreprocessPreset(
+            1L,
+            "Library low contrast",
+            "For old scans",
+            PreprocessPresetName.LOW_CONTRAST_SCAN,
+            Map.of("targetDpi", "300")
+        );
+
+        preset.delete();
+
+        assertThat(preset.isDeleted()).isTrue();
+        assertThat(preset.getDeletedAt()).isNotNull();
+    }
+}

--- a/backend-api/src/test/java/com/moonju/preprocess/api/domain/preprocess/service/CustomPreprocessPresetServiceTests.java
+++ b/backend-api/src/test/java/com/moonju/preprocess/api/domain/preprocess/service/CustomPreprocessPresetServiceTests.java
@@ -1,0 +1,106 @@
+package com.moonju.preprocess.api.domain.preprocess.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.moonju.preprocess.api.domain.preprocess.dto.CustomPresetCreateRequest;
+import com.moonju.preprocess.api.domain.preprocess.dto.CustomPresetResponse;
+import com.moonju.preprocess.api.domain.preprocess.entity.CustomPreprocessPreset;
+import com.moonju.preprocess.api.domain.preprocess.entity.PreprocessPresetName;
+import com.moonju.preprocess.api.domain.preprocess.exception.InvalidPresetParameterException;
+import com.moonju.preprocess.api.domain.preprocess.repository.CustomPreprocessPresetRepository;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+class CustomPreprocessPresetServiceTests {
+
+    @Mock
+    private CustomPreprocessPresetRepository customPresetRepository;
+
+    private final PreprocessPresetRegistry presetRegistry = new PreprocessPresetRegistry();
+
+    private final PreprocessParameterValidator parameterValidator = new PreprocessParameterValidator();
+
+    private CustomPreprocessPresetService service;
+
+    @Test
+    void createsCustomPresetWithValidatedParameters() {
+        service = new CustomPreprocessPresetService(customPresetRepository, presetRegistry, parameterValidator);
+        when(customPresetRepository.save(any(CustomPreprocessPreset.class))).thenAnswer(invocation -> {
+            CustomPreprocessPreset preset = invocation.getArgument(0);
+            ReflectionTestUtils.setField(preset, "id", 10L);
+            return preset;
+        });
+
+        CustomPresetResponse response = service.create(1L, new CustomPresetCreateRequest(
+            " Low contrast ",
+            "For old scans",
+            "LOW_CONTRAST_SCAN",
+            Map.of("targetDpi", "300")
+        ));
+
+        assertThat(response.id()).isEqualTo(10L);
+        assertThat(response.name()).isEqualTo("Low contrast");
+        assertThat(response.parameters()).containsEntry("targetDpi", "300");
+    }
+
+    @Test
+    void rejectsInvalidCustomPresetParameters() {
+        service = new CustomPreprocessPresetService(customPresetRepository, presetRegistry, parameterValidator);
+
+        assertThatThrownBy(() -> service.create(1L, new CustomPresetCreateRequest(
+            "Invalid",
+            null,
+            "A4_SCAN_300DPI",
+            Map.of("targetDpi", "1000")
+        )))
+            .isInstanceOf(InvalidPresetParameterException.class)
+            .hasMessageContaining("targetDpi must be between 150 and 600");
+    }
+
+    @Test
+    void listsMyCustomPresets() {
+        service = new CustomPreprocessPresetService(customPresetRepository, presetRegistry, parameterValidator);
+        CustomPreprocessPreset preset = preset(10L);
+        when(customPresetRepository.findAllByUserIdAndDeletedFalseOrderByIdDesc(1L)).thenReturn(List.of(preset));
+
+        List<CustomPresetResponse> responses = service.findMyPresets(1L);
+
+        assertThat(responses).hasSize(1);
+        assertThat(responses.getFirst().id()).isEqualTo(10L);
+    }
+
+    @Test
+    void softDeletesMyCustomPreset() {
+        service = new CustomPreprocessPresetService(customPresetRepository, presetRegistry, parameterValidator);
+        CustomPreprocessPreset preset = preset(10L);
+        when(customPresetRepository.findByIdAndUserIdAndDeletedFalse(10L, 1L)).thenReturn(Optional.of(preset));
+
+        service.delete(1L, 10L);
+
+        assertThat(preset.isDeleted()).isTrue();
+        verify(customPresetRepository).findByIdAndUserIdAndDeletedFalse(10L, 1L);
+    }
+
+    private CustomPreprocessPreset preset(Long id) {
+        CustomPreprocessPreset preset = new CustomPreprocessPreset(
+            1L,
+            "Low contrast",
+            "For old scans",
+            PreprocessPresetName.LOW_CONTRAST_SCAN,
+            Map.of("targetDpi", "300")
+        );
+        ReflectionTestUtils.setField(preset, "id", id);
+        return preset;
+    }
+}

--- a/backend-api/src/test/java/com/moonju/preprocess/api/domain/preprocess/service/PreprocessParameterValidatorTests.java
+++ b/backend-api/src/test/java/com/moonju/preprocess/api/domain/preprocess/service/PreprocessParameterValidatorTests.java
@@ -1,0 +1,54 @@
+package com.moonju.preprocess.api.domain.preprocess.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.moonju.preprocess.api.domain.preprocess.dto.PresetValidateResponse;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class PreprocessParameterValidatorTests {
+
+    private final PreprocessPresetRegistry registry = new PreprocessPresetRegistry();
+    private final PreprocessParameterValidator validator = new PreprocessParameterValidator();
+
+    @Test
+    void resolvesDefaultParametersWhenRequestIsEmpty() {
+        PresetValidateResponse response = validator.validate(
+            registry.findByName("A4_SCAN_300DPI"),
+            Map.of()
+        );
+
+        assertThat(response.valid()).isTrue();
+        assertThat(response.resolvedParameters())
+            .containsEntry("targetDpi", "300")
+            .containsEntry("binarizationMode", "otsu")
+            .containsEntry("debugArtifacts", "false");
+    }
+
+    @Test
+    void rejectsOutOfRangeAndUnknownParameters() {
+        PresetValidateResponse response = validator.validate(
+            registry.findByName("A4_SCAN_300DPI"),
+            Map.of(
+                "targetDpi", "1000",
+                "unknown", "value"
+            )
+        );
+
+        assertThat(response.valid()).isFalse();
+        assertThat(response.errors())
+            .contains("Unknown parameter: unknown")
+            .contains("targetDpi must be between 150 and 600.");
+    }
+
+    @Test
+    void rejectsInvalidEnumValue() {
+        PresetValidateResponse response = validator.validate(
+            registry.findByName("LOW_CONTRAST_SCAN"),
+            Map.of("binarizationMode", "global")
+        );
+
+        assertThat(response.valid()).isFalse();
+        assertThat(response.errors().getFirst()).contains("binarizationMode must be one of");
+    }
+}

--- a/backend-api/src/test/java/com/moonju/preprocess/api/domain/preprocess/service/PreprocessPresetRegistryTests.java
+++ b/backend-api/src/test/java/com/moonju/preprocess/api/domain/preprocess/service/PreprocessPresetRegistryTests.java
@@ -1,0 +1,38 @@
+package com.moonju.preprocess.api.domain.preprocess.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.moonju.preprocess.api.domain.preprocess.entity.PreprocessPresetName;
+import com.moonju.preprocess.api.domain.preprocess.exception.PresetNotFoundException;
+import org.junit.jupiter.api.Test;
+
+class PreprocessPresetRegistryTests {
+
+    private final PreprocessPresetRegistry registry = new PreprocessPresetRegistry();
+
+    @Test
+    void providesRequiredBuiltInPresets() {
+        assertThat(registry.findAll())
+            .extracting(preset -> preset.getName().name())
+            .containsExactly(
+                "A4_SCAN_300DPI",
+                "LOW_CONTRAST_SCAN",
+                "RECEIPT",
+                "NOISY_SCAN",
+                "AUTO"
+            );
+    }
+
+    @Test
+    void findsPresetByCaseInsensitiveName() {
+        assertThat(registry.findByName("low_contrast_scan").getName())
+            .isEqualTo(PreprocessPresetName.LOW_CONTRAST_SCAN);
+    }
+
+    @Test
+    void rejectsUnknownPresetName() {
+        assertThatThrownBy(() -> registry.findByName("resize_only"))
+            .isInstanceOf(PresetNotFoundException.class);
+    }
+}

--- a/backend-api/src/test/java/com/moonju/preprocess/api/domain/preprocess/service/PreprocessPresetServiceTests.java
+++ b/backend-api/src/test/java/com/moonju/preprocess/api/domain/preprocess/service/PreprocessPresetServiceTests.java
@@ -1,0 +1,46 @@
+package com.moonju.preprocess.api.domain.preprocess.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.moonju.preprocess.api.domain.preprocess.dto.PresetDetailResponse;
+import com.moonju.preprocess.api.domain.preprocess.dto.PresetResponse;
+import com.moonju.preprocess.api.domain.preprocess.dto.PresetValidateRequest;
+import com.moonju.preprocess.api.domain.preprocess.dto.PresetValidateResponse;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class PreprocessPresetServiceTests {
+
+    private final PreprocessPresetService service = new PreprocessPresetService(
+        new PreprocessPresetRegistry(),
+        new PreprocessParameterValidator()
+    );
+
+    @Test
+    void listsBuiltInPresets() {
+        List<PresetResponse> responses = service.findBuiltInPresets();
+
+        assertThat(responses).hasSize(5);
+        assertThat(responses).extracting(PresetResponse::name).contains("NOISY_SCAN", "AUTO");
+    }
+
+    @Test
+    void findsPresetDetailWithDocumentPipelineSteps() {
+        PresetDetailResponse response = service.findDetail("A4_SCAN_300DPI");
+
+        assertThat(response.steps()).contains("DESKEW", "DPI_NORMALIZE", "OPTIONAL_SHARPEN");
+        assertThat(response.parameters()).extracting(parameter -> parameter.name()).contains("targetDpi");
+    }
+
+    @Test
+    void validatesPresetParameters() {
+        PresetValidateResponse response = service.validate(new PresetValidateRequest(
+            "RECEIPT",
+            Map.of("targetDpi", "300", "sharpen", "true")
+        ));
+
+        assertThat(response.valid()).isTrue();
+        assertThat(response.resolvedParameters()).containsEntry("targetDpi", "300");
+    }
+}

--- a/docs/api/preprocess-preset-api.md
+++ b/docs/api/preprocess-preset-api.md
@@ -1,0 +1,165 @@
+# Preprocess Preset API
+
+## Purpose
+
+Preprocess Preset API exposes the preprocessing parameter contract shared by the API server, Job creation flow, and
+Worker. The API server validates preset names and parameters, but it does not execute OpenCV image preprocessing.
+
+## Rules
+
+- Built-in preset names must match Worker preset names.
+- API server validates parameter shape and range before a Job is created.
+- API server must not perform document preprocessing directly.
+- Presets describe OCR-oriented document preprocessing, not simple thumbnail resizing.
+- Custom presets are user-owned skeleton records derived from a built-in preset.
+
+## Built-In Presets
+
+| Name | Purpose |
+| --- | --- |
+| `A4_SCAN_300DPI` | General A4 document scan preset |
+| `LOW_CONTRAST_SCAN` | Low contrast scan preset with stronger contrast normalization |
+| `RECEIPT` | Narrow receipt-like document preset |
+| `NOISY_SCAN` | Strong background noise scan preset |
+| `AUTO` | Worker-side preset selection based on image characteristics |
+
+## Endpoints
+
+| Method | Path | Purpose |
+| --- | --- | --- |
+| `GET` | `/api/v1/preprocess/presets` | List built-in presets |
+| `GET` | `/api/v1/preprocess/presets/{presetName}` | Read built-in preset detail |
+| `POST` | `/api/v1/preprocess/presets/validate` | Validate preset parameters |
+| `POST` | `/api/v1/preprocess/presets/custom` | Create custom preset |
+| `GET` | `/api/v1/preprocess/presets/custom` | List my custom presets |
+| `DELETE` | `/api/v1/preprocess/presets/custom/{presetId}` | Delete my custom preset |
+
+## List Built-In Presets
+
+Response:
+
+```json
+{
+  "isSuccess": true,
+  "code": "common200",
+  "message": "Request succeeded.",
+  "result": [
+    {
+      "name": "A4_SCAN_300DPI",
+      "type": "BUILT_IN",
+      "displayName": "A4 300 DPI scan",
+      "description": "General A4 document scan preset for OCR preprocessing.",
+      "supportsDebug": true
+    }
+  ]
+}
+```
+
+## Preset Detail
+
+Response:
+
+```json
+{
+  "isSuccess": true,
+  "code": "common200",
+  "message": "Request succeeded.",
+  "result": {
+    "name": "LOW_CONTRAST_SCAN",
+    "type": "BUILT_IN",
+    "displayName": "Low contrast scan",
+    "description": "Improves low contrast scans using stronger contrast normalization before binarization.",
+    "supportsDebug": true,
+    "steps": [
+      "DECODE",
+      "COLOR_NORMALIZE",
+      "ORIENTATION_NORMALIZE",
+      "DESKEW",
+      "CROP",
+      "DENOISE",
+      "CONTRAST_NORMALIZE",
+      "BINARIZATION",
+      "MORPHOLOGY_CLEANUP",
+      "DPI_NORMALIZE",
+      "OPTIONAL_SHARPEN"
+    ],
+    "parameters": [
+      {
+        "name": "targetDpi",
+        "type": "INTEGER",
+        "required": true,
+        "defaultValue": "300",
+        "minValue": "150",
+        "maxValue": "600",
+        "allowedValues": []
+      }
+    ]
+  }
+}
+```
+
+## Validate Parameters
+
+Request:
+
+```json
+{
+  "presetName": "A4_SCAN_300DPI",
+  "parameters": {
+    "targetDpi": "300",
+    "binarizationMode": "otsu",
+    "debugArtifacts": "false"
+  }
+}
+```
+
+Response:
+
+```json
+{
+  "isSuccess": true,
+  "code": "common200",
+  "message": "Request succeeded.",
+  "result": {
+    "presetName": "A4_SCAN_300DPI",
+    "valid": true,
+    "errors": [],
+    "resolvedParameters": {
+      "targetDpi": "300",
+      "maxDeskewAngle": "40.0",
+      "binarizationMode": "otsu",
+      "contrastClipLimit": "1.2",
+      "sharpen": "false",
+      "debugArtifacts": "false"
+    }
+  }
+}
+```
+
+Invalid parameter values return `valid=false` with error messages in `result.errors`; unknown preset names return a
+normal API error response.
+
+## Custom Presets
+
+Create request:
+
+```json
+{
+  "name": "Library low contrast",
+  "description": "For old book scans",
+  "basePresetName": "LOW_CONTRAST_SCAN",
+  "parameters": {
+    "targetDpi": "300",
+    "contrastClipLimit": "1.8"
+  }
+}
+```
+
+Custom presets are currently a backend skeleton. Job creation and Worker execution will connect custom presets in a
+later task.
+
+## Next Work
+
+- Connect Job creation to preset validation.
+- Add Worker internal preset lookup endpoint.
+- Connect Worker preset registry to this API contract.

--- a/docs/feature-specs/issue-37-preprocess-preset.md
+++ b/docs/feature-specs/issue-37-preprocess-preset.md
@@ -1,0 +1,67 @@
+# Issue 37. Preprocess Preset Domain
+
+## Goal
+
+Implement the backend preset contract used by future Job creation and Worker execution. The API server owns preset
+metadata and validation. Actual OpenCV processing remains Worker responsibility.
+
+## Overall Order
+
+1. Define shared built-in preset names.
+2. Define built-in preset metadata, steps, and parameter definitions.
+3. Expose preset list API.
+4. Expose preset detail API.
+5. Expose parameter validation API.
+6. Add custom preset skeleton entity.
+7. Add custom preset create/list/delete APIs.
+8. Document API and Worker preset contract.
+9. Add service/controller/entity tests.
+
+## Functional Units
+
+### Built-In Presets
+
+- `A4_SCAN_300DPI`
+- `LOW_CONTRAST_SCAN`
+- `RECEIPT`
+- `NOISY_SCAN`
+- `AUTO`
+
+### Parameter Validation
+
+- Unknown parameters are rejected.
+- Missing parameters are resolved from defaults when defaults exist.
+- Integer/decimal parameters validate range.
+- Boolean parameters accept only `true` or `false`.
+- Enum parameters validate allowed values.
+
+### Custom Presets
+
+- Custom presets belong to the current user.
+- Custom presets are derived from a built-in base preset.
+- Custom preset parameters are validated against the base preset.
+- Delete is a soft delete.
+- Job/Worker connection for custom presets is intentionally deferred.
+
+## API Surface
+
+- `GET /api/v1/preprocess/presets`
+- `GET /api/v1/preprocess/presets/{presetName}`
+- `POST /api/v1/preprocess/presets/validate`
+- `POST /api/v1/preprocess/presets/custom`
+- `GET /api/v1/preprocess/presets/custom`
+- `DELETE /api/v1/preprocess/presets/custom/{presetId}`
+
+## Out Of Scope
+
+- API-side OpenCV execution.
+- Worker preset registry implementation.
+- Job creation integration.
+- Frontend custom preset UI.
+
+## Verification
+
+- Registry tests cover required built-in preset names.
+- Validator tests cover defaults, unknown parameters, range errors, and enum errors.
+- Service tests cover list/detail/validate and custom preset lifecycle.
+- Controller tests cover common response codes for custom create/delete.

--- a/docs/worker/preset-spec.md
+++ b/docs/worker/preset-spec.md
@@ -1,0 +1,71 @@
+# Worker Preset Spec
+
+## Purpose
+
+This document defines the preset names and parameter contract that the Worker must support. The backend API validates
+these names and parameter ranges before publishing preprocessing jobs.
+
+## Required Preset Names
+
+Worker preset names must exactly match backend names:
+
+- `A4_SCAN_300DPI`
+- `LOW_CONTRAST_SCAN`
+- `RECEIPT`
+- `NOISY_SCAN`
+- `AUTO`
+
+## Required Pipeline Steps
+
+Except `AUTO`, built-in document presets describe the following OCR-oriented processing sequence:
+
+1. `DECODE`
+2. `COLOR_NORMALIZE`
+3. `ORIENTATION_NORMALIZE`
+4. `DESKEW`
+5. `CROP`
+6. `DENOISE`
+7. `CONTRAST_NORMALIZE`
+8. `BINARIZATION`
+9. `MORPHOLOGY_CLEANUP`
+10. `DPI_NORMALIZE`
+11. `OPTIONAL_SHARPEN`
+
+These steps are not a simple resize pipeline. `DPI_NORMALIZE` is for OCR-oriented DPI normalization and must not be
+implemented as a thumbnail resize shortcut.
+
+## Common Parameters
+
+| Parameter | Type | Range/Values | Meaning |
+| --- | --- | --- | --- |
+| `targetDpi` | integer | `150` to `600` | Target DPI for OCR normalization |
+| `maxDeskewAngle` | decimal | `0.0` to `45.0` | Maximum allowed deskew angle |
+| `binarizationMode` | enum | `otsu`, `adaptive` | Binarization strategy |
+| `contrastClipLimit` | decimal | `1.0` to `4.0` | Contrast normalization strength |
+| `sharpen` | boolean | `true`, `false` | Whether optional sharpen step should run |
+| `debugArtifacts` | boolean | `true`, `false` | Whether to save intermediate debug images |
+
+## Preset Defaults
+
+| Preset | targetDpi | binarizationMode | contrastClipLimit | sharpen |
+| --- | --- | --- | --- | --- |
+| `A4_SCAN_300DPI` | `300` | `otsu` | `1.2` | `false` |
+| `LOW_CONTRAST_SCAN` | `300` | `adaptive` | `1.6` | `true` |
+| `RECEIPT` | `300` | `adaptive` | `1.4` | `true` |
+| `NOISY_SCAN` | `300` | `adaptive` | `1.5` | `false` |
+
+`AUTO` supports `debugArtifacts` and delegates final preset selection to the Worker based on image characteristics.
+
+## Backend Contract
+
+- Backend exposes preset list/detail through `/api/v1/preprocess/presets`.
+- Backend validates parameters through `/api/v1/preprocess/presets/validate`.
+- Backend does not execute OpenCV processing.
+- Worker must reject messages with unknown preset names or invalid parameter payloads.
+
+## Future Worker Work
+
+- Implement Worker-side `PreprocessPresetRegistry`.
+- Map backend preset names to Worker pipeline step parameters.
+- Add `AutoPresetSelector` based on image characteristics.
+- Add Worker tests that compare supported preset names with backend documentation.


### PR DESCRIPTION
## #️⃣ 기능 설명

API 서버에서 Worker와 Job 생성이 공통으로 사용할 전처리 preset 명세와 파라미터 검증 구조를 구현합니다. API 서버는 OpenCV 처리를 직접 수행하지 않고 preset 계약과 검증만 담당합니다.

Closes #37

## 🛠️ 작업 상세 내용

- [x] `A4_SCAN_300DPI`, `LOW_CONTRAST_SCAN`, `RECEIPT`, `NOISY_SCAN`, `AUTO` built-in preset registry 추가
- [x] preset 목록/상세 API 추가
- [x] preset parameter validate API 추가
- [x] parameter type/range/enum/boolean/default validation 추가
- [x] custom preset entity/repository/service/controller skeleton 추가
- [x] custom preset 생성/목록/soft delete API 추가
- [x] `docs/api/preprocess-preset-api.md` 작성
- [x] `docs/worker/preset-spec.md` 작성
- [x] feature spec 문서와 테스트 추가

## 📁 변경 파일 요약

- `backend-api/src/main/java/com/moonju/preprocess/api/domain/preprocess/...`
- `backend-api/src/test/java/com/moonju/preprocess/api/domain/preprocess/...`
- `docs/api/preprocess-preset-api.md`
- `docs/worker/preset-spec.md`
- `docs/feature-specs/issue-37-preprocess-preset.md`

## ✅ 검증 내용

- [x] `docker run --rm -v "${PWD}\\backend-api:/workspace" -w /workspace gradle:8.12.1-jdk21 gradle clean test --no-daemon`: 통과
- [x] `docker run --rm -v "${PWD}\\backend-api:/workspace" -w /workspace gradle:8.12.1-jdk21 gradle build --no-daemon`: 통과
- [x] `git diff --check`: 통과
- [x] secret scan: 실제 Google OAuth secret 미포함 확인

## 🔎 리뷰어가 확인해야 할 부분

- API 서버가 OpenCV 처리 로직 없이 preset 명세와 검증만 담당하는 구조인지 확인해주세요.
- Worker와 공유해야 하는 preset 이름이 문서와 코드에서 일치하는지 확인해주세요.
- Custom preset은 Job/Worker 연결 전 skeleton 범위로 제한했습니다.

## 💬 기타 공유사항 to 리뷰어

- 이번 작업에서 새로 필요한 환경변수는 없습니다.
- 리뷰 승인 전 merge하지 않습니다.