### PR TITLE
✨ [Feat] preprocess-worker 메시지 listener skeleton 추가

### DIFF
--- a/docs/feature-specs/issue-41-worker-listener-skeleton.md
+++ b/docs/feature-specs/issue-41-worker-listener-skeleton.md
@@ -1,0 +1,69 @@
+# Issue 41. Preprocess Worker Listener Skeleton
+
+## Goal
+
+Add the first executable `preprocess-worker` Spring Boot application skeleton. This issue introduces RabbitMQ listener
+boundaries, message DTOs, backend callback ports, and object storage ports without implementing OpenCV preprocessing.
+
+## Overall Order
+
+1. Add Worker Gradle and Spring Boot build files.
+2. Add safe local placeholder values in `application.yml`.
+3. Add Worker application entrypoint.
+4. Add RabbitMQ queue properties.
+5. Add `PreprocessJobMessage` DTO matching the backend Job publisher contract.
+6. Add listener skeleton for high, normal, and retry preprocessing queues.
+7. Add `WorkerJobService` orchestration skeleton.
+8. Add backend internal API client port and no-op report client.
+9. Add object storage port and no-op MinIO boundary implementation.
+10. Add unit tests for message validation, listener delegation, service orchestration, and queue defaults.
+11. Document Worker listener behavior and next work.
+
+## Functional Units
+
+### Listener
+
+- Listens to `image.preprocess.high`, `image.preprocess.normal`, and `image.preprocess.retry`.
+- Delegates message handling to `WorkerJobService`.
+- Is disabled by default through `WORKER_LISTENER_ENABLED=false` until the preprocessing pipeline exists.
+
+### Message Validation
+
+- Requires `messageId`, `jobId`, `itemId`, `projectId`, and `imageId`.
+- Requires `originalObjectKey` and `preset`.
+- Requires `attempt >= 1`.
+
+### Worker Orchestration
+
+- Reports started through the backend client boundary.
+- Prepares object storage download through the storage port boundary.
+- Reports `PIPELINE_NOT_IMPLEMENTED` until the OpenCV pipeline step task is implemented.
+
+## Safe Local Defaults
+
+These values are placeholders only and can be overridden by environment variables:
+
+- `SPRING_RABBITMQ_HOST=localhost`
+- `SPRING_RABBITMQ_PORT=5672`
+- `SPRING_RABBITMQ_USERNAME=guest`
+- `SPRING_RABBITMQ_PASSWORD=guest`
+- `BACKEND_API_INTERNAL_URL=http://localhost:8080`
+- `WORKER_INTERNAL_TOKEN=local-worker-token`
+- `MINIO_ENDPOINT=http://localhost:9000`
+- `MINIO_ACCESS_KEY=minioadmin`
+- `MINIO_SECRET_KEY=minioadmin`
+- `MINIO_BUCKET=image-preprocess-local`
+
+## Out Of Scope
+
+- OpenCV preprocessing pipeline implementation.
+- image-test repository integration.
+- Real HTTP calls to backend internal APIs.
+- Real MinIO SDK download/upload.
+- Worker heartbeat.
+- Benchmark listener.
+
+## Verification
+
+- Worker unit tests cover message validation, listener delegation, worker orchestration, and queue property defaults.
+- Worker build verifies the Spring Boot application is packageable.

--- a/docs/worker/listener-skeleton.md
+++ b/docs/worker/listener-skeleton.md
@@ -1,0 +1,81 @@
+# Worker Listener Skeleton
+
+## Purpose
+
+The Worker listener consumes preprocessing messages produced by the backend Job domain. It is the boundary between
+RabbitMQ and the future OpenCV document image preprocessing pipeline.
+
+## Current Scope
+
+Implemented in issue 41:
+
+- `PreprocessWorkerApplication`
+- `PreprocessJobListener`
+- `PreprocessJobMessage`
+- `WorkerJobService`
+- `BackendApiClient` port
+- `ObjectStoragePort` port
+- safe local configuration defaults
+
+## Listener Activation
+
+The listener is disabled by default:
+
+```text
+WORKER_LISTENER_ENABLED=false
+```
+
+Enable it only when RabbitMQ is running and the team intentionally wants the Worker to consume messages:
+
+```text
+WORKER_LISTENER_ENABLED=true
+```
+
+## Queues
+
+| Environment Variable | Default |
+| --- | --- |
+| `RABBITMQ_PREPROCESS_HIGH_QUEUE` | `image.preprocess.high` |
+| `RABBITMQ_PREPROCESS_NORMAL_QUEUE` | `image.preprocess.normal` |
+| `RABBITMQ_PREPROCESS_RETRY_QUEUE` | `image.preprocess.retry` |
+
+## Message Contract
+
+```json
+{
+  "messageId": "msg-uuid",
+  "jobId": 1,
+  "itemId": 10,
+  "projectId": 1,
+  "imageId": 100,
+  "userId": 20,
+  "originalObjectKey": "originals/1/1/100/scan.png",
+  "preset": "A4_SCAN_300DPI",
+  "presetParameters": {
+    "targetDpi": "300"
+  },
+  "debug": false,
+  "priority": "NORMAL",
+  "attempt": 1,
+  "traceId": "trace-uuid",
+  "createdAt": "2026-05-10T00:00:00Z"
+}
+```
+
+## Current Runtime Behavior
+
+Until the OpenCV preprocessing pipeline is implemented, a valid message follows this skeleton flow:
+
+1. Validate message identity fields.
+2. Report started through the backend API client boundary.
+3. Prepare object storage download through the storage port boundary.
+4. Report `PIPELINE_NOT_IMPLEMENTED`.
+
+This prevents the skeleton Worker from pretending to process images successfully before the real pipeline exists.
+
+## Next Work
+
+1. Add Worker internal API HTTP client implementation.
+2. Add MinIO/S3 SDK adapter implementation.
+3. Add preprocessing pipeline step skeleton.
+4. Connect pipeline result to processed image, preview, report, and debug artifact upload.

--- a/preprocess-worker/Dockerfile
+++ b/preprocess-worker/Dockerfile
@@ -1,0 +1,12 @@
+FROM gradle:8.12.1-jdk21 AS build
+
+WORKDIR /workspace
+COPY . .
+RUN gradle clean bootJar --no-daemon
+
+FROM eclipse-temurin:21-jre
+
+WORKDIR /app
+COPY --from=build /workspace/build/libs/*.jar app.jar
+
+ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/preprocess-worker/build.gradle
+++ b/preprocess-worker/build.gradle
@@ -1,0 +1,41 @@
+plugins {
+    id 'java'
+    id 'org.springframework.boot' version '3.4.5'
+    id 'io.spring.dependency-management' version '1.1.7'
+}
+
+group = 'com.moonju.preprocess'
+version = '0.0.1-SNAPSHOT'
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(21)
+    }
+}
+
+configurations {
+    compileOnly {
+        extendsFrom annotationProcessor
+    }
+}
+
+dependencies {
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
+    implementation 'org.springframework.boot:spring-boot-starter-amqp'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
+
+    compileOnly 'org.projectlombok:lombok'
+    annotationProcessor 'org.projectlombok:lombok'
+    annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
+
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+}
+
+tasks.named('test') {
+    useJUnitPlatform()
+}
+
+tasks.withType(JavaCompile).configureEach {
+    options.compilerArgs += '-parameters'
+}

--- a/preprocess-worker/settings.gradle
+++ b/preprocess-worker/settings.gradle
@@ -1,0 +1,15 @@
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+        mavenCentral()
+    }
+}
+
+dependencyResolutionManagement {
+    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+    repositories {
+        mavenCentral()
+    }
+}
+
+rootProject.name = 'preprocess-worker'

--- a/preprocess-worker/src/main/java/com/moonju/preprocess/worker/PreprocessWorkerApplication.java
+++ b/preprocess-worker/src/main/java/com/moonju/preprocess/worker/PreprocessWorkerApplication.java
@@ -1,0 +1,12 @@
+package com.moonju.preprocess.worker;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class PreprocessWorkerApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(PreprocessWorkerApplication.class, args);
+    }
+}

--- a/preprocess-worker/src/main/java/com/moonju/preprocess/worker/domain/workerjob/dto/JobPriority.java
+++ b/preprocess-worker/src/main/java/com/moonju/preprocess/worker/domain/workerjob/dto/JobPriority.java
@@ -1,0 +1,7 @@
+package com.moonju.preprocess.worker.domain.workerjob.dto;
+
+public enum JobPriority {
+    LOW,
+    NORMAL,
+    HIGH
+}

--- a/preprocess-worker/src/main/java/com/moonju/preprocess/worker/domain/workerjob/dto/PreprocessJobMessage.java
+++ b/preprocess-worker/src/main/java/com/moonju/preprocess/worker/domain/workerjob/dto/PreprocessJobMessage.java
@@ -1,0 +1,43 @@
+package com.moonju.preprocess.worker.domain.workerjob.dto;
+
+import com.moonju.preprocess.worker.domain.workerjob.exception.InvalidWorkerMessageException;
+import java.time.Instant;
+import java.util.Map;
+
+public record PreprocessJobMessage(
+    String messageId,
+    Long jobId,
+    Long itemId,
+    Long projectId,
+    Long imageId,
+    Long userId,
+    String originalObjectKey,
+    String preset,
+    Map<String, String> presetParameters,
+    boolean debug,
+    JobPriority priority,
+    int attempt,
+    String traceId,
+    Instant createdAt
+) {
+
+    public Map<String, String> safePresetParameters() {
+        return presetParameters == null ? Map.of() : presetParameters;
+    }
+
+    public void validateRequiredFields() {
+        if (isBlank(messageId) || jobId == null || itemId == null || projectId == null || imageId == null) {
+            throw new InvalidWorkerMessageException("Message identity fields are required.");
+        }
+        if (isBlank(originalObjectKey) || isBlank(preset)) {
+            throw new InvalidWorkerMessageException("Original object key and preset are required.");
+        }
+        if (attempt < 1) {
+            throw new InvalidWorkerMessageException("Attempt must be greater than zero.");
+        }
+    }
+
+    private boolean isBlank(String value) {
+        return value == null || value.isBlank();
+    }
+}

--- a/preprocess-worker/src/main/java/com/moonju/preprocess/worker/domain/workerjob/dto/WorkerJobResult.java
+++ b/preprocess-worker/src/main/java/com/moonju/preprocess/worker/domain/workerjob/dto/WorkerJobResult.java
@@ -1,0 +1,40 @@
+package com.moonju.preprocess.worker.domain.workerjob.dto;
+
+import com.moonju.preprocess.worker.domain.workerjob.status.WorkerFailureCode;
+import com.moonju.preprocess.worker.domain.workerjob.status.WorkerJobStatus;
+
+public record WorkerJobResult(
+    String messageId,
+    Long jobId,
+    Long itemId,
+    WorkerJobStatus status,
+    WorkerFailureCode failureCode,
+    String message
+) {
+
+    public static WorkerJobResult failed(
+        PreprocessJobMessage source,
+        WorkerFailureCode failureCode,
+        String message
+    ) {
+        return new WorkerJobResult(
+            source.messageId(),
+            source.jobId(),
+            source.itemId(),
+            WorkerJobStatus.FAILED,
+            failureCode,
+            message
+        );
+    }
+
+    public static WorkerJobResult invalid(String message) {
+        return new WorkerJobResult(
+            null,
+            null,
+            null,
+            WorkerJobStatus.FAILED,
+            WorkerFailureCode.INVALID_MESSAGE,
+            message
+        );
+    }
+}

--- a/preprocess-worker/src/main/java/com/moonju/preprocess/worker/domain/workerjob/exception/InvalidWorkerMessageException.java
+++ b/preprocess-worker/src/main/java/com/moonju/preprocess/worker/domain/workerjob/exception/InvalidWorkerMessageException.java
@@ -1,0 +1,8 @@
+package com.moonju.preprocess.worker.domain.workerjob.exception;
+
+public class InvalidWorkerMessageException extends RuntimeException {
+
+    public InvalidWorkerMessageException(String message) {
+        super(message);
+    }
+}

--- a/preprocess-worker/src/main/java/com/moonju/preprocess/worker/domain/workerjob/listener/PreprocessJobListener.java
+++ b/preprocess-worker/src/main/java/com/moonju/preprocess/worker/domain/workerjob/listener/PreprocessJobListener.java
@@ -1,0 +1,27 @@
+package com.moonju.preprocess.worker.domain.workerjob.listener;
+
+import com.moonju.preprocess.worker.domain.workerjob.dto.PreprocessJobMessage;
+import com.moonju.preprocess.worker.domain.workerjob.service.WorkerJobService;
+import org.springframework.amqp.rabbit.annotation.RabbitListener;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
+
+@Component
+@ConditionalOnProperty(prefix = "worker.listener", name = "enabled", havingValue = "true")
+public class PreprocessJobListener {
+
+    private final WorkerJobService workerJobService;
+
+    public PreprocessJobListener(WorkerJobService workerJobService) {
+        this.workerJobService = workerJobService;
+    }
+
+    @RabbitListener(queues = {
+        "${rabbitmq.queues.preprocess-high}",
+        "${rabbitmq.queues.preprocess-normal}",
+        "${rabbitmq.queues.preprocess-retry}"
+    })
+    public void handle(PreprocessJobMessage message) {
+        workerJobService.process(message);
+    }
+}

--- a/preprocess-worker/src/main/java/com/moonju/preprocess/worker/domain/workerjob/service/WorkerJobService.java
+++ b/preprocess-worker/src/main/java/com/moonju/preprocess/worker/domain/workerjob/service/WorkerJobService.java
@@ -1,0 +1,41 @@
+package com.moonju.preprocess.worker.domain.workerjob.service;
+
+import com.moonju.preprocess.worker.domain.workerjob.dto.PreprocessJobMessage;
+import com.moonju.preprocess.worker.domain.workerjob.dto.WorkerJobResult;
+import com.moonju.preprocess.worker.domain.workerjob.exception.InvalidWorkerMessageException;
+import com.moonju.preprocess.worker.domain.workerjob.status.WorkerFailureCode;
+import com.moonju.preprocess.worker.infra.api.BackendApiClient;
+import com.moonju.preprocess.worker.infra.storage.ObjectStoragePort;
+import org.springframework.stereotype.Service;
+
+@Service
+public class WorkerJobService {
+
+    private final BackendApiClient backendApiClient;
+    private final ObjectStoragePort objectStoragePort;
+
+    public WorkerJobService(BackendApiClient backendApiClient, ObjectStoragePort objectStoragePort) {
+        this.backendApiClient = backendApiClient;
+        this.objectStoragePort = objectStoragePort;
+    }
+
+    public WorkerJobResult process(PreprocessJobMessage message) {
+        try {
+            message.validateRequiredFields();
+            backendApiClient.reportStarted(message);
+            objectStoragePort.prepareDownload(message.originalObjectKey());
+            backendApiClient.reportFailed(
+                message,
+                WorkerFailureCode.PIPELINE_NOT_IMPLEMENTED,
+                "Preprocess pipeline is not implemented yet."
+            );
+            return WorkerJobResult.failed(
+                message,
+                WorkerFailureCode.PIPELINE_NOT_IMPLEMENTED,
+                "Preprocess pipeline is not implemented yet."
+            );
+        } catch (InvalidWorkerMessageException exception) {
+            return WorkerJobResult.invalid(exception.getMessage());
+        }
+    }
+}

--- a/preprocess-worker/src/main/java/com/moonju/preprocess/worker/domain/workerjob/status/WorkerFailureCode.java
+++ b/preprocess-worker/src/main/java/com/moonju/preprocess/worker/domain/workerjob/status/WorkerFailureCode.java
@@ -1,0 +1,8 @@
+package com.moonju.preprocess.worker.domain.workerjob.status;
+
+public enum WorkerFailureCode {
+    INVALID_MESSAGE,
+    PIPELINE_NOT_IMPLEMENTED,
+    STORAGE_DOWNLOAD_FAILED,
+    BACKEND_REPORT_FAILED
+}

--- a/preprocess-worker/src/main/java/com/moonju/preprocess/worker/domain/workerjob/status/WorkerJobStatus.java
+++ b/preprocess-worker/src/main/java/com/moonju/preprocess/worker/domain/workerjob/status/WorkerJobStatus.java
@@ -1,0 +1,7 @@
+package com.moonju.preprocess.worker.domain.workerjob.status;
+
+public enum WorkerJobStatus {
+    ACCEPTED,
+    SUCCEEDED,
+    FAILED
+}

--- a/preprocess-worker/src/main/java/com/moonju/preprocess/worker/infra/api/BackendApiClient.java
+++ b/preprocess-worker/src/main/java/com/moonju/preprocess/worker/infra/api/BackendApiClient.java
@@ -1,0 +1,11 @@
+package com.moonju.preprocess.worker.infra.api;
+
+import com.moonju.preprocess.worker.domain.workerjob.dto.PreprocessJobMessage;
+import com.moonju.preprocess.worker.domain.workerjob.status.WorkerFailureCode;
+
+public interface BackendApiClient {
+
+    void reportStarted(PreprocessJobMessage message);
+
+    void reportFailed(PreprocessJobMessage message, WorkerFailureCode failureCode, String failureMessage);
+}

--- a/preprocess-worker/src/main/java/com/moonju/preprocess/worker/infra/api/WorkerInternalApiProperties.java
+++ b/preprocess-worker/src/main/java/com/moonju/preprocess/worker/infra/api/WorkerInternalApiProperties.java
@@ -1,0 +1,26 @@
+package com.moonju.preprocess.worker.infra.api;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "backend-api")
+public class WorkerInternalApiProperties {
+
+    private String baseUrl = "http://localhost:8080";
+    private String workerToken = "local-worker-token";
+
+    public String getBaseUrl() {
+        return baseUrl;
+    }
+
+    public void setBaseUrl(String baseUrl) {
+        this.baseUrl = baseUrl;
+    }
+
+    public String getWorkerToken() {
+        return workerToken;
+    }
+
+    public void setWorkerToken(String workerToken) {
+        this.workerToken = workerToken;
+    }
+}

--- a/preprocess-worker/src/main/java/com/moonju/preprocess/worker/infra/api/WorkerJobReportClient.java
+++ b/preprocess-worker/src/main/java/com/moonju/preprocess/worker/infra/api/WorkerJobReportClient.java
@@ -1,0 +1,41 @@
+package com.moonju.preprocess.worker.infra.api;
+
+import com.moonju.preprocess.worker.domain.workerjob.dto.PreprocessJobMessage;
+import com.moonju.preprocess.worker.domain.workerjob.status.WorkerFailureCode;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+@Component
+public class WorkerJobReportClient implements BackendApiClient {
+
+    private static final Logger log = LoggerFactory.getLogger(WorkerJobReportClient.class);
+
+    private final WorkerInternalApiProperties properties;
+
+    public WorkerJobReportClient(WorkerInternalApiProperties properties) {
+        this.properties = properties;
+    }
+
+    @Override
+    public void reportStarted(PreprocessJobMessage message) {
+        log.info(
+            "Worker reportStarted skeleton: baseUrl={}, jobId={}, itemId={}",
+            properties.getBaseUrl(),
+            message.jobId(),
+            message.itemId()
+        );
+    }
+
+    @Override
+    public void reportFailed(PreprocessJobMessage message, WorkerFailureCode failureCode, String failureMessage) {
+        log.info(
+            "Worker reportFailed skeleton: baseUrl={}, jobId={}, itemId={}, code={}, message={}",
+            properties.getBaseUrl(),
+            message.jobId(),
+            message.itemId(),
+            failureCode,
+            failureMessage
+        );
+    }
+}

--- a/preprocess-worker/src/main/java/com/moonju/preprocess/worker/infra/rabbitmq/WorkerQueueProperties.java
+++ b/preprocess-worker/src/main/java/com/moonju/preprocess/worker/infra/rabbitmq/WorkerQueueProperties.java
@@ -1,0 +1,44 @@
+package com.moonju.preprocess.worker.infra.rabbitmq;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "rabbitmq.queues")
+public class WorkerQueueProperties {
+
+    private String preprocessHigh = "image.preprocess.high";
+    private String preprocessNormal = "image.preprocess.normal";
+    private String preprocessRetry = "image.preprocess.retry";
+    private String benchmarkNormal = "image.benchmark.normal";
+
+    public String getPreprocessHigh() {
+        return preprocessHigh;
+    }
+
+    public void setPreprocessHigh(String preprocessHigh) {
+        this.preprocessHigh = preprocessHigh;
+    }
+
+    public String getPreprocessNormal() {
+        return preprocessNormal;
+    }
+
+    public void setPreprocessNormal(String preprocessNormal) {
+        this.preprocessNormal = preprocessNormal;
+    }
+
+    public String getPreprocessRetry() {
+        return preprocessRetry;
+    }
+
+    public void setPreprocessRetry(String preprocessRetry) {
+        this.preprocessRetry = preprocessRetry;
+    }
+
+    public String getBenchmarkNormal() {
+        return benchmarkNormal;
+    }
+
+    public void setBenchmarkNormal(String benchmarkNormal) {
+        this.benchmarkNormal = benchmarkNormal;
+    }
+}

--- a/preprocess-worker/src/main/java/com/moonju/preprocess/worker/infra/rabbitmq/WorkerRabbitMqConfig.java
+++ b/preprocess-worker/src/main/java/com/moonju/preprocess/worker/infra/rabbitmq/WorkerRabbitMqConfig.java
@@ -1,0 +1,15 @@
+package com.moonju.preprocess.worker.infra.rabbitmq;
+
+import com.moonju.preprocess.worker.infra.api.WorkerInternalApiProperties;
+import com.moonju.preprocess.worker.infra.storage.StorageProperties;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@EnableConfigurationProperties({
+    WorkerQueueProperties.class,
+    WorkerInternalApiProperties.class,
+    StorageProperties.class
+})
+public class WorkerRabbitMqConfig {
+}

--- a/preprocess-worker/src/main/java/com/moonju/preprocess/worker/infra/storage/MinioObjectStorageClient.java
+++ b/preprocess-worker/src/main/java/com/moonju/preprocess/worker/infra/storage/MinioObjectStorageClient.java
@@ -1,0 +1,27 @@
+package com.moonju.preprocess.worker.infra.storage;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+@Component
+public class MinioObjectStorageClient implements ObjectStoragePort {
+
+    private static final Logger log = LoggerFactory.getLogger(MinioObjectStorageClient.class);
+
+    private final StorageProperties properties;
+
+    public MinioObjectStorageClient(StorageProperties properties) {
+        this.properties = properties;
+    }
+
+    @Override
+    public void prepareDownload(String objectKey) {
+        log.info(
+            "Object storage download skeleton: endpoint={}, bucket={}, objectKey={}",
+            properties.getEndpoint(),
+            properties.getBucket(),
+            objectKey
+        );
+    }
+}

--- a/preprocess-worker/src/main/java/com/moonju/preprocess/worker/infra/storage/ObjectStoragePort.java
+++ b/preprocess-worker/src/main/java/com/moonju/preprocess/worker/infra/storage/ObjectStoragePort.java
@@ -1,0 +1,6 @@
+package com.moonju.preprocess.worker.infra.storage;
+
+public interface ObjectStoragePort {
+
+    void prepareDownload(String objectKey);
+}

--- a/preprocess-worker/src/main/java/com/moonju/preprocess/worker/infra/storage/StorageProperties.java
+++ b/preprocess-worker/src/main/java/com/moonju/preprocess/worker/infra/storage/StorageProperties.java
@@ -1,0 +1,44 @@
+package com.moonju.preprocess.worker.infra.storage;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "storage")
+public class StorageProperties {
+
+    private String endpoint = "http://localhost:9000";
+    private String accessKey = "minioadmin";
+    private String secretKey = "minioadmin";
+    private String bucket = "image-preprocess-local";
+
+    public String getEndpoint() {
+        return endpoint;
+    }
+
+    public void setEndpoint(String endpoint) {
+        this.endpoint = endpoint;
+    }
+
+    public String getAccessKey() {
+        return accessKey;
+    }
+
+    public void setAccessKey(String accessKey) {
+        this.accessKey = accessKey;
+    }
+
+    public String getSecretKey() {
+        return secretKey;
+    }
+
+    public void setSecretKey(String secretKey) {
+        this.secretKey = secretKey;
+    }
+
+    public String getBucket() {
+        return bucket;
+    }
+
+    public void setBucket(String bucket) {
+        this.bucket = bucket;
+    }
+}

--- a/preprocess-worker/src/main/resources/application.yml
+++ b/preprocess-worker/src/main/resources/application.yml
@@ -1,0 +1,41 @@
+spring:
+  application:
+    name: preprocess-worker
+  main:
+    web-application-type: none
+  rabbitmq:
+    host: ${SPRING_RABBITMQ_HOST:localhost}
+    port: ${SPRING_RABBITMQ_PORT:5672}
+    username: ${SPRING_RABBITMQ_USERNAME:guest}
+    password: ${SPRING_RABBITMQ_PASSWORD:guest}
+
+management:
+  health:
+    rabbit:
+      enabled: ${RABBIT_HEALTH_ENABLED:false}
+  endpoints:
+    web:
+      exposure:
+        include: health,info
+
+rabbitmq:
+  queues:
+    preprocess-high: ${RABBITMQ_PREPROCESS_HIGH_QUEUE:image.preprocess.high}
+    preprocess-normal: ${RABBITMQ_PREPROCESS_NORMAL_QUEUE:image.preprocess.normal}
+    preprocess-retry: ${RABBITMQ_PREPROCESS_RETRY_QUEUE:image.preprocess.retry}
+    benchmark-normal: ${RABBITMQ_BENCHMARK_NORMAL_QUEUE:image.benchmark.normal}
+
+worker:
+  id: ${WORKER_ID:local-worker-1}
+  listener:
+    enabled: ${WORKER_LISTENER_ENABLED:false}
+
+backend-api:
+  base-url: ${BACKEND_API_INTERNAL_URL:http://localhost:8080}
+  worker-token: ${WORKER_INTERNAL_TOKEN:local-worker-token}
+
+storage:
+  endpoint: ${MINIO_ENDPOINT:http://localhost:9000}
+  access-key: ${MINIO_ACCESS_KEY:minioadmin}
+  secret-key: ${MINIO_SECRET_KEY:minioadmin}
+  bucket: ${MINIO_BUCKET:image-preprocess-local}

--- a/preprocess-worker/src/test/java/com/moonju/preprocess/worker/domain/workerjob/dto/PreprocessJobMessageTests.java
+++ b/preprocess-worker/src/test/java/com/moonju/preprocess/worker/domain/workerjob/dto/PreprocessJobMessageTests.java
@@ -1,0 +1,63 @@
+package com.moonju.preprocess.worker.domain.workerjob.dto;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.moonju.preprocess.worker.domain.workerjob.exception.InvalidWorkerMessageException;
+import java.time.Instant;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class PreprocessJobMessageTests {
+
+    @Test
+    void validatesRequiredIdentityFields() {
+        PreprocessJobMessage message = new PreprocessJobMessage(
+            null,
+            1L,
+            2L,
+            3L,
+            4L,
+            5L,
+            "originals/scan.png",
+            "A4_SCAN_300DPI",
+            Map.of(),
+            false,
+            JobPriority.NORMAL,
+            1,
+            "trace",
+            Instant.parse("2026-05-10T00:00:00Z")
+        );
+
+        assertThatThrownBy(message::validateRequiredFields)
+            .isInstanceOf(InvalidWorkerMessageException.class)
+            .hasMessage("Message identity fields are required.");
+    }
+
+    @Test
+    void validatesAttempt() {
+        PreprocessJobMessage message = validMessage(0);
+
+        assertThatThrownBy(message::validateRequiredFields)
+            .isInstanceOf(InvalidWorkerMessageException.class)
+            .hasMessage("Attempt must be greater than zero.");
+    }
+
+    private PreprocessJobMessage validMessage(int attempt) {
+        return new PreprocessJobMessage(
+            "msg",
+            1L,
+            2L,
+            3L,
+            4L,
+            5L,
+            "originals/scan.png",
+            "A4_SCAN_300DPI",
+            Map.of(),
+            false,
+            JobPriority.NORMAL,
+            attempt,
+            "trace",
+            Instant.parse("2026-05-10T00:00:00Z")
+        );
+    }
+}

--- a/preprocess-worker/src/test/java/com/moonju/preprocess/worker/domain/workerjob/listener/PreprocessJobListenerTests.java
+++ b/preprocess-worker/src/test/java/com/moonju/preprocess/worker/domain/workerjob/listener/PreprocessJobListenerTests.java
@@ -1,0 +1,43 @@
+package com.moonju.preprocess.worker.domain.workerjob.listener;
+
+import static org.mockito.Mockito.verify;
+
+import com.moonju.preprocess.worker.domain.workerjob.dto.JobPriority;
+import com.moonju.preprocess.worker.domain.workerjob.dto.PreprocessJobMessage;
+import com.moonju.preprocess.worker.domain.workerjob.service.WorkerJobService;
+import java.time.Instant;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class PreprocessJobListenerTests {
+
+    @Test
+    void delegatesMessageToWorkerJobService() {
+        WorkerJobService service = org.mockito.Mockito.mock(WorkerJobService.class);
+        PreprocessJobListener listener = new PreprocessJobListener(service);
+        PreprocessJobMessage message = message();
+
+        listener.handle(message);
+
+        verify(service).process(message);
+    }
+
+    private PreprocessJobMessage message() {
+        return new PreprocessJobMessage(
+            "msg",
+            1L,
+            2L,
+            3L,
+            4L,
+            5L,
+            "originals/scan.png",
+            "A4_SCAN_300DPI",
+            Map.of(),
+            false,
+            JobPriority.NORMAL,
+            1,
+            "trace",
+            Instant.parse("2026-05-10T00:00:00Z")
+        );
+    }
+}

--- a/preprocess-worker/src/test/java/com/moonju/preprocess/worker/domain/workerjob/service/WorkerJobServiceTests.java
+++ b/preprocess-worker/src/test/java/com/moonju/preprocess/worker/domain/workerjob/service/WorkerJobServiceTests.java
@@ -1,0 +1,85 @@
+package com.moonju.preprocess.worker.domain.workerjob.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+import com.moonju.preprocess.worker.domain.workerjob.dto.JobPriority;
+import com.moonju.preprocess.worker.domain.workerjob.dto.PreprocessJobMessage;
+import com.moonju.preprocess.worker.domain.workerjob.dto.WorkerJobResult;
+import com.moonju.preprocess.worker.domain.workerjob.status.WorkerFailureCode;
+import com.moonju.preprocess.worker.domain.workerjob.status.WorkerJobStatus;
+import com.moonju.preprocess.worker.infra.api.BackendApiClient;
+import com.moonju.preprocess.worker.infra.storage.ObjectStoragePort;
+import java.time.Instant;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class WorkerJobServiceTests {
+
+    private final BackendApiClient backendApiClient = org.mockito.Mockito.mock(BackendApiClient.class);
+    private final ObjectStoragePort objectStoragePort = org.mockito.Mockito.mock(ObjectStoragePort.class);
+    private final WorkerJobService service = new WorkerJobService(backendApiClient, objectStoragePort);
+
+    @Test
+    void reportsPipelineNotImplementedUntilPreprocessPipelineIsAdded() {
+        PreprocessJobMessage message = validMessage();
+
+        WorkerJobResult result = service.process(message);
+
+        assertThat(result.status()).isEqualTo(WorkerJobStatus.FAILED);
+        assertThat(result.failureCode()).isEqualTo(WorkerFailureCode.PIPELINE_NOT_IMPLEMENTED);
+        verify(backendApiClient).reportStarted(message);
+        verify(objectStoragePort).prepareDownload("originals/scan.png");
+        verify(backendApiClient).reportFailed(
+            message,
+            WorkerFailureCode.PIPELINE_NOT_IMPLEMENTED,
+            "Preprocess pipeline is not implemented yet."
+        );
+    }
+
+    @Test
+    void rejectsInvalidMessageBeforeExternalCalls() {
+        PreprocessJobMessage message = new PreprocessJobMessage(
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            Map.of(),
+            false,
+            JobPriority.NORMAL,
+            0,
+            null,
+            null
+        );
+
+        WorkerJobResult result = service.process(message);
+
+        assertThat(result.status()).isEqualTo(WorkerJobStatus.FAILED);
+        assertThat(result.failureCode()).isEqualTo(WorkerFailureCode.INVALID_MESSAGE);
+        verifyNoInteractions(backendApiClient, objectStoragePort);
+    }
+
+    private PreprocessJobMessage validMessage() {
+        return new PreprocessJobMessage(
+            "msg",
+            1L,
+            2L,
+            3L,
+            4L,
+            5L,
+            "originals/scan.png",
+            "A4_SCAN_300DPI",
+            Map.of("targetDpi", "300"),
+            false,
+            JobPriority.NORMAL,
+            1,
+            "trace",
+            Instant.parse("2026-05-10T00:00:00Z")
+        );
+    }
+}

--- a/preprocess-worker/src/test/java/com/moonju/preprocess/worker/infra/rabbitmq/WorkerQueuePropertiesTests.java
+++ b/preprocess-worker/src/test/java/com/moonju/preprocess/worker/infra/rabbitmq/WorkerQueuePropertiesTests.java
@@ -1,0 +1,18 @@
+package com.moonju.preprocess.worker.infra.rabbitmq;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class WorkerQueuePropertiesTests {
+
+    @Test
+    void providesSafeLocalQueueDefaults() {
+        WorkerQueueProperties properties = new WorkerQueueProperties();
+
+        assertThat(properties.getPreprocessHigh()).isEqualTo("image.preprocess.high");
+        assertThat(properties.getPreprocessNormal()).isEqualTo("image.preprocess.normal");
+        assertThat(properties.getPreprocessRetry()).isEqualTo("image.preprocess.retry");
+        assertThat(properties.getBenchmarkNormal()).isEqualTo("image.benchmark.normal");
+    }
+}


### PR DESCRIPTION
## #️⃣ 기능 설명

`preprocess-worker`를 실행 가능한 Spring Boot 앱으로 구성하고, RabbitMQ preprocessing 메시지 listener skeleton을 추가했습니다. 실제 OpenCV pipeline은 다음 작업으로 분리하고, 이번 PR은 Worker 경계와 메시지 처리 흐름만 잡습니다.

Closes #41

## 🛠️ 작업 상세 내용

- [x] `preprocess-worker` Gradle/Spring Boot 3.4.5 구성 추가
- [x] Worker Dockerfile 추가
- [x] 안전한 로컬 placeholder 기본값이 들어간 `application.yml` 추가
- [x] `PreprocessJobMessage` DTO와 필수 필드 검증 추가
- [x] high/normal/retry queue listener skeleton 추가
- [x] `WorkerJobService` orchestration skeleton 추가
- [x] backend callback client port와 storage port skeleton 추가
- [x] listener/message/service/properties 단위 테스트 추가
- [x] Worker listener 명세 문서 추가

## 📁 변경 파일 요약

- `preprocess-worker/build.gradle`
- `preprocess-worker/settings.gradle`
- `preprocess-worker/Dockerfile`
- `preprocess-worker/src/main/java/com/moonju/preprocess/worker/...`
- `preprocess-worker/src/test/java/com/moonju/preprocess/worker/...`
- `docs/feature-specs/issue-41-worker-listener-skeleton.md`
- `docs/worker/listener-skeleton.md`

## ✅ 검증 내용

- [x] `docker run --rm -v "${PWD}\\preprocess-worker:/workspace" -w /workspace gradle:8.12.1-jdk21 gradle clean test --no-daemon`
- [x] `docker run --rm -v "${PWD}\\preprocess-worker:/workspace" -w /workspace gradle:8.12.1-jdk21 gradle build --no-daemon`
- [x] `git diff --check`
- [x] staged diff에서 실제 Google/OAuth secret 없음 확인

## 🔎 리뷰어가 확인해야 할 부분

- Worker listener가 기본 비활성화(`WORKER_LISTENER_ENABLED=false`)인 것이 현재 pipeline 미구현 단계에 적절한지 확인해주세요.
- 현재 Worker는 유효 메시지를 받으면 `PIPELINE_NOT_IMPLEMENTED`로 실패 처리하는 skeleton입니다. 실제 처리 성공은 다음 pipeline 작업에서 연결합니다.
- `minioadmin`, `guest`, `local-worker-token`은 로컬 placeholder 값이며 운영 secret이 아닙니다.

## 📸 스크린샷

없음

## 💬 기타 공유사항 to 리뷰어

- 이번 PR은 Worker에 OAuth, 화면 API, DB 접근 로직을 넣지 않았습니다.
- 실제 Backend internal API HTTP 호출과 MinIO SDK 연동은 후속 작업으로 분리했습니다.