### PR TITLE
✨ [Feat] Job 도메인과 RabbitMQ 메시지 발행 구현

### DIFF
--- a/backend-api/src/main/java/com/moonju/preprocess/api/domain/image/repository/ImageRepository.java
+++ b/backend-api/src/main/java/com/moonju/preprocess/api/domain/image/repository/ImageRepository.java
@@ -2,6 +2,8 @@ package com.moonju.preprocess.api.domain.image.repository;
 
 import com.moonju.preprocess.api.domain.image.entity.Image;
 import com.moonju.preprocess.api.domain.image.entity.ImageStatus;
+import java.util.Collection;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -16,4 +18,6 @@ public interface ImageRepository extends JpaRepository<Image, Long> {
     Optional<Image> findByIdAndStatusNot(Long id, ImageStatus status);
 
     Page<Image> findAllByProjectIdAndStatusNot(Long projectId, ImageStatus status, Pageable pageable);
+
+    List<Image> findAllByProjectIdAndIdInAndStatusNot(Long projectId, Collection<Long> ids, ImageStatus status);
 }

--- a/backend-api/src/main/java/com/moonju/preprocess/api/domain/job/controller/JobController.java
+++ b/backend-api/src/main/java/com/moonju/preprocess/api/domain/job/controller/JobController.java
@@ -1,0 +1,109 @@
+package com.moonju.preprocess.api.domain.job.controller;
+
+import com.moonju.preprocess.api.domain.job.dto.JobArtifactResponse;
+import com.moonju.preprocess.api.domain.job.dto.JobCancelResponse;
+import com.moonju.preprocess.api.domain.job.dto.JobCreateRequest;
+import com.moonju.preprocess.api.domain.job.dto.JobCreateResponse;
+import com.moonju.preprocess.api.domain.job.dto.JobItemResponse;
+import com.moonju.preprocess.api.domain.job.dto.JobResponse;
+import com.moonju.preprocess.api.domain.job.dto.JobRetryResponse;
+import com.moonju.preprocess.api.domain.job.dto.JobSummaryResponse;
+import com.moonju.preprocess.api.domain.job.service.JobCancelService;
+import com.moonju.preprocess.api.domain.job.service.JobCommandService;
+import com.moonju.preprocess.api.domain.job.service.JobQueryService;
+import com.moonju.preprocess.api.domain.job.service.JobRetryService;
+import com.moonju.preprocess.api.global.error.ErrorCode;
+import com.moonju.preprocess.api.global.response.ApiResponse;
+import com.moonju.preprocess.api.global.response.PageResponse;
+import com.moonju.preprocess.api.global.support.CurrentUser;
+import jakarta.validation.Valid;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/jobs")
+public class JobController {
+
+    private final JobCommandService jobCommandService;
+    private final JobQueryService jobQueryService;
+    private final JobCancelService jobCancelService;
+    private final JobRetryService jobRetryService;
+
+    public JobController(
+        JobCommandService jobCommandService,
+        JobQueryService jobQueryService,
+        JobCancelService jobCancelService,
+        JobRetryService jobRetryService
+    ) {
+        this.jobCommandService = jobCommandService;
+        this.jobQueryService = jobQueryService;
+        this.jobCancelService = jobCancelService;
+        this.jobRetryService = jobRetryService;
+    }
+
+    @PostMapping
+    public ApiResponse<JobCreateResponse> create(
+        @CurrentUser Long currentUserId,
+        @Valid @RequestBody JobCreateRequest request
+    ) {
+        return ApiResponse.success(ErrorCode.COMMON_CREATED, jobCommandService.create(currentUserId, request));
+    }
+
+    @GetMapping
+    public ApiResponse<PageResponse<JobResponse>> findMyJobs(
+        @CurrentUser Long currentUserId,
+        @PageableDefault(size = 20) Pageable pageable
+    ) {
+        return ApiResponse.success(jobQueryService.findMyJobs(currentUserId, pageable));
+    }
+
+    @GetMapping("/{jobId}")
+    public ApiResponse<JobResponse> findOne(@CurrentUser Long currentUserId, @PathVariable Long jobId) {
+        return ApiResponse.success(jobQueryService.findOne(currentUserId, jobId));
+    }
+
+    @GetMapping("/{jobId}/items")
+    public ApiResponse<PageResponse<JobItemResponse>> findItems(
+        @CurrentUser Long currentUserId,
+        @PathVariable Long jobId,
+        @PageableDefault(size = 50) Pageable pageable
+    ) {
+        return ApiResponse.success(jobQueryService.findItems(currentUserId, jobId, pageable));
+    }
+
+    @GetMapping("/{jobId}/summary")
+    public ApiResponse<JobSummaryResponse> summary(@CurrentUser Long currentUserId, @PathVariable Long jobId) {
+        return ApiResponse.success(jobQueryService.summary(currentUserId, jobId));
+    }
+
+    @PostMapping("/{jobId}/cancel")
+    public ApiResponse<JobCancelResponse> cancel(@CurrentUser Long currentUserId, @PathVariable Long jobId) {
+        return ApiResponse.success(jobCancelService.cancel(currentUserId, jobId));
+    }
+
+    @PostMapping("/{jobId}/retry")
+    public ApiResponse<JobRetryResponse> retry(@CurrentUser Long currentUserId, @PathVariable Long jobId) {
+        return ApiResponse.success(jobRetryService.retryFailed(currentUserId, jobId));
+    }
+
+    @PostMapping("/{jobId}/rerun")
+    public ApiResponse<JobRetryResponse> rerun(@CurrentUser Long currentUserId, @PathVariable Long jobId) {
+        return ApiResponse.success(jobRetryService.rerun(currentUserId, jobId));
+    }
+
+    @GetMapping("/{jobId}/artifacts")
+    public ApiResponse<JobArtifactResponse> artifacts(@CurrentUser Long currentUserId, @PathVariable Long jobId) {
+        return ApiResponse.success(jobQueryService.artifacts(currentUserId, jobId));
+    }
+
+    @GetMapping("/{jobId}/download.zip")
+    public ApiResponse<JobArtifactResponse> downloadZip(@CurrentUser Long currentUserId, @PathVariable Long jobId) {
+        return ApiResponse.success(jobQueryService.artifacts(currentUserId, jobId));
+    }
+}

--- a/backend-api/src/main/java/com/moonju/preprocess/api/domain/job/dto/JobArtifactResponse.java
+++ b/backend-api/src/main/java/com/moonju/preprocess/api/domain/job/dto/JobArtifactResponse.java
@@ -1,0 +1,11 @@
+package com.moonju.preprocess.api.domain.job.dto;
+
+public record JobArtifactResponse(
+    Long jobId,
+    String message
+) {
+
+    public static JobArtifactResponse skeleton(Long jobId) {
+        return new JobArtifactResponse(jobId, "Job artifact listing is reserved for worker artifact integration.");
+    }
+}

--- a/backend-api/src/main/java/com/moonju/preprocess/api/domain/job/dto/JobCancelResponse.java
+++ b/backend-api/src/main/java/com/moonju/preprocess/api/domain/job/dto/JobCancelResponse.java
@@ -1,0 +1,14 @@
+package com.moonju.preprocess.api.domain.job.dto;
+
+import com.moonju.preprocess.api.domain.job.entity.Job;
+import com.moonju.preprocess.api.domain.job.entity.JobStatus;
+
+public record JobCancelResponse(
+    Long jobId,
+    JobStatus status
+) {
+
+    public static JobCancelResponse from(Job job) {
+        return new JobCancelResponse(job.getId(), job.getStatus());
+    }
+}

--- a/backend-api/src/main/java/com/moonju/preprocess/api/domain/job/dto/JobCreateRequest.java
+++ b/backend-api/src/main/java/com/moonju/preprocess/api/domain/job/dto/JobCreateRequest.java
@@ -1,0 +1,49 @@
+package com.moonju.preprocess.api.domain.job.dto;
+
+import com.moonju.preprocess.api.domain.job.entity.JobPriority;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import java.util.List;
+import java.util.Map;
+
+public record JobCreateRequest(
+    @NotNull
+    Long projectId,
+
+    @NotEmpty
+    @Size(max = 10_000)
+    List<Long> imageIds,
+
+    @NotBlank
+    String preset,
+
+    Map<String, String> presetParameters,
+
+    Boolean debug,
+
+    JobPriority priority,
+
+    JobOutputOptionsRequest outputOptions
+) {
+
+    public Map<String, String> safePresetParameters() {
+        return presetParameters == null ? Map.of() : presetParameters;
+    }
+
+    public boolean debugEnabled() {
+        return debug != null && debug;
+    }
+
+    public JobPriority normalizedPriority() {
+        return priority == null ? JobPriority.NORMAL : priority;
+    }
+
+    public JobOutputOptionsRequest normalizedOutputOptions() {
+        if (outputOptions == null) {
+            return new JobOutputOptionsRequest(true, true, true, false);
+        }
+        return outputOptions;
+    }
+}

--- a/backend-api/src/main/java/com/moonju/preprocess/api/domain/job/dto/JobCreateResponse.java
+++ b/backend-api/src/main/java/com/moonju/preprocess/api/domain/job/dto/JobCreateResponse.java
@@ -1,0 +1,24 @@
+package com.moonju.preprocess.api.domain.job.dto;
+
+import com.moonju.preprocess.api.domain.job.entity.Job;
+import com.moonju.preprocess.api.domain.job.entity.JobStatus;
+import java.time.LocalDateTime;
+
+public record JobCreateResponse(
+    Long jobId,
+    JobStatus status,
+    int totalImages,
+    int queuedImages,
+    LocalDateTime createdAt
+) {
+
+    public static JobCreateResponse from(Job job) {
+        return new JobCreateResponse(
+            job.getId(),
+            job.getStatus(),
+            job.getTotalCount(),
+            job.getQueuedCount(),
+            job.getCreatedAt()
+        );
+    }
+}

--- a/backend-api/src/main/java/com/moonju/preprocess/api/domain/job/dto/JobItemResponse.java
+++ b/backend-api/src/main/java/com/moonju/preprocess/api/domain/job/dto/JobItemResponse.java
@@ -1,0 +1,42 @@
+package com.moonju.preprocess.api.domain.job.dto;
+
+import com.moonju.preprocess.api.domain.job.entity.JobItem;
+import com.moonju.preprocess.api.domain.job.entity.JobItemStatus;
+import java.time.LocalDateTime;
+
+public record JobItemResponse(
+    Long id,
+    Long jobId,
+    Long imageId,
+    JobItemStatus status,
+    int attempt,
+    String workerId,
+    String processedObjectKey,
+    String previewObjectKey,
+    String reportObjectKey,
+    String errorCode,
+    String errorMessage,
+    LocalDateTime createdAt,
+    LocalDateTime startedAt,
+    LocalDateTime completedAt
+) {
+
+    public static JobItemResponse from(JobItem item) {
+        return new JobItemResponse(
+            item.getId(),
+            item.getJobId(),
+            item.getImageId(),
+            item.getStatus(),
+            item.getAttempt(),
+            item.getWorkerId(),
+            item.getProcessedObjectKey(),
+            item.getPreviewObjectKey(),
+            item.getReportObjectKey(),
+            item.getErrorCode(),
+            item.getErrorMessage(),
+            item.getCreatedAt(),
+            item.getStartedAt(),
+            item.getCompletedAt()
+        );
+    }
+}

--- a/backend-api/src/main/java/com/moonju/preprocess/api/domain/job/dto/JobOutputOptionsRequest.java
+++ b/backend-api/src/main/java/com/moonju/preprocess/api/domain/job/dto/JobOutputOptionsRequest.java
@@ -1,0 +1,25 @@
+package com.moonju.preprocess.api.domain.job.dto;
+
+public record JobOutputOptionsRequest(
+    Boolean saveProcessedImage,
+    Boolean savePreview,
+    Boolean saveReportJson,
+    Boolean saveDebugArtifacts
+) {
+
+    public boolean shouldSaveProcessedImage() {
+        return saveProcessedImage == null || saveProcessedImage;
+    }
+
+    public boolean shouldSavePreview() {
+        return savePreview == null || savePreview;
+    }
+
+    public boolean shouldSaveReportJson() {
+        return saveReportJson == null || saveReportJson;
+    }
+
+    public boolean shouldSaveDebugArtifacts() {
+        return saveDebugArtifacts != null && saveDebugArtifacts;
+    }
+}

--- a/backend-api/src/main/java/com/moonju/preprocess/api/domain/job/dto/JobResponse.java
+++ b/backend-api/src/main/java/com/moonju/preprocess/api/domain/job/dto/JobResponse.java
@@ -1,0 +1,48 @@
+package com.moonju.preprocess.api.domain.job.dto;
+
+import com.moonju.preprocess.api.domain.job.entity.Job;
+import com.moonju.preprocess.api.domain.job.entity.JobPriority;
+import com.moonju.preprocess.api.domain.job.entity.JobStatus;
+import java.time.LocalDateTime;
+import java.util.Map;
+
+public record JobResponse(
+    Long id,
+    Long projectId,
+    Long userId,
+    String preset,
+    Map<String, String> presetParameters,
+    boolean debug,
+    JobPriority priority,
+    JobStatus status,
+    int totalCount,
+    int queuedCount,
+    int processingCount,
+    int succeededCount,
+    int failedCount,
+    LocalDateTime createdAt,
+    LocalDateTime startedAt,
+    LocalDateTime completedAt
+) {
+
+    public static JobResponse from(Job job) {
+        return new JobResponse(
+            job.getId(),
+            job.getProjectId(),
+            job.getUserId(),
+            job.getPreset(),
+            job.getPresetParameters(),
+            job.isDebug(),
+            job.getPriority(),
+            job.getStatus(),
+            job.getTotalCount(),
+            job.getQueuedCount(),
+            job.getProcessingCount(),
+            job.getSucceededCount(),
+            job.getFailedCount(),
+            job.getCreatedAt(),
+            job.getStartedAt(),
+            job.getCompletedAt()
+        );
+    }
+}

--- a/backend-api/src/main/java/com/moonju/preprocess/api/domain/job/dto/JobRetryResponse.java
+++ b/backend-api/src/main/java/com/moonju/preprocess/api/domain/job/dto/JobRetryResponse.java
@@ -1,0 +1,15 @@
+package com.moonju.preprocess.api.domain.job.dto;
+
+import com.moonju.preprocess.api.domain.job.entity.Job;
+import com.moonju.preprocess.api.domain.job.entity.JobStatus;
+
+public record JobRetryResponse(
+    Long jobId,
+    JobStatus status,
+    int queuedItems
+) {
+
+    public static JobRetryResponse of(Job job, int queuedItems) {
+        return new JobRetryResponse(job.getId(), job.getStatus(), queuedItems);
+    }
+}

--- a/backend-api/src/main/java/com/moonju/preprocess/api/domain/job/dto/JobSummaryResponse.java
+++ b/backend-api/src/main/java/com/moonju/preprocess/api/domain/job/dto/JobSummaryResponse.java
@@ -1,0 +1,29 @@
+package com.moonju.preprocess.api.domain.job.dto;
+
+import com.moonju.preprocess.api.domain.job.entity.Job;
+
+public record JobSummaryResponse(
+    Long jobId,
+    int total,
+    int queued,
+    int processing,
+    int succeeded,
+    int failed,
+    double progressPercent
+) {
+
+    public static JobSummaryResponse from(Job job) {
+        double progress = job.getTotalCount() == 0
+            ? 0.0
+            : (double) (job.getSucceededCount() + job.getFailedCount()) * 100.0 / job.getTotalCount();
+        return new JobSummaryResponse(
+            job.getId(),
+            job.getTotalCount(),
+            job.getQueuedCount(),
+            job.getProcessingCount(),
+            job.getSucceededCount(),
+            job.getFailedCount(),
+            progress
+        );
+    }
+}

--- a/backend-api/src/main/java/com/moonju/preprocess/api/domain/job/entity/Job.java
+++ b/backend-api/src/main/java/com/moonju/preprocess/api/domain/job/entity/Job.java
@@ -1,0 +1,183 @@
+package com.moonju.preprocess.api.domain.job.entity;
+
+import com.moonju.preprocess.api.global.support.BaseEntity;
+import jakarta.persistence.CollectionTable;
+import jakarta.persistence.Column;
+import jakarta.persistence.ElementCollection;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.MapKeyColumn;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+@Entity
+@Table(name = "jobs")
+public class Job extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private Long projectId;
+
+    @Column(nullable = false)
+    private Long userId;
+
+    @Column(nullable = false, length = 100)
+    private String preset;
+
+    @ElementCollection
+    @CollectionTable(name = "job_preset_parameters", joinColumns = @JoinColumn(name = "job_id"))
+    @MapKeyColumn(name = "parameter_name", length = 100)
+    @Column(name = "parameter_value", length = 500)
+    private Map<String, String> presetParameters = new LinkedHashMap<>();
+
+    @Column(nullable = false)
+    private boolean debug;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private JobPriority priority;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 30)
+    private JobStatus status;
+
+    @Column(nullable = false)
+    private int totalCount;
+
+    @Column(nullable = false)
+    private int queuedCount;
+
+    @Column(nullable = false)
+    private int processingCount;
+
+    @Column(nullable = false)
+    private int succeededCount;
+
+    @Column(nullable = false)
+    private int failedCount;
+
+    private LocalDateTime startedAt;
+
+    private LocalDateTime completedAt;
+
+    protected Job() {
+    }
+
+    public Job(
+        Long projectId,
+        Long userId,
+        String preset,
+        Map<String, String> presetParameters,
+        boolean debug,
+        JobPriority priority,
+        int totalCount
+    ) {
+        this.projectId = projectId;
+        this.userId = userId;
+        this.preset = preset;
+        this.presetParameters = new LinkedHashMap<>(presetParameters);
+        this.debug = debug;
+        this.priority = priority;
+        this.status = JobStatus.CREATED;
+        this.totalCount = totalCount;
+    }
+
+    public static Job create(
+        Long projectId,
+        Long userId,
+        String preset,
+        Map<String, String> presetParameters,
+        boolean debug,
+        JobPriority priority,
+        int totalCount
+    ) {
+        return new Job(projectId, userId, preset, presetParameters, debug, priority, totalCount);
+    }
+
+    public void markQueued(int queuedCount) {
+        this.status = JobStatus.QUEUED;
+        this.queuedCount = queuedCount;
+    }
+
+    public void requestCancel() {
+        if (status == JobStatus.SUCCEEDED || status == JobStatus.FAILED || status == JobStatus.CANCELLED) {
+            return;
+        }
+        this.status = JobStatus.CANCEL_REQUESTED;
+    }
+
+    public void markRetrying(int queuedCount) {
+        this.status = JobStatus.RETRYING;
+        this.queuedCount = queuedCount;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public Long getProjectId() {
+        return projectId;
+    }
+
+    public Long getUserId() {
+        return userId;
+    }
+
+    public String getPreset() {
+        return preset;
+    }
+
+    public Map<String, String> getPresetParameters() {
+        return Map.copyOf(presetParameters);
+    }
+
+    public boolean isDebug() {
+        return debug;
+    }
+
+    public JobPriority getPriority() {
+        return priority;
+    }
+
+    public JobStatus getStatus() {
+        return status;
+    }
+
+    public int getTotalCount() {
+        return totalCount;
+    }
+
+    public int getQueuedCount() {
+        return queuedCount;
+    }
+
+    public int getProcessingCount() {
+        return processingCount;
+    }
+
+    public int getSucceededCount() {
+        return succeededCount;
+    }
+
+    public int getFailedCount() {
+        return failedCount;
+    }
+
+    public LocalDateTime getStartedAt() {
+        return startedAt;
+    }
+
+    public LocalDateTime getCompletedAt() {
+        return completedAt;
+    }
+}

--- a/backend-api/src/main/java/com/moonju/preprocess/api/domain/job/entity/JobItem.java
+++ b/backend-api/src/main/java/com/moonju/preprocess/api/domain/job/entity/JobItem.java
@@ -1,0 +1,154 @@
+package com.moonju.preprocess.api.domain.job.entity;
+
+import com.moonju.preprocess.api.global.support.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "job_items")
+public class JobItem extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private Long jobId;
+
+    @Column(nullable = false)
+    private Long imageId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 30)
+    private JobItemStatus status;
+
+    @Column(nullable = false)
+    private int attempt;
+
+    @Column(length = 100)
+    private String workerId;
+
+    @Column(length = 1000)
+    private String processedObjectKey;
+
+    @Column(length = 1000)
+    private String previewObjectKey;
+
+    @Column(length = 1000)
+    private String reportObjectKey;
+
+    @Column(length = 100)
+    private String errorCode;
+
+    @Column(length = 2000)
+    private String errorMessage;
+
+    private LocalDateTime startedAt;
+
+    private LocalDateTime completedAt;
+
+    protected JobItem() {
+    }
+
+    public JobItem(Long jobId, Long imageId, JobItemStatus status, int attempt) {
+        this.jobId = jobId;
+        this.imageId = imageId;
+        this.status = status;
+        this.attempt = attempt;
+    }
+
+    public static JobItem queued(Long jobId, Long imageId) {
+        return new JobItem(jobId, imageId, JobItemStatus.QUEUED, 1);
+    }
+
+    public void requestCancel() {
+        if (status == JobItemStatus.QUEUED || status == JobItemStatus.PENDING || status == JobItemStatus.RETRYING) {
+            status = JobItemStatus.CANCELLED;
+        }
+    }
+
+    public void retry() {
+        if (status == JobItemStatus.FAILED || status == JobItemStatus.DEAD_LETTERED) {
+            markRetrying();
+        }
+    }
+
+    public boolean canRetry() {
+        return status == JobItemStatus.FAILED || status == JobItemStatus.DEAD_LETTERED;
+    }
+
+    public void rerun() {
+        if (status != JobItemStatus.PROCESSING) {
+            markRetrying();
+        }
+    }
+
+    private void markRetrying() {
+        status = JobItemStatus.RETRYING;
+        attempt++;
+        errorCode = null;
+        errorMessage = null;
+        workerId = null;
+        startedAt = null;
+        completedAt = null;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public Long getJobId() {
+        return jobId;
+    }
+
+    public Long getImageId() {
+        return imageId;
+    }
+
+    public JobItemStatus getStatus() {
+        return status;
+    }
+
+    public int getAttempt() {
+        return attempt;
+    }
+
+    public String getWorkerId() {
+        return workerId;
+    }
+
+    public String getProcessedObjectKey() {
+        return processedObjectKey;
+    }
+
+    public String getPreviewObjectKey() {
+        return previewObjectKey;
+    }
+
+    public String getReportObjectKey() {
+        return reportObjectKey;
+    }
+
+    public String getErrorCode() {
+        return errorCode;
+    }
+
+    public String getErrorMessage() {
+        return errorMessage;
+    }
+
+    public LocalDateTime getStartedAt() {
+        return startedAt;
+    }
+
+    public LocalDateTime getCompletedAt() {
+        return completedAt;
+    }
+}

--- a/backend-api/src/main/java/com/moonju/preprocess/api/domain/job/entity/JobItemStatus.java
+++ b/backend-api/src/main/java/com/moonju/preprocess/api/domain/job/entity/JobItemStatus.java
@@ -1,0 +1,13 @@
+package com.moonju.preprocess.api.domain.job.entity;
+
+public enum JobItemStatus {
+    PENDING,
+    QUEUED,
+    PROCESSING,
+    SUCCEEDED,
+    FAILED,
+    SKIPPED,
+    CANCELLED,
+    RETRYING,
+    DEAD_LETTERED
+}

--- a/backend-api/src/main/java/com/moonju/preprocess/api/domain/job/entity/JobPriority.java
+++ b/backend-api/src/main/java/com/moonju/preprocess/api/domain/job/entity/JobPriority.java
@@ -1,0 +1,7 @@
+package com.moonju.preprocess.api.domain.job.entity;
+
+public enum JobPriority {
+    LOW,
+    NORMAL,
+    HIGH
+}

--- a/backend-api/src/main/java/com/moonju/preprocess/api/domain/job/entity/JobStatus.java
+++ b/backend-api/src/main/java/com/moonju/preprocess/api/domain/job/entity/JobStatus.java
@@ -1,0 +1,13 @@
+package com.moonju.preprocess.api.domain.job.entity;
+
+public enum JobStatus {
+    CREATED,
+    QUEUED,
+    RUNNING,
+    PARTIAL_SUCCEEDED,
+    SUCCEEDED,
+    FAILED,
+    CANCEL_REQUESTED,
+    CANCELLED,
+    RETRYING
+}

--- a/backend-api/src/main/java/com/moonju/preprocess/api/domain/job/exception/InvalidJobRequestException.java
+++ b/backend-api/src/main/java/com/moonju/preprocess/api/domain/job/exception/InvalidJobRequestException.java
@@ -1,0 +1,11 @@
+package com.moonju.preprocess.api.domain.job.exception;
+
+import com.moonju.preprocess.api.global.error.BusinessException;
+import com.moonju.preprocess.api.global.error.ErrorCode;
+
+public class InvalidJobRequestException extends BusinessException {
+
+    public InvalidJobRequestException(String message) {
+        super(ErrorCode.VALIDATION_ERROR, message);
+    }
+}

--- a/backend-api/src/main/java/com/moonju/preprocess/api/domain/job/exception/JobAlreadyCompletedException.java
+++ b/backend-api/src/main/java/com/moonju/preprocess/api/domain/job/exception/JobAlreadyCompletedException.java
@@ -1,0 +1,11 @@
+package com.moonju.preprocess.api.domain.job.exception;
+
+import com.moonju.preprocess.api.global.error.BusinessException;
+import com.moonju.preprocess.api.global.error.ErrorCode;
+
+public class JobAlreadyCompletedException extends BusinessException {
+
+    public JobAlreadyCompletedException() {
+        super(ErrorCode.COMMON_CONFLICT, "Job is already completed.");
+    }
+}

--- a/backend-api/src/main/java/com/moonju/preprocess/api/domain/job/exception/JobNotFoundException.java
+++ b/backend-api/src/main/java/com/moonju/preprocess/api/domain/job/exception/JobNotFoundException.java
@@ -1,0 +1,11 @@
+package com.moonju.preprocess.api.domain.job.exception;
+
+import com.moonju.preprocess.api.global.error.BusinessException;
+import com.moonju.preprocess.api.global.error.ErrorCode;
+
+public class JobNotFoundException extends BusinessException {
+
+    public JobNotFoundException() {
+        super(ErrorCode.COMMON_NOT_FOUND, "Job not found.");
+    }
+}

--- a/backend-api/src/main/java/com/moonju/preprocess/api/domain/job/repository/JobItemRepository.java
+++ b/backend-api/src/main/java/com/moonju/preprocess/api/domain/job/repository/JobItemRepository.java
@@ -1,0 +1,18 @@
+package com.moonju.preprocess.api.domain.job.repository;
+
+import com.moonju.preprocess.api.domain.job.entity.JobItem;
+import com.moonju.preprocess.api.domain.job.entity.JobItemStatus;
+import java.util.Collection;
+import java.util.List;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface JobItemRepository extends JpaRepository<JobItem, Long> {
+
+    Page<JobItem> findAllByJobId(Long jobId, Pageable pageable);
+
+    List<JobItem> findAllByJobId(Long jobId);
+
+    List<JobItem> findAllByJobIdAndStatusIn(Long jobId, Collection<JobItemStatus> statuses);
+}

--- a/backend-api/src/main/java/com/moonju/preprocess/api/domain/job/repository/JobRepository.java
+++ b/backend-api/src/main/java/com/moonju/preprocess/api/domain/job/repository/JobRepository.java
@@ -1,0 +1,14 @@
+package com.moonju.preprocess.api.domain.job.repository;
+
+import com.moonju.preprocess.api.domain.job.entity.Job;
+import java.util.Optional;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface JobRepository extends JpaRepository<Job, Long> {
+
+    Optional<Job> findByIdAndUserId(Long id, Long userId);
+
+    Page<Job> findAllByUserId(Long userId, Pageable pageable);
+}

--- a/backend-api/src/main/java/com/moonju/preprocess/api/domain/job/service/JobCancelService.java
+++ b/backend-api/src/main/java/com/moonju/preprocess/api/domain/job/service/JobCancelService.java
@@ -1,0 +1,29 @@
+package com.moonju.preprocess.api.domain.job.service;
+
+import com.moonju.preprocess.api.domain.job.dto.JobCancelResponse;
+import com.moonju.preprocess.api.domain.job.entity.Job;
+import com.moonju.preprocess.api.domain.job.repository.JobItemRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class JobCancelService {
+
+    private final JobQueryService jobQueryService;
+    private final JobItemRepository jobItemRepository;
+
+    public JobCancelService(JobQueryService jobQueryService, JobItemRepository jobItemRepository) {
+        this.jobQueryService = jobQueryService;
+        this.jobItemRepository = jobItemRepository;
+    }
+
+    @Transactional
+    public JobCancelResponse cancel(Long currentUserId, Long jobId) {
+        Job job = jobQueryService.findEditableJob(currentUserId, jobId);
+        job.requestCancel();
+        jobItemRepository.findAllByJobId(job.getId()).forEach(item -> {
+            item.requestCancel();
+        });
+        return JobCancelResponse.from(job);
+    }
+}

--- a/backend-api/src/main/java/com/moonju/preprocess/api/domain/job/service/JobCommandService.java
+++ b/backend-api/src/main/java/com/moonju/preprocess/api/domain/job/service/JobCommandService.java
@@ -1,0 +1,115 @@
+package com.moonju.preprocess.api.domain.job.service;
+
+import com.moonju.preprocess.api.domain.image.entity.Image;
+import com.moonju.preprocess.api.domain.image.entity.ImageStatus;
+import com.moonju.preprocess.api.domain.image.repository.ImageRepository;
+import com.moonju.preprocess.api.domain.job.dto.JobCreateRequest;
+import com.moonju.preprocess.api.domain.job.dto.JobCreateResponse;
+import com.moonju.preprocess.api.domain.job.entity.Job;
+import com.moonju.preprocess.api.domain.job.entity.JobItem;
+import com.moonju.preprocess.api.domain.job.exception.InvalidJobRequestException;
+import com.moonju.preprocess.api.domain.job.repository.JobItemRepository;
+import com.moonju.preprocess.api.domain.job.repository.JobRepository;
+import com.moonju.preprocess.api.domain.preprocess.dto.PresetValidateRequest;
+import com.moonju.preprocess.api.domain.preprocess.dto.PresetValidateResponse;
+import com.moonju.preprocess.api.domain.preprocess.exception.InvalidPresetParameterException;
+import com.moonju.preprocess.api.domain.preprocess.service.PreprocessPresetService;
+import com.moonju.preprocess.api.domain.project.service.ProjectPermissionService;
+import com.moonju.preprocess.api.infra.rabbitmq.JobMessagePublisher;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class JobCommandService {
+
+    private final JobRepository jobRepository;
+    private final JobItemRepository jobItemRepository;
+    private final ImageRepository imageRepository;
+    private final ProjectPermissionService projectPermissionService;
+    private final PreprocessPresetService preprocessPresetService;
+    private final JobMessageFactory jobMessageFactory;
+    private final JobMessagePublisher jobMessagePublisher;
+
+    public JobCommandService(
+        JobRepository jobRepository,
+        JobItemRepository jobItemRepository,
+        ImageRepository imageRepository,
+        ProjectPermissionService projectPermissionService,
+        PreprocessPresetService preprocessPresetService,
+        JobMessageFactory jobMessageFactory,
+        JobMessagePublisher jobMessagePublisher
+    ) {
+        this.jobRepository = jobRepository;
+        this.jobItemRepository = jobItemRepository;
+        this.imageRepository = imageRepository;
+        this.projectPermissionService = projectPermissionService;
+        this.preprocessPresetService = preprocessPresetService;
+        this.jobMessageFactory = jobMessageFactory;
+        this.jobMessagePublisher = jobMessagePublisher;
+    }
+
+    @Transactional
+    public JobCreateResponse create(Long currentUserId, JobCreateRequest request) {
+        projectPermissionService.validateEditable(request.projectId(), currentUserId);
+        List<Long> imageIds = uniqueImageIds(request.imageIds());
+        List<Image> images = findImages(request.projectId(), imageIds);
+        PresetValidateResponse presetValidation = preprocessPresetService.validate(new PresetValidateRequest(
+            request.preset(),
+            request.safePresetParameters()
+        ));
+        if (!presetValidation.valid()) {
+            throw new InvalidPresetParameterException(String.join(", ", presetValidation.errors()));
+        }
+
+        Job job = jobRepository.save(Job.create(
+            request.projectId(),
+            currentUserId,
+            presetValidation.presetName(),
+            presetValidation.resolvedParameters(),
+            request.debugEnabled(),
+            request.normalizedPriority(),
+            images.size()
+        ));
+        List<JobItem> items = images.stream()
+            .map(image -> jobItemRepository.save(JobItem.queued(job.getId(), image.getId())))
+            .toList();
+        job.markQueued(items.size());
+        publishMessages(job, items, images);
+        return JobCreateResponse.from(job);
+    }
+
+    private List<Long> uniqueImageIds(List<Long> imageIds) {
+        List<Long> uniqueImageIds = new LinkedHashSet<>(imageIds).stream().toList();
+        if (uniqueImageIds.size() != imageIds.size()) {
+            throw new InvalidJobRequestException("Duplicate imageIds are not allowed.");
+        }
+        return uniqueImageIds;
+    }
+
+    private List<Image> findImages(Long projectId, List<Long> imageIds) {
+        List<Image> images = imageRepository.findAllByProjectIdAndIdInAndStatusNot(
+            projectId,
+            imageIds,
+            ImageStatus.DELETED
+        );
+        if (images.size() != imageIds.size()) {
+            throw new InvalidJobRequestException("Some images do not belong to the project or do not exist.");
+        }
+        Map<Long, Image> imagesById = images.stream()
+            .collect(java.util.stream.Collectors.toMap(Image::getId, image -> image));
+        return imageIds.stream().map(imagesById::get).toList();
+    }
+
+    private void publishMessages(Job job, List<JobItem> items, List<Image> images) {
+        Map<Long, Image> imagesById = images.stream()
+            .collect(java.util.stream.Collectors.toMap(Image::getId, image -> image));
+        for (JobItem item : items) {
+            jobMessagePublisher.publishPreprocess(
+                jobMessageFactory.create(job, item, imagesById.get(item.getImageId()))
+            );
+        }
+    }
+}

--- a/backend-api/src/main/java/com/moonju/preprocess/api/domain/job/service/JobMessageFactory.java
+++ b/backend-api/src/main/java/com/moonju/preprocess/api/domain/job/service/JobMessageFactory.java
@@ -1,0 +1,32 @@
+package com.moonju.preprocess.api.domain.job.service;
+
+import com.moonju.preprocess.api.domain.image.entity.Image;
+import com.moonju.preprocess.api.domain.job.entity.Job;
+import com.moonju.preprocess.api.domain.job.entity.JobItem;
+import com.moonju.preprocess.api.infra.rabbitmq.PreprocessJobMessage;
+import java.time.Instant;
+import java.util.UUID;
+import org.springframework.stereotype.Component;
+
+@Component
+public class JobMessageFactory {
+
+    public PreprocessJobMessage create(Job job, JobItem item, Image image) {
+        return new PreprocessJobMessage(
+            UUID.randomUUID().toString(),
+            job.getId(),
+            item.getId(),
+            job.getProjectId(),
+            image.getId(),
+            job.getUserId(),
+            image.getOriginalObjectKey(),
+            job.getPreset(),
+            job.getPresetParameters(),
+            job.isDebug(),
+            job.getPriority(),
+            item.getAttempt(),
+            UUID.randomUUID().toString(),
+            Instant.now()
+        );
+    }
+}

--- a/backend-api/src/main/java/com/moonju/preprocess/api/domain/job/service/JobQueryService.java
+++ b/backend-api/src/main/java/com/moonju/preprocess/api/domain/job/service/JobQueryService.java
@@ -1,0 +1,78 @@
+package com.moonju.preprocess.api.domain.job.service;
+
+import com.moonju.preprocess.api.domain.job.dto.JobArtifactResponse;
+import com.moonju.preprocess.api.domain.job.dto.JobItemResponse;
+import com.moonju.preprocess.api.domain.job.dto.JobResponse;
+import com.moonju.preprocess.api.domain.job.dto.JobSummaryResponse;
+import com.moonju.preprocess.api.domain.job.entity.Job;
+import com.moonju.preprocess.api.domain.job.exception.JobNotFoundException;
+import com.moonju.preprocess.api.domain.job.repository.JobItemRepository;
+import com.moonju.preprocess.api.domain.job.repository.JobRepository;
+import com.moonju.preprocess.api.domain.project.service.ProjectPermissionService;
+import com.moonju.preprocess.api.global.response.PageResponse;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class JobQueryService {
+
+    private final JobRepository jobRepository;
+    private final JobItemRepository jobItemRepository;
+    private final ProjectPermissionService projectPermissionService;
+
+    public JobQueryService(
+        JobRepository jobRepository,
+        JobItemRepository jobItemRepository,
+        ProjectPermissionService projectPermissionService
+    ) {
+        this.jobRepository = jobRepository;
+        this.jobItemRepository = jobItemRepository;
+        this.projectPermissionService = projectPermissionService;
+    }
+
+    @Transactional(readOnly = true)
+    public PageResponse<JobResponse> findMyJobs(Long currentUserId, Pageable pageable) {
+        return PageResponse.from(jobRepository.findAllByUserId(currentUserId, pageable).map(JobResponse::from));
+    }
+
+    @Transactional(readOnly = true)
+    public JobResponse findOne(Long currentUserId, Long jobId) {
+        return JobResponse.from(findReadableJob(currentUserId, jobId));
+    }
+
+    @Transactional(readOnly = true)
+    public PageResponse<JobItemResponse> findItems(Long currentUserId, Long jobId, Pageable pageable) {
+        Job job = findReadableJob(currentUserId, jobId);
+        return PageResponse.from(jobItemRepository.findAllByJobId(job.getId(), pageable).map(JobItemResponse::from));
+    }
+
+    @Transactional(readOnly = true)
+    public JobSummaryResponse summary(Long currentUserId, Long jobId) {
+        return JobSummaryResponse.from(findReadableJob(currentUserId, jobId));
+    }
+
+    @Transactional(readOnly = true)
+    public JobArtifactResponse artifacts(Long currentUserId, Long jobId) {
+        Job job = findReadableJob(currentUserId, jobId);
+        return JobArtifactResponse.skeleton(job.getId());
+    }
+
+    @Transactional(readOnly = true)
+    public Job findReadableJob(Long currentUserId, Long jobId) {
+        Job job = findById(jobId);
+        projectPermissionService.validateReadable(job.getProjectId(), currentUserId);
+        return job;
+    }
+
+    @Transactional(readOnly = true)
+    public Job findEditableJob(Long currentUserId, Long jobId) {
+        Job job = findById(jobId);
+        projectPermissionService.validateEditable(job.getProjectId(), currentUserId);
+        return job;
+    }
+
+    private Job findById(Long jobId) {
+        return jobRepository.findById(jobId).orElseThrow(JobNotFoundException::new);
+    }
+}

--- a/backend-api/src/main/java/com/moonju/preprocess/api/domain/job/service/JobRetryService.java
+++ b/backend-api/src/main/java/com/moonju/preprocess/api/domain/job/service/JobRetryService.java
@@ -1,0 +1,91 @@
+package com.moonju.preprocess.api.domain.job.service;
+
+import com.moonju.preprocess.api.domain.image.entity.Image;
+import com.moonju.preprocess.api.domain.image.entity.ImageStatus;
+import com.moonju.preprocess.api.domain.image.repository.ImageRepository;
+import com.moonju.preprocess.api.domain.job.dto.JobRetryResponse;
+import com.moonju.preprocess.api.domain.job.entity.Job;
+import com.moonju.preprocess.api.domain.job.entity.JobItem;
+import com.moonju.preprocess.api.domain.job.entity.JobItemStatus;
+import com.moonju.preprocess.api.domain.job.repository.JobItemRepository;
+import com.moonju.preprocess.api.infra.rabbitmq.JobMessagePublisher;
+import java.util.List;
+import java.util.Map;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class JobRetryService {
+
+    private static final List<JobItemStatus> RETRYABLE_STATUSES = List.of(
+        JobItemStatus.FAILED,
+        JobItemStatus.DEAD_LETTERED
+    );
+
+    private final JobQueryService jobQueryService;
+    private final JobItemRepository jobItemRepository;
+    private final ImageRepository imageRepository;
+    private final JobMessageFactory jobMessageFactory;
+    private final JobMessagePublisher jobMessagePublisher;
+
+    public JobRetryService(
+        JobQueryService jobQueryService,
+        JobItemRepository jobItemRepository,
+        ImageRepository imageRepository,
+        JobMessageFactory jobMessageFactory,
+        JobMessagePublisher jobMessagePublisher
+    ) {
+        this.jobQueryService = jobQueryService;
+        this.jobItemRepository = jobItemRepository;
+        this.imageRepository = imageRepository;
+        this.jobMessageFactory = jobMessageFactory;
+        this.jobMessagePublisher = jobMessagePublisher;
+    }
+
+    @Transactional
+    public JobRetryResponse retryFailed(Long currentUserId, Long jobId) {
+        Job job = jobQueryService.findEditableJob(currentUserId, jobId);
+        List<JobItem> retryItems = jobItemRepository.findAllByJobIdAndStatusIn(job.getId(), RETRYABLE_STATUSES);
+        retryItems.forEach(JobItem::retry);
+        job.markRetrying(retryItems.size());
+        publishRetryMessages(job, retryItems);
+        return JobRetryResponse.of(job, retryItems.size());
+    }
+
+    @Transactional
+    public JobRetryResponse rerun(Long currentUserId, Long jobId) {
+        Job job = jobQueryService.findEditableJob(currentUserId, jobId);
+        List<JobItem> items = jobItemRepository.findAllByJobId(job.getId());
+        items.forEach(JobItem::rerun);
+        List<JobItem> retryItems = items.stream()
+            .filter(item -> item.getStatus() == JobItemStatus.RETRYING)
+            .toList();
+        job.markRetrying(retryItems.size());
+        publishRetryMessages(job, retryItems);
+        return JobRetryResponse.of(job, retryItems.size());
+    }
+
+    private void publishRetryMessages(Job job, List<JobItem> items) {
+        Map<Long, Image> imagesById = findImages(job.getProjectId(), items);
+        for (JobItem item : items) {
+            Image image = imagesById.get(item.getImageId());
+            if (image != null) {
+                jobMessagePublisher.publishRetry(jobMessageFactory.create(job, item, image));
+            }
+        }
+    }
+
+    private Map<Long, Image> findImages(Long projectId, List<JobItem> items) {
+        List<Long> imageIds = items.stream().map(JobItem::getImageId).toList();
+        if (imageIds.isEmpty()) {
+            return Map.of();
+        }
+        return imageRepository.findAllByProjectIdAndIdInAndStatusNot(
+                projectId,
+                imageIds,
+                ImageStatus.DELETED
+            )
+            .stream()
+            .collect(java.util.stream.Collectors.toMap(Image::getId, image -> image));
+    }
+}

--- a/backend-api/src/main/java/com/moonju/preprocess/api/infra/rabbitmq/JobMessagePublisher.java
+++ b/backend-api/src/main/java/com/moonju/preprocess/api/infra/rabbitmq/JobMessagePublisher.java
@@ -1,0 +1,24 @@
+package com.moonju.preprocess.api.infra.rabbitmq;
+
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+public class JobMessagePublisher {
+
+    private final RabbitTemplate rabbitTemplate;
+    private final RabbitMqProperties rabbitMqProperties;
+
+    public JobMessagePublisher(RabbitTemplate rabbitTemplate, RabbitMqProperties rabbitMqProperties) {
+        this.rabbitTemplate = rabbitTemplate;
+        this.rabbitMqProperties = rabbitMqProperties;
+    }
+
+    public void publishPreprocess(PreprocessJobMessage message) {
+        rabbitTemplate.convertAndSend(rabbitMqProperties.queueFor(message.priority()), message);
+    }
+
+    public void publishRetry(PreprocessJobMessage message) {
+        rabbitTemplate.convertAndSend(rabbitMqProperties.retryQueue(), message);
+    }
+}

--- a/backend-api/src/main/java/com/moonju/preprocess/api/infra/rabbitmq/PreprocessJobMessage.java
+++ b/backend-api/src/main/java/com/moonju/preprocess/api/infra/rabbitmq/PreprocessJobMessage.java
@@ -1,0 +1,23 @@
+package com.moonju.preprocess.api.infra.rabbitmq;
+
+import com.moonju.preprocess.api.domain.job.entity.JobPriority;
+import java.time.Instant;
+import java.util.Map;
+
+public record PreprocessJobMessage(
+    String messageId,
+    Long jobId,
+    Long itemId,
+    Long projectId,
+    Long imageId,
+    Long userId,
+    String originalObjectKey,
+    String preset,
+    Map<String, String> presetParameters,
+    boolean debug,
+    JobPriority priority,
+    int attempt,
+    String traceId,
+    Instant createdAt
+) {
+}

--- a/backend-api/src/main/java/com/moonju/preprocess/api/infra/rabbitmq/RabbitMqConfig.java
+++ b/backend-api/src/main/java/com/moonju/preprocess/api/infra/rabbitmq/RabbitMqConfig.java
@@ -1,0 +1,9 @@
+package com.moonju.preprocess.api.infra.rabbitmq;
+
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@EnableConfigurationProperties(RabbitMqProperties.class)
+public class RabbitMqConfig {
+}

--- a/backend-api/src/main/java/com/moonju/preprocess/api/infra/rabbitmq/RabbitMqProperties.java
+++ b/backend-api/src/main/java/com/moonju/preprocess/api/infra/rabbitmq/RabbitMqProperties.java
@@ -1,0 +1,56 @@
+package com.moonju.preprocess.api.infra.rabbitmq;
+
+import com.moonju.preprocess.api.domain.job.entity.JobPriority;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "rabbitmq.queues")
+public class RabbitMqProperties {
+
+    private String preprocessHigh = "image.preprocess.high";
+    private String preprocessNormal = "image.preprocess.normal";
+    private String preprocessRetry = "image.preprocess.retry";
+    private String preprocessDlq = "image.preprocess.dlq";
+
+    public String queueFor(JobPriority priority) {
+        if (priority == JobPriority.HIGH) {
+            return preprocessHigh;
+        }
+        return preprocessNormal;
+    }
+
+    public String retryQueue() {
+        return preprocessRetry;
+    }
+
+    public String getPreprocessHigh() {
+        return preprocessHigh;
+    }
+
+    public void setPreprocessHigh(String preprocessHigh) {
+        this.preprocessHigh = preprocessHigh;
+    }
+
+    public String getPreprocessNormal() {
+        return preprocessNormal;
+    }
+
+    public void setPreprocessNormal(String preprocessNormal) {
+        this.preprocessNormal = preprocessNormal;
+    }
+
+    public String getPreprocessRetry() {
+        return preprocessRetry;
+    }
+
+    public void setPreprocessRetry(String preprocessRetry) {
+        this.preprocessRetry = preprocessRetry;
+    }
+
+    public String getPreprocessDlq() {
+        return preprocessDlq;
+    }
+
+    public void setPreprocessDlq(String preprocessDlq) {
+        this.preprocessDlq = preprocessDlq;
+    }
+}

--- a/backend-api/src/test/java/com/moonju/preprocess/api/domain/job/controller/JobControllerTests.java
+++ b/backend-api/src/test/java/com/moonju/preprocess/api/domain/job/controller/JobControllerTests.java
@@ -1,0 +1,84 @@
+package com.moonju.preprocess.api.domain.job.controller;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.moonju.preprocess.api.domain.job.dto.JobCreateRequest;
+import com.moonju.preprocess.api.domain.job.dto.JobCreateResponse;
+import com.moonju.preprocess.api.domain.job.dto.JobRetryResponse;
+import com.moonju.preprocess.api.domain.job.entity.JobPriority;
+import com.moonju.preprocess.api.domain.job.entity.JobStatus;
+import com.moonju.preprocess.api.domain.job.service.JobCancelService;
+import com.moonju.preprocess.api.domain.job.service.JobCommandService;
+import com.moonju.preprocess.api.domain.job.service.JobQueryService;
+import com.moonju.preprocess.api.domain.job.service.JobRetryService;
+import com.moonju.preprocess.api.global.response.ApiResponse;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class JobControllerTests {
+
+    @Mock
+    private JobCommandService jobCommandService;
+
+    @Mock
+    private JobQueryService jobQueryService;
+
+    @Mock
+    private JobCancelService jobCancelService;
+
+    @Mock
+    private JobRetryService jobRetryService;
+
+    @Test
+    void createsJobWithCommonCreatedResponse() {
+        JobController controller = controller();
+        JobCreateRequest request = new JobCreateRequest(
+            10L,
+            List.of(100L),
+            "A4_SCAN_300DPI",
+            Map.of("targetDpi", "300"),
+            false,
+            JobPriority.NORMAL,
+            null
+        );
+        JobCreateResponse serviceResponse = new JobCreateResponse(
+            1L,
+            JobStatus.QUEUED,
+            1,
+            1,
+            LocalDateTime.of(2026, 5, 10, 12, 0)
+        );
+        when(jobCommandService.create(20L, request)).thenReturn(serviceResponse);
+
+        ApiResponse<JobCreateResponse> response = controller.create(20L, request);
+
+        assertThat(response.isSuccess()).isTrue();
+        assertThat(response.code()).isEqualTo("common201");
+        assertThat(response.result()).isSameAs(serviceResponse);
+    }
+
+    @Test
+    void retriesFailedJobItems() {
+        JobController controller = controller();
+        JobRetryResponse serviceResponse = new JobRetryResponse(1L, JobStatus.RETRYING, 2);
+        when(jobRetryService.retryFailed(20L, 1L)).thenReturn(serviceResponse);
+
+        ApiResponse<JobRetryResponse> response = controller.retry(20L, 1L);
+
+        assertThat(response.isSuccess()).isTrue();
+        assertThat(response.result()).isSameAs(serviceResponse);
+        verify(jobRetryService).retryFailed(20L, 1L);
+    }
+
+    private JobController controller() {
+        return new JobController(jobCommandService, jobQueryService, jobCancelService, jobRetryService);
+    }
+}

--- a/backend-api/src/test/java/com/moonju/preprocess/api/domain/job/entity/JobItemTests.java
+++ b/backend-api/src/test/java/com/moonju/preprocess/api/domain/job/entity/JobItemTests.java
@@ -1,0 +1,37 @@
+package com.moonju.preprocess.api.domain.job.entity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class JobItemTests {
+
+    @Test
+    void createsQueuedJobItem() {
+        JobItem item = JobItem.queued(1L, 100L);
+
+        assertThat(item.getJobId()).isEqualTo(1L);
+        assertThat(item.getImageId()).isEqualTo(100L);
+        assertThat(item.getStatus()).isEqualTo(JobItemStatus.QUEUED);
+        assertThat(item.getAttempt()).isEqualTo(1);
+    }
+
+    @Test
+    void retriesFailedItem() {
+        JobItem item = new JobItem(1L, 100L, JobItemStatus.FAILED, 1);
+
+        item.retry();
+
+        assertThat(item.getStatus()).isEqualTo(JobItemStatus.RETRYING);
+        assertThat(item.getAttempt()).isEqualTo(2);
+    }
+
+    @Test
+    void cancelsQueuedItem() {
+        JobItem item = JobItem.queued(1L, 100L);
+
+        item.requestCancel();
+
+        assertThat(item.getStatus()).isEqualTo(JobItemStatus.CANCELLED);
+    }
+}

--- a/backend-api/src/test/java/com/moonju/preprocess/api/domain/job/entity/JobTests.java
+++ b/backend-api/src/test/java/com/moonju/preprocess/api/domain/job/entity/JobTests.java
@@ -1,0 +1,29 @@
+package com.moonju.preprocess.api.domain.job.entity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class JobTests {
+
+    @Test
+    void createsJobInCreatedStatus() {
+        Job job = Job.create(10L, 20L, "A4_SCAN_300DPI", Map.of("targetDpi", "300"), false, JobPriority.NORMAL, 2);
+
+        assertThat(job.getProjectId()).isEqualTo(10L);
+        assertThat(job.getStatus()).isEqualTo(JobStatus.CREATED);
+        assertThat(job.getTotalCount()).isEqualTo(2);
+    }
+
+    @Test
+    void marksQueuedAndCancelRequested() {
+        Job job = Job.create(10L, 20L, "A4_SCAN_300DPI", Map.of(), false, JobPriority.NORMAL, 2);
+
+        job.markQueued(2);
+        job.requestCancel();
+
+        assertThat(job.getQueuedCount()).isEqualTo(2);
+        assertThat(job.getStatus()).isEqualTo(JobStatus.CANCEL_REQUESTED);
+    }
+}

--- a/backend-api/src/test/java/com/moonju/preprocess/api/domain/job/service/JobCancelServiceTests.java
+++ b/backend-api/src/test/java/com/moonju/preprocess/api/domain/job/service/JobCancelServiceTests.java
@@ -1,0 +1,52 @@
+package com.moonju.preprocess.api.domain.job.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import com.moonju.preprocess.api.domain.job.dto.JobCancelResponse;
+import com.moonju.preprocess.api.domain.job.entity.Job;
+import com.moonju.preprocess.api.domain.job.entity.JobItem;
+import com.moonju.preprocess.api.domain.job.entity.JobItemStatus;
+import com.moonju.preprocess.api.domain.job.entity.JobPriority;
+import com.moonju.preprocess.api.domain.job.entity.JobStatus;
+import com.moonju.preprocess.api.domain.job.repository.JobItemRepository;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+class JobCancelServiceTests {
+
+    @Mock
+    private JobQueryService jobQueryService;
+
+    @Mock
+    private JobItemRepository jobItemRepository;
+
+    @Test
+    void marksJobAndQueuedItemsAsCancelRequested() {
+        JobCancelService service = new JobCancelService(jobQueryService, jobItemRepository);
+        Job job = job(1L);
+        JobItem queuedItem = JobItem.queued(1L, 100L);
+        JobItem processingItem = new JobItem(1L, 101L, JobItemStatus.PROCESSING, 1);
+        when(jobQueryService.findEditableJob(20L, 1L)).thenReturn(job);
+        when(jobItemRepository.findAllByJobId(1L)).thenReturn(List.of(queuedItem, processingItem));
+
+        JobCancelResponse response = service.cancel(20L, 1L);
+
+        assertThat(response.status()).isEqualTo(JobStatus.CANCEL_REQUESTED);
+        assertThat(queuedItem.getStatus()).isEqualTo(JobItemStatus.CANCELLED);
+        assertThat(processingItem.getStatus()).isEqualTo(JobItemStatus.PROCESSING);
+    }
+
+    private Job job(Long id) {
+        Job job = Job.create(10L, 20L, "A4_SCAN_300DPI", Map.of(), false, JobPriority.NORMAL, 2);
+        ReflectionTestUtils.setField(job, "id", id);
+        job.markQueued(2);
+        return job;
+    }
+}

--- a/backend-api/src/test/java/com/moonju/preprocess/api/domain/job/service/JobCommandServiceTests.java
+++ b/backend-api/src/test/java/com/moonju/preprocess/api/domain/job/service/JobCommandServiceTests.java
@@ -1,0 +1,130 @@
+package com.moonju.preprocess.api.domain.job.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.moonju.preprocess.api.domain.image.entity.Image;
+import com.moonju.preprocess.api.domain.image.entity.ImageFormat;
+import com.moonju.preprocess.api.domain.image.entity.ImageStatus;
+import com.moonju.preprocess.api.domain.image.repository.ImageRepository;
+import com.moonju.preprocess.api.domain.job.dto.JobCreateRequest;
+import com.moonju.preprocess.api.domain.job.dto.JobCreateResponse;
+import com.moonju.preprocess.api.domain.job.entity.Job;
+import com.moonju.preprocess.api.domain.job.entity.JobItem;
+import com.moonju.preprocess.api.domain.job.entity.JobPriority;
+import com.moonju.preprocess.api.domain.job.entity.JobStatus;
+import com.moonju.preprocess.api.domain.job.exception.InvalidJobRequestException;
+import com.moonju.preprocess.api.domain.job.repository.JobItemRepository;
+import com.moonju.preprocess.api.domain.job.repository.JobRepository;
+import com.moonju.preprocess.api.domain.preprocess.dto.PresetValidateRequest;
+import com.moonju.preprocess.api.domain.preprocess.dto.PresetValidateResponse;
+import com.moonju.preprocess.api.domain.preprocess.service.PreprocessPresetService;
+import com.moonju.preprocess.api.domain.project.service.ProjectPermissionService;
+import com.moonju.preprocess.api.infra.rabbitmq.JobMessagePublisher;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+class JobCommandServiceTests {
+
+    @Mock
+    private JobRepository jobRepository;
+
+    @Mock
+    private JobItemRepository jobItemRepository;
+
+    @Mock
+    private ImageRepository imageRepository;
+
+    @Mock
+    private ProjectPermissionService projectPermissionService;
+
+    @Mock
+    private PreprocessPresetService preprocessPresetService;
+
+    @Mock
+    private JobMessageFactory jobMessageFactory;
+
+    @Mock
+    private JobMessagePublisher jobMessagePublisher;
+
+    @InjectMocks
+    private JobCommandService service;
+
+    @Test
+    void createsJobItemsAndPublishesOneMessagePerImage() {
+        Image image = image(100L, 10L);
+        when(projectPermissionService.validateEditable(10L, 20L)).thenReturn(null);
+        when(imageRepository.findAllByProjectIdAndIdInAndStatusNot(10L, List.of(100L), ImageStatus.DELETED))
+            .thenReturn(List.of(image));
+        when(preprocessPresetService.validate(any(PresetValidateRequest.class)))
+            .thenReturn(PresetValidateResponse.valid("A4_SCAN_300DPI", Map.of("targetDpi", "300")));
+        when(jobRepository.save(any(Job.class))).thenAnswer(invocation -> {
+            Job job = invocation.getArgument(0);
+            ReflectionTestUtils.setField(job, "id", 1L);
+            return job;
+        });
+        when(jobItemRepository.save(any(JobItem.class))).thenAnswer(invocation -> {
+            JobItem item = invocation.getArgument(0);
+            ReflectionTestUtils.setField(item, "id", 10L);
+            return item;
+        });
+
+        JobCreateResponse response = service.create(20L, new JobCreateRequest(
+            10L,
+            List.of(100L),
+            "A4_SCAN_300DPI",
+            Map.of("targetDpi", "300"),
+            false,
+            JobPriority.NORMAL,
+            null
+        ));
+
+        assertThat(response.jobId()).isEqualTo(1L);
+        assertThat(response.status()).isEqualTo(JobStatus.QUEUED);
+        assertThat(response.queuedImages()).isEqualTo(1);
+        verify(jobMessagePublisher).publishPreprocess(any());
+    }
+
+    @Test
+    void rejectsDuplicateImageIds() {
+        assertThatThrownBy(() -> service.create(20L, new JobCreateRequest(
+            10L,
+            List.of(100L, 100L),
+            "A4_SCAN_300DPI",
+            Map.of(),
+            false,
+            JobPriority.NORMAL,
+            null
+        )))
+            .isInstanceOf(InvalidJobRequestException.class)
+            .hasMessage("Duplicate imageIds are not allowed.");
+    }
+
+    private Image image(Long imageId, Long projectId) {
+        Image image = new Image(
+            projectId,
+            1L,
+            2L,
+            20L,
+            "scan.png",
+            "originals/scan.png",
+            "image/png",
+            1024L,
+            "a".repeat(64),
+            ImageFormat.PNG,
+            ImageStatus.UPLOADED
+        );
+        ReflectionTestUtils.setField(image, "id", imageId);
+        return image;
+    }
+}

--- a/backend-api/src/test/java/com/moonju/preprocess/api/domain/job/service/JobMessageFactoryTests.java
+++ b/backend-api/src/test/java/com/moonju/preprocess/api/domain/job/service/JobMessageFactoryTests.java
@@ -1,0 +1,66 @@
+package com.moonju.preprocess.api.domain.job.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.moonju.preprocess.api.domain.image.entity.Image;
+import com.moonju.preprocess.api.domain.image.entity.ImageFormat;
+import com.moonju.preprocess.api.domain.image.entity.ImageStatus;
+import com.moonju.preprocess.api.domain.job.entity.Job;
+import com.moonju.preprocess.api.domain.job.entity.JobItem;
+import com.moonju.preprocess.api.domain.job.entity.JobPriority;
+import com.moonju.preprocess.api.infra.rabbitmq.PreprocessJobMessage;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+class JobMessageFactoryTests {
+
+    private final JobMessageFactory factory = new JobMessageFactory();
+
+    @Test
+    void createsMessageWithJobItemAndImageContext() {
+        Job job = Job.create(
+            10L,
+            20L,
+            "LOW_CONTRAST_SCAN",
+            Map.of("targetDpi", "300"),
+            true,
+            JobPriority.HIGH,
+            1
+        );
+        ReflectionTestUtils.setField(job, "id", 1L);
+        JobItem item = JobItem.queued(1L, 100L);
+        ReflectionTestUtils.setField(item, "id", 2L);
+        Image image = image(100L);
+
+        PreprocessJobMessage message = factory.create(job, item, image);
+
+        assertThat(message.jobId()).isEqualTo(1L);
+        assertThat(message.itemId()).isEqualTo(2L);
+        assertThat(message.originalObjectKey()).isEqualTo("originals/project-10/scan.png");
+        assertThat(message.preset()).isEqualTo("LOW_CONTRAST_SCAN");
+        assertThat(message.presetParameters()).containsEntry("targetDpi", "300");
+        assertThat(message.debug()).isTrue();
+        assertThat(message.priority()).isEqualTo(JobPriority.HIGH);
+        assertThat(message.messageId()).isNotBlank();
+        assertThat(message.traceId()).isNotBlank();
+    }
+
+    private Image image(Long id) {
+        Image image = new Image(
+            10L,
+            1L,
+            2L,
+            20L,
+            "scan.png",
+            "originals/project-10/scan.png",
+            "image/png",
+            1024L,
+            "a".repeat(64),
+            ImageFormat.PNG,
+            ImageStatus.UPLOADED
+        );
+        ReflectionTestUtils.setField(image, "id", id);
+        return image;
+    }
+}

--- a/backend-api/src/test/java/com/moonju/preprocess/api/domain/job/service/JobQueryServiceTests.java
+++ b/backend-api/src/test/java/com/moonju/preprocess/api/domain/job/service/JobQueryServiceTests.java
@@ -1,0 +1,84 @@
+package com.moonju.preprocess.api.domain.job.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.moonju.preprocess.api.domain.job.dto.JobResponse;
+import com.moonju.preprocess.api.domain.job.dto.JobSummaryResponse;
+import com.moonju.preprocess.api.domain.job.entity.Job;
+import com.moonju.preprocess.api.domain.job.entity.JobPriority;
+import com.moonju.preprocess.api.domain.job.repository.JobItemRepository;
+import com.moonju.preprocess.api.domain.job.repository.JobRepository;
+import com.moonju.preprocess.api.domain.project.service.ProjectPermissionService;
+import com.moonju.preprocess.api.global.response.PageResponse;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+class JobQueryServiceTests {
+
+    @Mock
+    private JobRepository jobRepository;
+
+    @Mock
+    private JobItemRepository jobItemRepository;
+
+    @Mock
+    private ProjectPermissionService projectPermissionService;
+
+    @InjectMocks
+    private JobQueryService service;
+
+    @Test
+    void listsJobsCreatedByCurrentUser() {
+        Job job = job(1L);
+        when(jobRepository.findAllByUserId(20L, PageRequest.of(0, 20)))
+            .thenReturn(new PageImpl<>(java.util.List.of(job)));
+
+        PageResponse<JobResponse> response = service.findMyJobs(20L, PageRequest.of(0, 20));
+
+        assertThat(response.content()).hasSize(1);
+        assertThat(response.content().getFirst().id()).isEqualTo(1L);
+    }
+
+    @Test
+    void readsJobAfterProjectReadPermissionValidation() {
+        Job job = job(1L);
+        when(jobRepository.findById(1L)).thenReturn(Optional.of(job));
+        when(projectPermissionService.validateReadable(10L, 20L)).thenReturn(null);
+
+        JobResponse response = service.findOne(20L, 1L);
+
+        assertThat(response.id()).isEqualTo(1L);
+        verify(projectPermissionService).validateReadable(10L, 20L);
+    }
+
+    @Test
+    void summarizesJobProgressFromPersistedCounters() {
+        Job job = job(1L);
+        ReflectionTestUtils.setField(job, "succeededCount", 1);
+        ReflectionTestUtils.setField(job, "failedCount", 1);
+        when(jobRepository.findById(1L)).thenReturn(Optional.of(job));
+        when(projectPermissionService.validateReadable(10L, 20L)).thenReturn(null);
+
+        JobSummaryResponse response = service.summary(20L, 1L);
+
+        assertThat(response.progressPercent()).isEqualTo(100.0);
+    }
+
+    private Job job(Long id) {
+        Job job = Job.create(10L, 20L, "A4_SCAN_300DPI", Map.of(), false, JobPriority.NORMAL, 2);
+        ReflectionTestUtils.setField(job, "id", id);
+        job.markQueued(2);
+        return job;
+    }
+}

--- a/backend-api/src/test/java/com/moonju/preprocess/api/domain/job/service/JobRetryServiceTests.java
+++ b/backend-api/src/test/java/com/moonju/preprocess/api/domain/job/service/JobRetryServiceTests.java
@@ -1,0 +1,153 @@
+package com.moonju.preprocess.api.domain.job.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.moonju.preprocess.api.domain.image.entity.Image;
+import com.moonju.preprocess.api.domain.image.entity.ImageFormat;
+import com.moonju.preprocess.api.domain.image.entity.ImageStatus;
+import com.moonju.preprocess.api.domain.image.repository.ImageRepository;
+import com.moonju.preprocess.api.domain.job.dto.JobRetryResponse;
+import com.moonju.preprocess.api.domain.job.entity.Job;
+import com.moonju.preprocess.api.domain.job.entity.JobItem;
+import com.moonju.preprocess.api.domain.job.entity.JobItemStatus;
+import com.moonju.preprocess.api.domain.job.entity.JobPriority;
+import com.moonju.preprocess.api.domain.job.entity.JobStatus;
+import com.moonju.preprocess.api.domain.job.repository.JobItemRepository;
+import com.moonju.preprocess.api.infra.rabbitmq.JobMessagePublisher;
+import com.moonju.preprocess.api.infra.rabbitmq.PreprocessJobMessage;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+class JobRetryServiceTests {
+
+    @Mock
+    private JobQueryService jobQueryService;
+
+    @Mock
+    private JobItemRepository jobItemRepository;
+
+    @Mock
+    private ImageRepository imageRepository;
+
+    @Mock
+    private JobMessageFactory jobMessageFactory;
+
+    @Mock
+    private JobMessagePublisher jobMessagePublisher;
+
+    @Test
+    void retriesFailedAndDeadLetteredItemsOnly() {
+        JobRetryService service = service();
+        Job job = job(1L);
+        JobItem failed = item(10L, JobItemStatus.FAILED);
+        JobItem deadLettered = item(11L, JobItemStatus.DEAD_LETTERED);
+        Image image100 = image(100L);
+        Image image101 = image(101L);
+        when(jobQueryService.findEditableJob(20L, 1L)).thenReturn(job);
+        when(jobItemRepository.findAllByJobIdAndStatusIn(
+            1L,
+            List.of(JobItemStatus.FAILED, JobItemStatus.DEAD_LETTERED)
+        )).thenReturn(List.of(failed, deadLettered));
+        when(imageRepository.findAllByProjectIdAndIdInAndStatusNot(
+            10L,
+            List.of(100L, 101L),
+            ImageStatus.DELETED
+        )).thenReturn(List.of(image100, image101));
+        when(jobMessageFactory.create(any(Job.class), any(JobItem.class), any(Image.class)))
+            .thenReturn(message());
+
+        JobRetryResponse response = service.retryFailed(20L, 1L);
+
+        assertThat(response.status()).isEqualTo(JobStatus.RETRYING);
+        assertThat(response.queuedItems()).isEqualTo(2);
+        assertThat(failed.getStatus()).isEqualTo(JobItemStatus.RETRYING);
+        assertThat(deadLettered.getAttempt()).isEqualTo(2);
+        verify(jobMessagePublisher, org.mockito.Mockito.times(2)).publishRetry(any());
+    }
+
+    @Test
+    void doesNotPublishWhenThereAreNoRetryableItems() {
+        JobRetryService service = service();
+        Job job = job(1L);
+        when(jobQueryService.findEditableJob(20L, 1L)).thenReturn(job);
+        when(jobItemRepository.findAllByJobIdAndStatusIn(
+            1L,
+            List.of(JobItemStatus.FAILED, JobItemStatus.DEAD_LETTERED)
+        )).thenReturn(List.of());
+
+        JobRetryResponse response = service.retryFailed(20L, 1L);
+
+        assertThat(response.queuedItems()).isZero();
+        verify(jobMessagePublisher, never()).publishRetry(any());
+    }
+
+    private JobRetryService service() {
+        return new JobRetryService(
+            jobQueryService,
+            jobItemRepository,
+            imageRepository,
+            jobMessageFactory,
+            jobMessagePublisher
+        );
+    }
+
+    private Job job(Long id) {
+        Job job = Job.create(10L, 20L, "A4_SCAN_300DPI", Map.of(), false, JobPriority.NORMAL, 2);
+        ReflectionTestUtils.setField(job, "id", id);
+        job.markQueued(2);
+        return job;
+    }
+
+    private JobItem item(Long id, JobItemStatus status) {
+        JobItem item = new JobItem(1L, id + 90L, status, 1);
+        ReflectionTestUtils.setField(item, "id", id);
+        return item;
+    }
+
+    private Image image(Long id) {
+        Image image = new Image(
+            10L,
+            1L,
+            2L,
+            20L,
+            "scan.png",
+            "originals/scan.png",
+            "image/png",
+            1024L,
+            "a".repeat(64),
+            ImageFormat.PNG,
+            ImageStatus.UPLOADED
+        );
+        ReflectionTestUtils.setField(image, "id", id);
+        return image;
+    }
+
+    private PreprocessJobMessage message() {
+        return new PreprocessJobMessage(
+            "msg",
+            1L,
+            10L,
+            10L,
+            100L,
+            20L,
+            "originals/scan.png",
+            "A4_SCAN_300DPI",
+            Map.of(),
+            false,
+            JobPriority.NORMAL,
+            2,
+            "trace",
+            java.time.Instant.parse("2026-05-10T00:00:00Z")
+        );
+    }
+}

--- a/backend-api/src/test/java/com/moonju/preprocess/api/infra/rabbitmq/JobMessagePublisherTests.java
+++ b/backend-api/src/test/java/com/moonju/preprocess/api/infra/rabbitmq/JobMessagePublisherTests.java
@@ -1,0 +1,55 @@
+package com.moonju.preprocess.api.infra.rabbitmq;
+
+import static org.mockito.Mockito.verify;
+
+import com.moonju.preprocess.api.domain.job.entity.JobPriority;
+import java.time.Instant;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+
+class JobMessagePublisherTests {
+
+    @Test
+    void publishesHighPriorityMessageToHighQueue() {
+        RabbitTemplate rabbitTemplate = org.mockito.Mockito.mock(RabbitTemplate.class);
+        RabbitMqProperties properties = new RabbitMqProperties();
+        JobMessagePublisher publisher = new JobMessagePublisher(rabbitTemplate, properties);
+        PreprocessJobMessage message = message(JobPriority.HIGH);
+
+        publisher.publishPreprocess(message);
+
+        verify(rabbitTemplate).convertAndSend("image.preprocess.high", message);
+    }
+
+    @Test
+    void publishesRetryMessageToRetryQueue() {
+        RabbitTemplate rabbitTemplate = org.mockito.Mockito.mock(RabbitTemplate.class);
+        RabbitMqProperties properties = new RabbitMqProperties();
+        JobMessagePublisher publisher = new JobMessagePublisher(rabbitTemplate, properties);
+        PreprocessJobMessage message = message(JobPriority.NORMAL);
+
+        publisher.publishRetry(message);
+
+        verify(rabbitTemplate).convertAndSend("image.preprocess.retry", message);
+    }
+
+    private PreprocessJobMessage message(JobPriority priority) {
+        return new PreprocessJobMessage(
+            "msg",
+            1L,
+            2L,
+            3L,
+            4L,
+            5L,
+            "originals/scan.png",
+            "A4_SCAN_300DPI",
+            Map.of(),
+            false,
+            priority,
+            1,
+            "trace",
+            Instant.parse("2026-05-10T00:00:00Z")
+        );
+    }
+}

--- a/docs/api/job-api.md
+++ b/docs/api/job-api.md
@@ -1,0 +1,198 @@
+# Job API
+
+## Purpose
+
+Job API registers large-scale document image preprocessing work. It validates project access, selected images, and
+preprocess preset parameters, then publishes image-level RabbitMQ messages for Worker execution.
+
+The API server does not execute OpenCV preprocessing. Worker execution and artifact upload are handled by later Worker
+tasks.
+
+## State Model
+
+### Job Status
+
+| Status | Meaning |
+| --- | --- |
+| `CREATED` | Job entity was created before queueing |
+| `QUEUED` | JobItems were queued and messages were published |
+| `RUNNING` | At least one Worker is processing an item |
+| `PARTIAL_SUCCEEDED` | Some items succeeded and some failed |
+| `SUCCEEDED` | All items succeeded |
+| `FAILED` | Job failed without successful completion |
+| `CANCEL_REQUESTED` | User requested cancellation |
+| `CANCELLED` | Job was cancelled |
+| `RETRYING` | Failed or selected items were requeued |
+
+### JobItem Status
+
+| Status | Meaning |
+| --- | --- |
+| `PENDING` | Item exists but is not queued yet |
+| `QUEUED` | Item is ready for Worker consumption |
+| `PROCESSING` | Worker is processing the image |
+| `SUCCEEDED` | Worker completed successfully |
+| `FAILED` | Worker reported a retryable or final failure |
+| `SKIPPED` | Item was skipped intentionally |
+| `CANCELLED` | Item was cancelled before processing |
+| `RETRYING` | Item was requeued |
+| `DEAD_LETTERED` | Item exceeded retry handling and moved to DLQ |
+
+## Endpoints
+
+All endpoints require `Authorization: Bearer <access-token>`.
+
+| Method | Path | Purpose |
+| --- | --- | --- |
+| `POST` | `/api/v1/jobs` | Create preprocessing job |
+| `GET` | `/api/v1/jobs` | List my jobs |
+| `GET` | `/api/v1/jobs/{jobId}` | Read job detail |
+| `GET` | `/api/v1/jobs/{jobId}/items` | List image-level job items |
+| `GET` | `/api/v1/jobs/{jobId}/summary` | Read progress counters |
+| `POST` | `/api/v1/jobs/{jobId}/cancel` | Request cancellation |
+| `POST` | `/api/v1/jobs/{jobId}/retry` | Retry failed and dead-lettered items |
+| `POST` | `/api/v1/jobs/{jobId}/rerun` | Requeue all non-processing items |
+| `GET` | `/api/v1/jobs/{jobId}/artifacts` | Read artifact listing placeholder |
+| `GET` | `/api/v1/jobs/{jobId}/download.zip` | Read ZIP download placeholder |
+
+## Create Job
+
+Request:
+
+```json
+{
+  "projectId": 1,
+  "imageIds": [100, 101, 102],
+  "preset": "LOW_CONTRAST_SCAN",
+  "presetParameters": {
+    "targetDpi": "300",
+    "binarizationMode": "adaptive"
+  },
+  "debug": false,
+  "priority": "NORMAL",
+  "outputOptions": {
+    "saveProcessedImage": true,
+    "savePreview": true,
+    "saveReportJson": true,
+    "saveDebugArtifacts": false
+  }
+}
+```
+
+Response:
+
+```json
+{
+  "isSuccess": true,
+  "code": "common201",
+  "message": "Created.",
+  "result": {
+    "jobId": 1,
+    "status": "QUEUED",
+    "totalImages": 3,
+    "queuedImages": 3,
+    "createdAt": "2026-05-10T12:00:00"
+  }
+}
+```
+
+Rules:
+
+- `imageIds` must be non-empty and unique.
+- All images must belong to the requested project.
+- Deleted images are rejected.
+- Preset parameters are validated by `POST /api/v1/preprocess/presets/validate` logic before messages are published.
+- The API publishes one RabbitMQ message per image.
+
+## RabbitMQ Routing
+
+| Priority | Queue |
+| --- | --- |
+| `HIGH` | `image.preprocess.high` |
+| `LOW` | `image.preprocess.normal` |
+| `NORMAL` | `image.preprocess.normal` |
+
+Retry requests publish to `image.preprocess.retry`.
+
+## Message Contract
+
+```json
+{
+  "messageId": "msg-uuid",
+  "jobId": 1,
+  "itemId": 10,
+  "projectId": 1,
+  "imageId": 100,
+  "userId": 20,
+  "originalObjectKey": "originals/1/1/100/scan.png",
+  "preset": "LOW_CONTRAST_SCAN",
+  "presetParameters": {
+    "targetDpi": "300"
+  },
+  "debug": false,
+  "priority": "NORMAL",
+  "attempt": 1,
+  "traceId": "trace-uuid",
+  "createdAt": "2026-05-10T03:00:00Z"
+}
+```
+
+## List And Detail
+
+```text
+GET /api/v1/jobs?page=0&size=20
+GET /api/v1/jobs/{jobId}
+GET /api/v1/jobs/{jobId}/items?page=0&size=50
+```
+
+`GET /api/v1/jobs` lists jobs created by the current user. Detail and item APIs validate project read permission.
+
+## Summary
+
+Response:
+
+```json
+{
+  "isSuccess": true,
+  "code": "common200",
+  "message": "Request succeeded.",
+  "result": {
+    "jobId": 1,
+    "total": 1000,
+    "queued": 120,
+    "processing": 20,
+    "succeeded": 850,
+    "failed": 10,
+    "progressPercent": 86.0
+  }
+}
+```
+
+`progressPercent` is calculated from `(succeeded + failed) / total * 100`.
+
+## Cancel
+
+```text
+POST /api/v1/jobs/{jobId}/cancel
+```
+
+Cancellation is cooperative. The API marks the Job as `CANCEL_REQUESTED` and cancels items that have not started.
+Processing items are left unchanged so the Worker can finish or stop at a safe checkpoint.
+
+## Retry
+
+```text
+POST /api/v1/jobs/{jobId}/retry
+POST /api/v1/jobs/{jobId}/rerun
+```
+
+- `retry` requeues only `FAILED` and `DEAD_LETTERED` items.
+- `rerun` requeues all non-`PROCESSING` items.
+- Each retry increments `attempt`.
+- Retried messages are published to `image.preprocess.retry`.
+
+## Current Limitations
+
+- SSE progress streaming is not implemented in this issue.
+- Worker success/failure callback API is not implemented in this issue.
+- Artifact listing and ZIP download currently return placeholders.

--- a/docs/feature-specs/issue-39-job-domain.md
+++ b/docs/feature-specs/issue-39-job-domain.md
@@ -1,0 +1,96 @@
+# Issue 39. Job Domain And RabbitMQ Publishing
+
+## Goal
+
+Implement the backend Job domain that registers document image preprocessing work and publishes one RabbitMQ message
+per image. The API server only manages metadata, permissions, validation, and queue publishing. It does not run OpenCV
+preprocessing.
+
+## Overall Order
+
+1. Define Job and JobItem state enums.
+2. Add Job and JobItem entities.
+3. Add repository interfaces for Job and JobItem lookup.
+4. Add Job creation request/response DTOs.
+5. Validate project edit permission before creating a Job.
+6. Validate image ownership and exclude deleted images.
+7. Validate preprocess preset parameters through the Preprocess Preset domain.
+8. Persist Job and one JobItem per selected image.
+9. Publish one RabbitMQ message per JobItem.
+10. Add Job list/detail/item/summary APIs.
+11. Add cancel, failed-item retry, and full rerun APIs.
+12. Document API and Worker retry contract.
+13. Add entity, service, controller, and publisher tests.
+
+## Functional Units
+
+### Job Creation
+
+- Requires project edit permission.
+- Requires non-empty, unique image IDs.
+- Rejects images outside the project or deleted images.
+- Validates preset name and parameters before persisting queue work.
+- Creates a `Job` row and one `JobItem` row per image.
+- Publishes messages to `image.preprocess.high` for `HIGH` priority, otherwise `image.preprocess.normal`.
+
+### RabbitMQ Message
+
+Each message contains:
+
+- `messageId`
+- `jobId`
+- `itemId`
+- `projectId`
+- `imageId`
+- `userId`
+- `originalObjectKey`
+- `preset`
+- `presetParameters`
+- `debug`
+- `priority`
+- `attempt`
+- `traceId`
+- `createdAt`
+
+### Query APIs
+
+- Users can list their own jobs.
+- Job detail, items, summary, and artifact placeholders validate project read permission.
+- Artifact and ZIP download APIs are placeholders until Worker artifact integration is implemented.
+
+### Cancel And Retry
+
+- Cancel requests mark the Job as `CANCEL_REQUESTED`.
+- Queued, pending, and retrying items are marked `CANCELLED`.
+- Processing items are not force-killed by the API server.
+- Retry publishes only failed and dead-lettered items.
+- Rerun republishes every non-processing item.
+
+## API Surface
+
+- `POST /api/v1/jobs`
+- `GET /api/v1/jobs`
+- `GET /api/v1/jobs/{jobId}`
+- `GET /api/v1/jobs/{jobId}/items`
+- `GET /api/v1/jobs/{jobId}/summary`
+- `POST /api/v1/jobs/{jobId}/cancel`
+- `POST /api/v1/jobs/{jobId}/retry`
+- `POST /api/v1/jobs/{jobId}/rerun`
+- `GET /api/v1/jobs/{jobId}/artifacts`
+- `GET /api/v1/jobs/{jobId}/download.zip`
+
+## Out Of Scope
+
+- SSE progress streaming.
+- Worker listener implementation.
+- Worker internal callback API.
+- Worker artifact registration.
+- Result ZIP generation.
+- API-side OpenCV preprocessing.
+
+## Verification
+
+- Entity tests cover Job and JobItem state transitions.
+- Service tests cover create, read permission validation, cancel, retry, and message factory behavior.
+- Controller tests cover common response wrapping.
+- Publisher tests cover normal/high priority queue routing and retry queue routing.

--- a/docs/worker/retry-policy.md
+++ b/docs/worker/retry-policy.md
@@ -1,0 +1,61 @@
+# Worker Retry Policy
+
+## Purpose
+
+This document defines the retry contract shared by the backend Job domain and future Worker implementation.
+
+## Queue Layout
+
+| Queue | Purpose |
+| --- | --- |
+| `image.preprocess.high` | High priority preprocessing work |
+| `image.preprocess.normal` | Normal and low priority preprocessing work |
+| `image.preprocess.retry` | Explicit retry and rerun work |
+| `image.preprocess.dlq` | Final failed messages after retry exhaustion |
+
+## Retryable Failures
+
+The following failures should be treated as retryable by the Worker:
+
+- Temporary Object Storage download failure.
+- Temporary Object Storage upload failure.
+- Backend internal API timeout.
+- RabbitMQ delivery interruption before acknowledgement.
+- Worker process crash before message acknowledgement.
+
+## Non-Retryable Failures
+
+The following failures should fail the item without repeated retry unless the user manually reruns it:
+
+- Image decode failure.
+- Unsupported file content despite accepted metadata.
+- Invalid preset name.
+- Invalid preset parameter payload.
+- Corrupted image bytes.
+
+## Backend Behavior Implemented In Issue 39
+
+- `POST /api/v1/jobs/{jobId}/retry` requeues only `FAILED` and `DEAD_LETTERED` items.
+- `POST /api/v1/jobs/{jobId}/rerun` requeues all non-`PROCESSING` items.
+- Retried items move to `RETRYING`.
+- Retried item `attempt` is incremented.
+- Retry messages are published to `image.preprocess.retry`.
+
+## Future Worker Behavior
+
+1. Consume a message from the selected queue.
+2. Report item started through the internal Worker API.
+3. Download the original image from Object Storage.
+4. Execute the OpenCV preprocessing pipeline.
+5. Upload processed image, preview, processing report, and optional debug artifacts.
+6. Report success or failure through the internal Worker API.
+7. Acknowledge RabbitMQ only after the item result is safely reported.
+
+## DLQ Rules
+
+The exact automatic retry count is deferred to the Worker listener task. The target policy is:
+
+- Retry transient failures up to 3 attempts.
+- Send messages to `image.preprocess.dlq` after retry exhaustion.
+- Preserve `jobId`, `itemId`, `imageId`, `attempt`, `traceId`, and failure reason.
+- Allow backend manual retry to publish a new message to `image.preprocess.retry`.


### PR DESCRIPTION
## #️⃣ 기능 설명

Job 도메인을 추가해 전처리 작업을 생성하고 이미지 단위 `JobItem`을 RabbitMQ 메시지로 발행합니다. API 서버는 작업 등록/조회/취소/재시도와 큐 발행까지만 담당하며, OpenCV 전처리는 Worker 작업으로 분리합니다.

Closes #39

## 🛠️ 작업 상세 내용

- [x] `Job`, `JobItem`, 상태 enum, repository 추가
- [x] Job 생성/목록/상세/아이템/요약 API 추가
- [x] Job 취소, 실패 항목 재시도, 전체 rerun skeleton 추가
- [x] Preprocess preset 검증 연동
- [x] RabbitMQ `PreprocessJobMessage`, queue properties, publisher 추가
- [x] Job API, 기능 명세, Worker retry policy 문서 추가
- [x] entity/service/controller/publisher 테스트 추가

## 📁 변경 파일 요약

- `backend-api/src/main/java/com/moonju/preprocess/api/domain/job/...`
- `backend-api/src/main/java/com/moonju/preprocess/api/infra/rabbitmq/...`
- `backend-api/src/test/java/com/moonju/preprocess/api/domain/job/...`
- `backend-api/src/test/java/com/moonju/preprocess/api/infra/rabbitmq/...`
- `docs/api/job-api.md`
- `docs/feature-specs/issue-39-job-domain.md`
- `docs/worker/retry-policy.md`

## ✅ 검증 내용

- [x] `docker run --rm -v "${PWD}\\backend-api:/workspace" -w /workspace gradle:8.12.1-jdk21 gradle clean test --no-daemon`
- [x] `docker run --rm -v "${PWD}\\backend-api:/workspace" -w /workspace gradle:8.12.1-jdk21 gradle build --no-daemon`
- [x] `git diff --cached --check`
- [x] staged diff secret keyword scan
- [ ] Swagger 직접 실행 확인은 미수행. Controller 단위 테스트와 build로 대체했습니다.

## 🔎 리뷰어가 확인해야 할 부분

- Job 생성 시 API 서버가 OpenCV 작업을 직접 하지 않고 RabbitMQ 메시지만 발행하는지 확인해주세요.
- `retry`와 `rerun` 범위가 현재 Worker 미구현 단계의 skeleton으로 적절한지 확인해주세요.
- Artifact/ZIP API는 Worker artifact 연동 전 placeholder로 둔 것이 의도에 맞는지 확인해주세요.

## 📸 스크린샷

없음

## 💬 기타 공유사항 to 리뷰어

- 새 환경변수는 필수로 추가하지 않았습니다. Spring RabbitMQ 기본값은 `localhost:5672`이며, 로컬 값이 다르면 `SPRING_RABBITMQ_HOST`, `SPRING_RABBITMQ_PORT`, `SPRING_RABBITMQ_USERNAME`, `SPRING_RABBITMQ_PASSWORD`를 주입하면 됩니다.