### PR TITLE
✨ [Feat] preprocess-worker 전처리 pipeline step skeleton 추가

### DIFF
--- a/docs/feature-specs/issue-43-worker-preprocess-pipeline.md
+++ b/docs/feature-specs/issue-43-worker-preprocess-pipeline.md
@@ -1,0 +1,90 @@
+# Issue 43. Worker Preprocess Pipeline Step Skeleton
+
+## Goal
+
+Add the Worker-side preprocessing pipeline contract. This is not a simple resize worker. The pipeline explicitly models
+document image preprocessing steps needed before OCR and keeps actual OpenCV implementation deferred to later tasks.
+
+## Overall Order
+
+1. Define `PreprocessStepName`.
+2. Define `PreprocessStep`.
+3. Add skeleton step classes for every required document preprocessing stage.
+4. Add `PreprocessStepCatalog`.
+5. Define `PreprocessPresetName`.
+6. Add built-in preset definitions.
+7. Add `PreprocessPresetRegistry`.
+8. Add `PreprocessContext`.
+9. Add `PreprocessPipeline`.
+10. Add `PreprocessPipelineRunner`.
+11. Connect `WorkerJobService` to execute the pipeline skeleton.
+12. Keep Worker result as failed with `PIPELINE_NOT_IMPLEMENTED` until OpenCV and artifact integration exist.
+13. Add unit tests for preset names, step catalog, execution order, and worker service boundary.
+14. Document the Worker pipeline behavior.
+
+## Functional Units
+
+### Step Contract
+
+Every step implements `PreprocessStep`:
+
+- `name()`
+- `execute(PreprocessContext context)`
+
+Current steps record skeleton execution notes only. They do not process image bytes yet.
+
+### Required Steps
+
+The catalog registers these steps:
+
+1. `DECODE`
+2. `COLOR_NORMALIZE`
+3. `ORIENTATION_NORMALIZE`
+4. `DESKEW`
+5. `CROP`
+6. `DENOISE`
+7. `CONTRAST_NORMALIZE`
+8. `BINARIZATION`
+9. `MORPHOLOGY_CLEANUP`
+10. `DPI_NORMALIZE`
+11. `OPTIONAL_SHARPEN`
+
+### Presets
+
+The registry supports:
+
+- `A4_SCAN_300DPI`
+- `LOW_CONTRAST_SCAN`
+- `RECEIPT`
+- `NOISY_SCAN`
+- `AUTO`
+
+`AUTO` currently reserves the Worker-side selection boundary. Actual image feature analysis is deferred.
+
+### Worker Service Boundary
+
+`WorkerJobService` now:
+
+1. Validates the message.
+2. Reports started.
+3. Prepares object storage download.
+4. Executes the pipeline skeleton.
+5. Reports `PIPELINE_NOT_IMPLEMENTED`.
+
+The Worker intentionally does not report success because OpenCV processing and artifact upload are not implemented yet.
+
+## Out Of Scope
+
+- OpenCV `Mat` loading and memory management.
+- image-test repository integration.
+- Actual deskew, crop, denoise, contrast, binarization, morphology, DPI, or sharpen algorithms.
+- Debug artifact generation.
+- Processed image upload.
+- Backend success callback.
+
+## Verification
+
+- `PreprocessStepCatalogTests` verifies every required step is registered.
+- `PreprocessPresetRegistryTests` verifies required preset names and full document step sequence.
+- `PreprocessPipelineRunnerTests` verifies execution order.
+- `WorkerJobServiceTests` verifies the Worker executes the skeleton and still reports the not-implemented boundary.

--- a/docs/worker/listener-skeleton.md
+++ b/docs/worker/listener-skeleton.md
@@ -64,12 +64,13 @@ WORKER_LISTENER_ENABLED=true
 
 ## Current Runtime Behavior
 
-Until the OpenCV preprocessing pipeline is implemented, a valid message follows this skeleton flow:
+Until the OpenCV preprocessing pipeline is fully implemented, a valid message follows this skeleton flow:
 
 1. Validate message identity fields.
 2. Report started through the backend API client boundary.
 3. Prepare object storage download through the storage port boundary.
-4. Report `PIPELINE_NOT_IMPLEMENTED`.
+4. Execute the preprocessing pipeline skeleton.
+5. Report `PIPELINE_NOT_IMPLEMENTED`.
 
 This prevents the skeleton Worker from pretending to process images successfully before the real pipeline exists.
 
@@ -77,5 +78,5 @@ This prevents the skeleton Worker from pretending to process images successfully
 
 1. Add Worker internal API HTTP client implementation.
 2. Add MinIO/S3 SDK adapter implementation.
-3. Add preprocessing pipeline step skeleton.
+3. Replace pipeline skeleton steps with image-test/OpenCV-backed implementations.
 4. Connect pipeline result to processed image, preview, report, and debug artifact upload.

--- a/docs/worker/preprocess-pipeline.md
+++ b/docs/worker/preprocess-pipeline.md
@@ -1,0 +1,77 @@
+# Worker Preprocess Pipeline
+
+## Purpose
+
+The Worker preprocessing pipeline models the OCR-oriented document image preprocessing mechanism that will be backed by
+OpenCV and the `image-test` repository logic. It is not a thumbnail or resize-only pipeline.
+
+## Current Implementation
+
+Issue 43 adds the pipeline skeleton:
+
+- `PreprocessContext`
+- `PreprocessPipeline`
+- `PreprocessPipelineRunner`
+- `PreprocessResult`
+- `PreprocessStep`
+- `PreprocessStepCatalog`
+- built-in preset registry
+
+Each step currently records a skeleton execution note. Actual image mutation is deferred.
+
+## Required Execution Order
+
+Every built-in document preset executes the following order:
+
+1. `DECODE`
+2. `COLOR_NORMALIZE`
+3. `ORIENTATION_NORMALIZE`
+4. `DESKEW`
+5. `CROP`
+6. `DENOISE`
+7. `CONTRAST_NORMALIZE`
+8. `BINARIZATION`
+9. `MORPHOLOGY_CLEANUP`
+10. `DPI_NORMALIZE`
+11. `OPTIONAL_SHARPEN`
+
+`DPI_NORMALIZE` is reserved for OCR quality normalization. It must not be reduced to a thumbnail resize shortcut.
+
+## Preset Registry
+
+Supported preset names:
+
+- `A4_SCAN_300DPI`
+- `LOW_CONTRAST_SCAN`
+- `RECEIPT`
+- `NOISY_SCAN`
+- `AUTO`
+
+Preset names must stay aligned with the backend `/api/v1/preprocess/presets` contract.
+
+## Worker Runtime Boundary
+
+The current Worker flow executes the skeleton and then reports:
+
+```text
+PIPELINE_NOT_IMPLEMENTED
+```
+
+This is intentional. A successful Worker result requires all of the following future integrations:
+
+- Actual OpenCV processing.
+- Object Storage download.
+- Processed image upload.
+- Preview upload.
+- Processing report upload.
+- Optional debug artifact upload.
+- Backend success callback.
+
+## Next Implementation Steps
+
+1. Add image codec adapter and OpenCV loader.
+2. Replace `DecodeStep` skeleton with actual image decode.
+3. Add `ImageMatHolder` and resource cleanup.
+4. Implement steps one by one with unit tests.
+5. Add report generation per step.
+6. Add artifact save service.

--- a/docs/worker/preset-spec.md
+++ b/docs/worker/preset-spec.md
@@ -65,7 +65,7 @@ implemented as a thumbnail resize shortcut.
 
 ## Future Worker Work
 
-- Implement Worker-side `PreprocessPresetRegistry`.
-- Map backend preset names to Worker pipeline step parameters.
+- Replace Worker-side `PreprocessPresetRegistry` skeleton with image-test-backed runtime behavior.
+- Map backend preset parameters to real OpenCV step parameters.
 - Add `AutoPresetSelector` based on image characteristics.
 - Add Worker tests that compare supported preset names with backend documentation.

--- a/preprocess-worker/src/main/java/com/moonju/preprocess/worker/domain/preprocess/exception/PreprocessStepNotFoundException.java
+++ b/preprocess-worker/src/main/java/com/moonju/preprocess/worker/domain/preprocess/exception/PreprocessStepNotFoundException.java
@@ -1,0 +1,10 @@
+package com.moonju.preprocess.worker.domain.preprocess.exception;
+
+import com.moonju.preprocess.worker.domain.preprocess.step.PreprocessStepName;
+
+public class PreprocessStepNotFoundException extends RuntimeException {
+
+    public PreprocessStepNotFoundException(PreprocessStepName stepName) {
+        super("Preprocess step is not registered: " + stepName);
+    }
+}

--- a/preprocess-worker/src/main/java/com/moonju/preprocess/worker/domain/preprocess/exception/PresetNotSupportedException.java
+++ b/preprocess-worker/src/main/java/com/moonju/preprocess/worker/domain/preprocess/exception/PresetNotSupportedException.java
@@ -1,0 +1,8 @@
+package com.moonju.preprocess.worker.domain.preprocess.exception;
+
+public class PresetNotSupportedException extends RuntimeException {
+
+    public PresetNotSupportedException(String presetName) {
+        super("Unsupported preprocess preset: " + presetName);
+    }
+}

--- a/preprocess-worker/src/main/java/com/moonju/preprocess/worker/domain/preprocess/pipeline/PreprocessContext.java
+++ b/preprocess-worker/src/main/java/com/moonju/preprocess/worker/domain/preprocess/pipeline/PreprocessContext.java
@@ -1,0 +1,78 @@
+package com.moonju.preprocess.worker.domain.preprocess.pipeline;
+
+import com.moonju.preprocess.worker.domain.preprocess.step.PreprocessStepName;
+import com.moonju.preprocess.worker.domain.workerjob.dto.PreprocessJobMessage;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+public class PreprocessContext {
+
+    private final Long jobId;
+    private final Long itemId;
+    private final String originalObjectKey;
+    private final String presetName;
+    private final Map<String, String> parameters;
+    private final boolean debug;
+    private final List<PreprocessStepExecution> stepExecutions = new ArrayList<>();
+
+    public PreprocessContext(
+        Long jobId,
+        Long itemId,
+        String originalObjectKey,
+        String presetName,
+        Map<String, String> parameters,
+        boolean debug
+    ) {
+        this.jobId = jobId;
+        this.itemId = itemId;
+        this.originalObjectKey = originalObjectKey;
+        this.presetName = presetName;
+        this.parameters = new LinkedHashMap<>(parameters);
+        this.debug = debug;
+    }
+
+    public static PreprocessContext fromMessage(PreprocessJobMessage message) {
+        return new PreprocessContext(
+            message.jobId(),
+            message.itemId(),
+            message.originalObjectKey(),
+            message.preset(),
+            message.safePresetParameters(),
+            message.debug()
+        );
+    }
+
+    public void recordStep(PreprocessStepName stepName, String note) {
+        stepExecutions.add(new PreprocessStepExecution(stepName, note));
+    }
+
+    public Long jobId() {
+        return jobId;
+    }
+
+    public Long itemId() {
+        return itemId;
+    }
+
+    public String originalObjectKey() {
+        return originalObjectKey;
+    }
+
+    public String presetName() {
+        return presetName;
+    }
+
+    public Map<String, String> parameters() {
+        return Map.copyOf(parameters);
+    }
+
+    public boolean debug() {
+        return debug;
+    }
+
+    public List<PreprocessStepExecution> stepExecutions() {
+        return List.copyOf(stepExecutions);
+    }
+}

--- a/preprocess-worker/src/main/java/com/moonju/preprocess/worker/domain/preprocess/pipeline/PreprocessPipeline.java
+++ b/preprocess-worker/src/main/java/com/moonju/preprocess/worker/domain/preprocess/pipeline/PreprocessPipeline.java
@@ -1,0 +1,16 @@
+package com.moonju.preprocess.worker.domain.preprocess.pipeline;
+
+import com.moonju.preprocess.worker.domain.preprocess.preset.PreprocessPreset;
+import com.moonju.preprocess.worker.domain.preprocess.step.PreprocessStep;
+import com.moonju.preprocess.worker.domain.preprocess.step.PreprocessStepCatalog;
+import java.util.List;
+
+public record PreprocessPipeline(
+    PreprocessPreset preset,
+    List<PreprocessStep> steps
+) {
+
+    public static PreprocessPipeline from(PreprocessPreset preset, PreprocessStepCatalog stepCatalog) {
+        return new PreprocessPipeline(preset, stepCatalog.resolveAll(preset.steps()));
+    }
+}

--- a/preprocess-worker/src/main/java/com/moonju/preprocess/worker/domain/preprocess/pipeline/PreprocessPipelineRunner.java
+++ b/preprocess-worker/src/main/java/com/moonju/preprocess/worker/domain/preprocess/pipeline/PreprocessPipelineRunner.java
@@ -1,0 +1,28 @@
+package com.moonju.preprocess.worker.domain.preprocess.pipeline;
+
+import com.moonju.preprocess.worker.domain.preprocess.preset.PreprocessPreset;
+import com.moonju.preprocess.worker.domain.preprocess.preset.PreprocessPresetRegistry;
+import com.moonju.preprocess.worker.domain.preprocess.step.PreprocessStep;
+import com.moonju.preprocess.worker.domain.preprocess.step.PreprocessStepCatalog;
+import org.springframework.stereotype.Service;
+
+@Service
+public class PreprocessPipelineRunner {
+
+    private final PreprocessPresetRegistry presetRegistry;
+    private final PreprocessStepCatalog stepCatalog;
+
+    public PreprocessPipelineRunner(PreprocessPresetRegistry presetRegistry, PreprocessStepCatalog stepCatalog) {
+        this.presetRegistry = presetRegistry;
+        this.stepCatalog = stepCatalog;
+    }
+
+    public PreprocessResult run(PreprocessContext context) {
+        PreprocessPreset preset = presetRegistry.findByName(context.presetName());
+        PreprocessPipeline pipeline = PreprocessPipeline.from(preset, stepCatalog);
+        for (PreprocessStep step : pipeline.steps()) {
+            step.execute(context);
+        }
+        return PreprocessResult.from(context, true);
+    }
+}

--- a/preprocess-worker/src/main/java/com/moonju/preprocess/worker/domain/preprocess/pipeline/PreprocessResult.java
+++ b/preprocess-worker/src/main/java/com/moonju/preprocess/worker/domain/preprocess/pipeline/PreprocessResult.java
@@ -1,0 +1,29 @@
+package com.moonju.preprocess.worker.domain.preprocess.pipeline;
+
+import com.moonju.preprocess.worker.domain.preprocess.step.PreprocessStepName;
+import java.util.List;
+
+public record PreprocessResult(
+    Long jobId,
+    Long itemId,
+    String presetName,
+    List<PreprocessStepExecution> stepExecutions,
+    boolean skeletonOnly
+) {
+
+    public static PreprocessResult from(PreprocessContext context, boolean skeletonOnly) {
+        return new PreprocessResult(
+            context.jobId(),
+            context.itemId(),
+            context.presetName(),
+            context.stepExecutions(),
+            skeletonOnly
+        );
+    }
+
+    public List<PreprocessStepName> executedStepNames() {
+        return stepExecutions.stream()
+            .map(PreprocessStepExecution::stepName)
+            .toList();
+    }
+}

--- a/preprocess-worker/src/main/java/com/moonju/preprocess/worker/domain/preprocess/pipeline/PreprocessStepExecution.java
+++ b/preprocess-worker/src/main/java/com/moonju/preprocess/worker/domain/preprocess/pipeline/PreprocessStepExecution.java
@@ -1,0 +1,9 @@
+package com.moonju.preprocess.worker.domain.preprocess.pipeline;
+
+import com.moonju.preprocess.worker.domain.preprocess.step.PreprocessStepName;
+
+public record PreprocessStepExecution(
+    PreprocessStepName stepName,
+    String note
+) {
+}

--- a/preprocess-worker/src/main/java/com/moonju/preprocess/worker/domain/preprocess/preset/A4Scan300DpiPreset.java
+++ b/preprocess-worker/src/main/java/com/moonju/preprocess/worker/domain/preprocess/preset/A4Scan300DpiPreset.java
@@ -1,0 +1,24 @@
+package com.moonju.preprocess.worker.domain.preprocess.preset;
+
+import java.util.Map;
+import org.springframework.stereotype.Component;
+
+@Component
+public class A4Scan300DpiPreset implements PreprocessPresetDefinition {
+
+    @Override
+    public PreprocessPreset preset() {
+        return new PreprocessPreset(
+            PreprocessPresetName.A4_SCAN_300DPI,
+            "A4 300 DPI scan",
+            "General A4 document scan preset for OCR preprocessing.",
+            DocumentStepSequence.standard(),
+            Map.of(
+                "targetDpi", "300",
+                "binarizationMode", "otsu",
+                "contrastClipLimit", "1.2",
+                "sharpen", "false"
+            )
+        );
+    }
+}

--- a/preprocess-worker/src/main/java/com/moonju/preprocess/worker/domain/preprocess/preset/AutoPreprocessPreset.java
+++ b/preprocess-worker/src/main/java/com/moonju/preprocess/worker/domain/preprocess/preset/AutoPreprocessPreset.java
@@ -1,0 +1,19 @@
+package com.moonju.preprocess.worker.domain.preprocess.preset;
+
+import java.util.Map;
+import org.springframework.stereotype.Component;
+
+@Component
+public class AutoPreprocessPreset implements PreprocessPresetDefinition {
+
+    @Override
+    public PreprocessPreset preset() {
+        return new PreprocessPreset(
+            PreprocessPresetName.AUTO,
+            "Auto preset",
+            "Skeleton preset that reserves Worker-side preset selection based on image characteristics.",
+            DocumentStepSequence.standard(),
+            Map.of("debugArtifacts", "false")
+        );
+    }
+}

--- a/preprocess-worker/src/main/java/com/moonju/preprocess/worker/domain/preprocess/preset/AutoPresetSelector.java
+++ b/preprocess-worker/src/main/java/com/moonju/preprocess/worker/domain/preprocess/preset/AutoPresetSelector.java
@@ -1,0 +1,12 @@
+package com.moonju.preprocess.worker.domain.preprocess.preset;
+
+import com.moonju.preprocess.worker.domain.preprocess.pipeline.PreprocessContext;
+import org.springframework.stereotype.Component;
+
+@Component
+public class AutoPresetSelector {
+
+    public PreprocessPresetName select(PreprocessContext context) {
+        return PreprocessPresetName.A4_SCAN_300DPI;
+    }
+}

--- a/preprocess-worker/src/main/java/com/moonju/preprocess/worker/domain/preprocess/preset/DocumentStepSequence.java
+++ b/preprocess-worker/src/main/java/com/moonju/preprocess/worker/domain/preprocess/preset/DocumentStepSequence.java
@@ -1,0 +1,26 @@
+package com.moonju.preprocess.worker.domain.preprocess.preset;
+
+import com.moonju.preprocess.worker.domain.preprocess.step.PreprocessStepName;
+import java.util.List;
+
+public final class DocumentStepSequence {
+
+    private DocumentStepSequence() {
+    }
+
+    public static List<PreprocessStepName> standard() {
+        return List.of(
+            PreprocessStepName.DECODE,
+            PreprocessStepName.COLOR_NORMALIZE,
+            PreprocessStepName.ORIENTATION_NORMALIZE,
+            PreprocessStepName.DESKEW,
+            PreprocessStepName.CROP,
+            PreprocessStepName.DENOISE,
+            PreprocessStepName.CONTRAST_NORMALIZE,
+            PreprocessStepName.BINARIZATION,
+            PreprocessStepName.MORPHOLOGY_CLEANUP,
+            PreprocessStepName.DPI_NORMALIZE,
+            PreprocessStepName.OPTIONAL_SHARPEN
+        );
+    }
+}

--- a/preprocess-worker/src/main/java/com/moonju/preprocess/worker/domain/preprocess/preset/LowContrastScanPreset.java
+++ b/preprocess-worker/src/main/java/com/moonju/preprocess/worker/domain/preprocess/preset/LowContrastScanPreset.java
@@ -1,0 +1,24 @@
+package com.moonju.preprocess.worker.domain.preprocess.preset;
+
+import java.util.Map;
+import org.springframework.stereotype.Component;
+
+@Component
+public class LowContrastScanPreset implements PreprocessPresetDefinition {
+
+    @Override
+    public PreprocessPreset preset() {
+        return new PreprocessPreset(
+            PreprocessPresetName.LOW_CONTRAST_SCAN,
+            "Low contrast scan",
+            "Low contrast document preset with stronger contrast normalization.",
+            DocumentStepSequence.standard(),
+            Map.of(
+                "targetDpi", "300",
+                "binarizationMode", "adaptive",
+                "contrastClipLimit", "1.6",
+                "sharpen", "true"
+            )
+        );
+    }
+}

--- a/preprocess-worker/src/main/java/com/moonju/preprocess/worker/domain/preprocess/preset/NoisyScanPreset.java
+++ b/preprocess-worker/src/main/java/com/moonju/preprocess/worker/domain/preprocess/preset/NoisyScanPreset.java
@@ -1,0 +1,24 @@
+package com.moonju.preprocess.worker.domain.preprocess.preset;
+
+import java.util.Map;
+import org.springframework.stereotype.Component;
+
+@Component
+public class NoisyScanPreset implements PreprocessPresetDefinition {
+
+    @Override
+    public PreprocessPreset preset() {
+        return new PreprocessPreset(
+            PreprocessPresetName.NOISY_SCAN,
+            "Noisy scan",
+            "Document preset reserved for strong background noise cases.",
+            DocumentStepSequence.standard(),
+            Map.of(
+                "targetDpi", "300",
+                "binarizationMode", "adaptive",
+                "contrastClipLimit", "1.5",
+                "sharpen", "false"
+            )
+        );
+    }
+}

--- a/preprocess-worker/src/main/java/com/moonju/preprocess/worker/domain/preprocess/preset/PreprocessPreset.java
+++ b/preprocess-worker/src/main/java/com/moonju/preprocess/worker/domain/preprocess/preset/PreprocessPreset.java
@@ -1,0 +1,14 @@
+package com.moonju.preprocess.worker.domain.preprocess.preset;
+
+import com.moonju.preprocess.worker.domain.preprocess.step.PreprocessStepName;
+import java.util.List;
+import java.util.Map;
+
+public record PreprocessPreset(
+    PreprocessPresetName name,
+    String displayName,
+    String description,
+    List<PreprocessStepName> steps,
+    Map<String, String> defaultParameters
+) {
+}

--- a/preprocess-worker/src/main/java/com/moonju/preprocess/worker/domain/preprocess/preset/PreprocessPresetDefinition.java
+++ b/preprocess-worker/src/main/java/com/moonju/preprocess/worker/domain/preprocess/preset/PreprocessPresetDefinition.java
@@ -1,0 +1,6 @@
+package com.moonju.preprocess.worker.domain.preprocess.preset;
+
+public interface PreprocessPresetDefinition {
+
+    PreprocessPreset preset();
+}

--- a/preprocess-worker/src/main/java/com/moonju/preprocess/worker/domain/preprocess/preset/PreprocessPresetName.java
+++ b/preprocess-worker/src/main/java/com/moonju/preprocess/worker/domain/preprocess/preset/PreprocessPresetName.java
@@ -1,0 +1,9 @@
+package com.moonju.preprocess.worker.domain.preprocess.preset;
+
+public enum PreprocessPresetName {
+    A4_SCAN_300DPI,
+    LOW_CONTRAST_SCAN,
+    RECEIPT,
+    NOISY_SCAN,
+    AUTO
+}

--- a/preprocess-worker/src/main/java/com/moonju/preprocess/worker/domain/preprocess/preset/PreprocessPresetRegistry.java
+++ b/preprocess-worker/src/main/java/com/moonju/preprocess/worker/domain/preprocess/preset/PreprocessPresetRegistry.java
@@ -1,0 +1,52 @@
+package com.moonju.preprocess.worker.domain.preprocess.preset;
+
+import com.moonju.preprocess.worker.domain.preprocess.exception.PresetNotSupportedException;
+import java.util.EnumMap;
+import java.util.List;
+import java.util.Map;
+import org.springframework.stereotype.Component;
+
+@Component
+public class PreprocessPresetRegistry {
+
+    private final Map<PreprocessPresetName, PreprocessPreset> presets;
+
+    public PreprocessPresetRegistry(List<PreprocessPresetDefinition> definitions) {
+        this.presets = new EnumMap<>(PreprocessPresetName.class);
+        for (PreprocessPresetDefinition definition : definitions) {
+            PreprocessPreset preset = definition.preset();
+            presets.put(preset.name(), preset);
+        }
+    }
+
+    public static PreprocessPresetRegistry builtIn() {
+        return new PreprocessPresetRegistry(List.of(
+            new A4Scan300DpiPreset(),
+            new LowContrastScanPreset(),
+            new ReceiptPreset(),
+            new NoisyScanPreset(),
+            new AutoPreprocessPreset()
+        ));
+    }
+
+    public PreprocessPreset findByName(String presetName) {
+        PreprocessPresetName name = parseName(presetName);
+        PreprocessPreset preset = presets.get(name);
+        if (preset == null) {
+            throw new PresetNotSupportedException(presetName);
+        }
+        return preset;
+    }
+
+    public List<PreprocessPresetName> supportedNames() {
+        return List.copyOf(presets.keySet());
+    }
+
+    private PreprocessPresetName parseName(String presetName) {
+        try {
+            return PreprocessPresetName.valueOf(presetName);
+        } catch (IllegalArgumentException exception) {
+            throw new PresetNotSupportedException(presetName);
+        }
+    }
+}

--- a/preprocess-worker/src/main/java/com/moonju/preprocess/worker/domain/preprocess/preset/ReceiptPreset.java
+++ b/preprocess-worker/src/main/java/com/moonju/preprocess/worker/domain/preprocess/preset/ReceiptPreset.java
@@ -1,0 +1,24 @@
+package com.moonju.preprocess.worker.domain.preprocess.preset;
+
+import java.util.Map;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ReceiptPreset implements PreprocessPresetDefinition {
+
+    @Override
+    public PreprocessPreset preset() {
+        return new PreprocessPreset(
+            PreprocessPresetName.RECEIPT,
+            "Receipt",
+            "Narrow receipt-like document preset.",
+            DocumentStepSequence.standard(),
+            Map.of(
+                "targetDpi", "300",
+                "binarizationMode", "adaptive",
+                "contrastClipLimit", "1.4",
+                "sharpen", "true"
+            )
+        );
+    }
+}

--- a/preprocess-worker/src/main/java/com/moonju/preprocess/worker/domain/preprocess/step/AbstractSkeletonPreprocessStep.java
+++ b/preprocess-worker/src/main/java/com/moonju/preprocess/worker/domain/preprocess/step/AbstractSkeletonPreprocessStep.java
@@ -1,0 +1,11 @@
+package com.moonju.preprocess.worker.domain.preprocess.step;
+
+import com.moonju.preprocess.worker.domain.preprocess.pipeline.PreprocessContext;
+
+public abstract class AbstractSkeletonPreprocessStep implements PreprocessStep {
+
+    @Override
+    public void execute(PreprocessContext context) {
+        context.recordStep(name(), "Skeleton step executed; OpenCV implementation is deferred.");
+    }
+}

--- a/preprocess-worker/src/main/java/com/moonju/preprocess/worker/domain/preprocess/step/BinarizationStep.java
+++ b/preprocess-worker/src/main/java/com/moonju/preprocess/worker/domain/preprocess/step/BinarizationStep.java
@@ -1,0 +1,12 @@
+package com.moonju.preprocess.worker.domain.preprocess.step;
+
+import org.springframework.stereotype.Component;
+
+@Component
+public class BinarizationStep extends AbstractSkeletonPreprocessStep {
+
+    @Override
+    public PreprocessStepName name() {
+        return PreprocessStepName.BINARIZATION;
+    }
+}

--- a/preprocess-worker/src/main/java/com/moonju/preprocess/worker/domain/preprocess/step/ColorNormalizeStep.java
+++ b/preprocess-worker/src/main/java/com/moonju/preprocess/worker/domain/preprocess/step/ColorNormalizeStep.java
@@ -1,0 +1,12 @@
+package com.moonju.preprocess.worker.domain.preprocess.step;
+
+import org.springframework.stereotype.Component;
+
+@Component
+public class ColorNormalizeStep extends AbstractSkeletonPreprocessStep {
+
+    @Override
+    public PreprocessStepName name() {
+        return PreprocessStepName.COLOR_NORMALIZE;
+    }
+}

--- a/preprocess-worker/src/main/java/com/moonju/preprocess/worker/domain/preprocess/step/ContrastNormalizeStep.java
+++ b/preprocess-worker/src/main/java/com/moonju/preprocess/worker/domain/preprocess/step/ContrastNormalizeStep.java
@@ -1,0 +1,12 @@
+package com.moonju.preprocess.worker.domain.preprocess.step;
+
+import org.springframework.stereotype.Component;
+
+@Component
+public class ContrastNormalizeStep extends AbstractSkeletonPreprocessStep {
+
+    @Override
+    public PreprocessStepName name() {
+        return PreprocessStepName.CONTRAST_NORMALIZE;
+    }
+}

--- a/preprocess-worker/src/main/java/com/moonju/preprocess/worker/domain/preprocess/step/CropStep.java
+++ b/preprocess-worker/src/main/java/com/moonju/preprocess/worker/domain/preprocess/step/CropStep.java
@@ -1,0 +1,12 @@
+package com.moonju.preprocess.worker.domain.preprocess.step;
+
+import org.springframework.stereotype.Component;
+
+@Component
+public class CropStep extends AbstractSkeletonPreprocessStep {
+
+    @Override
+    public PreprocessStepName name() {
+        return PreprocessStepName.CROP;
+    }
+}

--- a/preprocess-worker/src/main/java/com/moonju/preprocess/worker/domain/preprocess/step/DecodeStep.java
+++ b/preprocess-worker/src/main/java/com/moonju/preprocess/worker/domain/preprocess/step/DecodeStep.java
@@ -1,0 +1,12 @@
+package com.moonju.preprocess.worker.domain.preprocess.step;
+
+import org.springframework.stereotype.Component;
+
+@Component
+public class DecodeStep extends AbstractSkeletonPreprocessStep {
+
+    @Override
+    public PreprocessStepName name() {
+        return PreprocessStepName.DECODE;
+    }
+}

--- a/preprocess-worker/src/main/java/com/moonju/preprocess/worker/domain/preprocess/step/DenoiseStep.java
+++ b/preprocess-worker/src/main/java/com/moonju/preprocess/worker/domain/preprocess/step/DenoiseStep.java
@@ -1,0 +1,12 @@
+package com.moonju.preprocess.worker.domain.preprocess.step;
+
+import org.springframework.stereotype.Component;
+
+@Component
+public class DenoiseStep extends AbstractSkeletonPreprocessStep {
+
+    @Override
+    public PreprocessStepName name() {
+        return PreprocessStepName.DENOISE;
+    }
+}

--- a/preprocess-worker/src/main/java/com/moonju/preprocess/worker/domain/preprocess/step/DeskewStep.java
+++ b/preprocess-worker/src/main/java/com/moonju/preprocess/worker/domain/preprocess/step/DeskewStep.java
@@ -1,0 +1,12 @@
+package com.moonju.preprocess.worker.domain.preprocess.step;
+
+import org.springframework.stereotype.Component;
+
+@Component
+public class DeskewStep extends AbstractSkeletonPreprocessStep {
+
+    @Override
+    public PreprocessStepName name() {
+        return PreprocessStepName.DESKEW;
+    }
+}

--- a/preprocess-worker/src/main/java/com/moonju/preprocess/worker/domain/preprocess/step/DpiNormalizeStep.java
+++ b/preprocess-worker/src/main/java/com/moonju/preprocess/worker/domain/preprocess/step/DpiNormalizeStep.java
@@ -1,0 +1,12 @@
+package com.moonju.preprocess.worker.domain.preprocess.step;
+
+import org.springframework.stereotype.Component;
+
+@Component
+public class DpiNormalizeStep extends AbstractSkeletonPreprocessStep {
+
+    @Override
+    public PreprocessStepName name() {
+        return PreprocessStepName.DPI_NORMALIZE;
+    }
+}

--- a/preprocess-worker/src/main/java/com/moonju/preprocess/worker/domain/preprocess/step/MorphologyCleanupStep.java
+++ b/preprocess-worker/src/main/java/com/moonju/preprocess/worker/domain/preprocess/step/MorphologyCleanupStep.java
@@ -1,0 +1,12 @@
+package com.moonju.preprocess.worker.domain.preprocess.step;
+
+import org.springframework.stereotype.Component;
+
+@Component
+public class MorphologyCleanupStep extends AbstractSkeletonPreprocessStep {
+
+    @Override
+    public PreprocessStepName name() {
+        return PreprocessStepName.MORPHOLOGY_CLEANUP;
+    }
+}

--- a/preprocess-worker/src/main/java/com/moonju/preprocess/worker/domain/preprocess/step/OrientationNormalizeStep.java
+++ b/preprocess-worker/src/main/java/com/moonju/preprocess/worker/domain/preprocess/step/OrientationNormalizeStep.java
@@ -1,0 +1,12 @@
+package com.moonju.preprocess.worker.domain.preprocess.step;
+
+import org.springframework.stereotype.Component;
+
+@Component
+public class OrientationNormalizeStep extends AbstractSkeletonPreprocessStep {
+
+    @Override
+    public PreprocessStepName name() {
+        return PreprocessStepName.ORIENTATION_NORMALIZE;
+    }
+}

--- a/preprocess-worker/src/main/java/com/moonju/preprocess/worker/domain/preprocess/step/PreprocessStep.java
+++ b/preprocess-worker/src/main/java/com/moonju/preprocess/worker/domain/preprocess/step/PreprocessStep.java
@@ -1,0 +1,10 @@
+package com.moonju.preprocess.worker.domain.preprocess.step;
+
+import com.moonju.preprocess.worker.domain.preprocess.pipeline.PreprocessContext;
+
+public interface PreprocessStep {
+
+    PreprocessStepName name();
+
+    void execute(PreprocessContext context);
+}

--- a/preprocess-worker/src/main/java/com/moonju/preprocess/worker/domain/preprocess/step/PreprocessStepCatalog.java
+++ b/preprocess-worker/src/main/java/com/moonju/preprocess/worker/domain/preprocess/step/PreprocessStepCatalog.java
@@ -1,0 +1,52 @@
+package com.moonju.preprocess.worker.domain.preprocess.step;
+
+import com.moonju.preprocess.worker.domain.preprocess.exception.PreprocessStepNotFoundException;
+import java.util.EnumMap;
+import java.util.List;
+import java.util.Map;
+import org.springframework.stereotype.Component;
+
+@Component
+public class PreprocessStepCatalog {
+
+    private final Map<PreprocessStepName, PreprocessStep> steps;
+
+    public PreprocessStepCatalog(List<PreprocessStep> steps) {
+        this.steps = new EnumMap<>(PreprocessStepName.class);
+        for (PreprocessStep step : steps) {
+            this.steps.put(step.name(), step);
+        }
+    }
+
+    public static PreprocessStepCatalog builtIn() {
+        return new PreprocessStepCatalog(List.of(
+            new DecodeStep(),
+            new ColorNormalizeStep(),
+            new OrientationNormalizeStep(),
+            new DeskewStep(),
+            new CropStep(),
+            new DenoiseStep(),
+            new ContrastNormalizeStep(),
+            new BinarizationStep(),
+            new MorphologyCleanupStep(),
+            new DpiNormalizeStep(),
+            new SharpenStep()
+        ));
+    }
+
+    public List<PreprocessStep> resolveAll(List<PreprocessStepName> names) {
+        return names.stream().map(this::findByName).toList();
+    }
+
+    public List<PreprocessStepName> registeredNames() {
+        return List.copyOf(steps.keySet());
+    }
+
+    private PreprocessStep findByName(PreprocessStepName name) {
+        PreprocessStep step = steps.get(name);
+        if (step == null) {
+            throw new PreprocessStepNotFoundException(name);
+        }
+        return step;
+    }
+}

--- a/preprocess-worker/src/main/java/com/moonju/preprocess/worker/domain/preprocess/step/PreprocessStepName.java
+++ b/preprocess-worker/src/main/java/com/moonju/preprocess/worker/domain/preprocess/step/PreprocessStepName.java
@@ -1,0 +1,15 @@
+package com.moonju.preprocess.worker.domain.preprocess.step;
+
+public enum PreprocessStepName {
+    DECODE,
+    COLOR_NORMALIZE,
+    ORIENTATION_NORMALIZE,
+    DESKEW,
+    CROP,
+    DENOISE,
+    CONTRAST_NORMALIZE,
+    BINARIZATION,
+    MORPHOLOGY_CLEANUP,
+    DPI_NORMALIZE,
+    OPTIONAL_SHARPEN
+}

--- a/preprocess-worker/src/main/java/com/moonju/preprocess/worker/domain/preprocess/step/SharpenStep.java
+++ b/preprocess-worker/src/main/java/com/moonju/preprocess/worker/domain/preprocess/step/SharpenStep.java
@@ -1,0 +1,12 @@
+package com.moonju.preprocess.worker.domain.preprocess.step;
+
+import org.springframework.stereotype.Component;
+
+@Component
+public class SharpenStep extends AbstractSkeletonPreprocessStep {
+
+    @Override
+    public PreprocessStepName name() {
+        return PreprocessStepName.OPTIONAL_SHARPEN;
+    }
+}

--- a/preprocess-worker/src/main/java/com/moonju/preprocess/worker/domain/workerjob/service/WorkerJobService.java
+++ b/preprocess-worker/src/main/java/com/moonju/preprocess/worker/domain/workerjob/service/WorkerJobService.java
@@ -1,5 +1,8 @@
 package com.moonju.preprocess.worker.domain.workerjob.service;
 
+import com.moonju.preprocess.worker.domain.preprocess.pipeline.PreprocessContext;
+import com.moonju.preprocess.worker.domain.preprocess.pipeline.PreprocessPipelineRunner;
+import com.moonju.preprocess.worker.domain.preprocess.pipeline.PreprocessResult;
 import com.moonju.preprocess.worker.domain.workerjob.dto.PreprocessJobMessage;
 import com.moonju.preprocess.worker.domain.workerjob.dto.WorkerJobResult;
 import com.moonju.preprocess.worker.domain.workerjob.exception.InvalidWorkerMessageException;
@@ -13,10 +16,16 @@ public class WorkerJobService {
 
     private final BackendApiClient backendApiClient;
     private final ObjectStoragePort objectStoragePort;
+    private final PreprocessPipelineRunner preprocessPipelineRunner;
 
-    public WorkerJobService(BackendApiClient backendApiClient, ObjectStoragePort objectStoragePort) {
+    public WorkerJobService(
+        BackendApiClient backendApiClient,
+        ObjectStoragePort objectStoragePort,
+        PreprocessPipelineRunner preprocessPipelineRunner
+    ) {
         this.backendApiClient = backendApiClient;
         this.objectStoragePort = objectStoragePort;
+        this.preprocessPipelineRunner = preprocessPipelineRunner;
     }
 
     public WorkerJobResult process(PreprocessJobMessage message) {
@@ -24,15 +33,19 @@ public class WorkerJobService {
             message.validateRequiredFields();
             backendApiClient.reportStarted(message);
             objectStoragePort.prepareDownload(message.originalObjectKey());
+            PreprocessResult result = preprocessPipelineRunner.run(PreprocessContext.fromMessage(message));
+            String failureMessage = "Preprocess pipeline skeleton executed "
+                + result.executedStepNames().size()
+                + " steps; OpenCV and artifact integration are not implemented yet.";
             backendApiClient.reportFailed(
                 message,
                 WorkerFailureCode.PIPELINE_NOT_IMPLEMENTED,
-                "Preprocess pipeline is not implemented yet."
+                failureMessage
             );
             return WorkerJobResult.failed(
                 message,
                 WorkerFailureCode.PIPELINE_NOT_IMPLEMENTED,
-                "Preprocess pipeline is not implemented yet."
+                failureMessage
             );
         } catch (InvalidWorkerMessageException exception) {
             return WorkerJobResult.invalid(exception.getMessage());

--- a/preprocess-worker/src/test/java/com/moonju/preprocess/worker/domain/preprocess/pipeline/PreprocessPipelineRunnerTests.java
+++ b/preprocess-worker/src/test/java/com/moonju/preprocess/worker/domain/preprocess/pipeline/PreprocessPipelineRunnerTests.java
@@ -1,0 +1,46 @@
+package com.moonju.preprocess.worker.domain.preprocess.pipeline;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.moonju.preprocess.worker.domain.preprocess.preset.PreprocessPresetRegistry;
+import com.moonju.preprocess.worker.domain.preprocess.step.PreprocessStepCatalog;
+import com.moonju.preprocess.worker.domain.preprocess.step.PreprocessStepName;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class PreprocessPipelineRunnerTests {
+
+    private final PreprocessPipelineRunner runner = new PreprocessPipelineRunner(
+        PreprocessPresetRegistry.builtIn(),
+        PreprocessStepCatalog.builtIn()
+    );
+
+    @Test
+    void runsDocumentPipelineStepsInOcrPreprocessOrder() {
+        PreprocessContext context = new PreprocessContext(
+            1L,
+            10L,
+            "originals/project/scan.png",
+            "LOW_CONTRAST_SCAN",
+            Map.of("targetDpi", "300"),
+            false
+        );
+
+        PreprocessResult result = runner.run(context);
+
+        assertThat(result.skeletonOnly()).isTrue();
+        assertThat(result.executedStepNames()).containsExactly(
+            PreprocessStepName.DECODE,
+            PreprocessStepName.COLOR_NORMALIZE,
+            PreprocessStepName.ORIENTATION_NORMALIZE,
+            PreprocessStepName.DESKEW,
+            PreprocessStepName.CROP,
+            PreprocessStepName.DENOISE,
+            PreprocessStepName.CONTRAST_NORMALIZE,
+            PreprocessStepName.BINARIZATION,
+            PreprocessStepName.MORPHOLOGY_CLEANUP,
+            PreprocessStepName.DPI_NORMALIZE,
+            PreprocessStepName.OPTIONAL_SHARPEN
+        );
+    }
+}

--- a/preprocess-worker/src/test/java/com/moonju/preprocess/worker/domain/preprocess/preset/AutoPresetSelectorTests.java
+++ b/preprocess-worker/src/test/java/com/moonju/preprocess/worker/domain/preprocess/preset/AutoPresetSelectorTests.java
@@ -1,0 +1,27 @@
+package com.moonju.preprocess.worker.domain.preprocess.preset;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.moonju.preprocess.worker.domain.preprocess.pipeline.PreprocessContext;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class AutoPresetSelectorTests {
+
+    @Test
+    void reservesAutoSelectionBoundaryWithoutChangingPipelineContract() {
+        AutoPresetSelector selector = new AutoPresetSelector();
+        PreprocessContext context = new PreprocessContext(
+            1L,
+            10L,
+            "originals/project/scan.png",
+            "AUTO",
+            Map.of(),
+            false
+        );
+
+        PreprocessPresetName selected = selector.select(context);
+
+        assertThat(selected).isEqualTo(PreprocessPresetName.A4_SCAN_300DPI);
+    }
+}

--- a/preprocess-worker/src/test/java/com/moonju/preprocess/worker/domain/preprocess/preset/PreprocessPresetRegistryTests.java
+++ b/preprocess-worker/src/test/java/com/moonju/preprocess/worker/domain/preprocess/preset/PreprocessPresetRegistryTests.java
@@ -1,0 +1,39 @@
+package com.moonju.preprocess.worker.domain.preprocess.preset;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.moonju.preprocess.worker.domain.preprocess.step.PreprocessStepName;
+import org.junit.jupiter.api.Test;
+
+class PreprocessPresetRegistryTests {
+
+    private final PreprocessPresetRegistry registry = PreprocessPresetRegistry.builtIn();
+
+    @Test
+    void containsRequiredBackendPresetNames() {
+        assertThat(registry.supportedNames()).containsExactlyInAnyOrder(
+            PreprocessPresetName.A4_SCAN_300DPI,
+            PreprocessPresetName.LOW_CONTRAST_SCAN,
+            PreprocessPresetName.RECEIPT,
+            PreprocessPresetName.NOISY_SCAN,
+            PreprocessPresetName.AUTO
+        );
+    }
+
+    @Test
+    void a4PresetUsesFullDocumentPreprocessSequence() {
+        PreprocessPreset preset = registry.findByName("A4_SCAN_300DPI");
+
+        assertThat(preset.steps()).contains(
+            PreprocessStepName.DESKEW,
+            PreprocessStepName.CROP,
+            PreprocessStepName.DENOISE,
+            PreprocessStepName.CONTRAST_NORMALIZE,
+            PreprocessStepName.BINARIZATION,
+            PreprocessStepName.MORPHOLOGY_CLEANUP,
+            PreprocessStepName.DPI_NORMALIZE,
+            PreprocessStepName.OPTIONAL_SHARPEN
+        );
+        assertThat(preset.steps()).hasSize(11);
+    }
+}

--- a/preprocess-worker/src/test/java/com/moonju/preprocess/worker/domain/preprocess/step/PreprocessStepCatalogTests.java
+++ b/preprocess-worker/src/test/java/com/moonju/preprocess/worker/domain/preprocess/step/PreprocessStepCatalogTests.java
@@ -1,0 +1,15 @@
+package com.moonju.preprocess.worker.domain.preprocess.step;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class PreprocessStepCatalogTests {
+
+    @Test
+    void registersEveryRequiredDocumentStep() {
+        PreprocessStepCatalog catalog = PreprocessStepCatalog.builtIn();
+
+        assertThat(catalog.registeredNames()).containsExactlyInAnyOrder(PreprocessStepName.values());
+    }
+}

--- a/preprocess-worker/src/test/java/com/moonju/preprocess/worker/domain/workerjob/service/WorkerJobServiceTests.java
+++ b/preprocess-worker/src/test/java/com/moonju/preprocess/worker/domain/workerjob/service/WorkerJobServiceTests.java
@@ -7,6 +7,9 @@ import static org.mockito.Mockito.verifyNoInteractions;
 import com.moonju.preprocess.worker.domain.workerjob.dto.JobPriority;
 import com.moonju.preprocess.worker.domain.workerjob.dto.PreprocessJobMessage;
 import com.moonju.preprocess.worker.domain.workerjob.dto.WorkerJobResult;
+import com.moonju.preprocess.worker.domain.preprocess.pipeline.PreprocessPipelineRunner;
+import com.moonju.preprocess.worker.domain.preprocess.preset.PreprocessPresetRegistry;
+import com.moonju.preprocess.worker.domain.preprocess.step.PreprocessStepCatalog;
 import com.moonju.preprocess.worker.domain.workerjob.status.WorkerFailureCode;
 import com.moonju.preprocess.worker.domain.workerjob.status.WorkerJobStatus;
 import com.moonju.preprocess.worker.infra.api.BackendApiClient;
@@ -19,22 +22,31 @@ class WorkerJobServiceTests {
 
     private final BackendApiClient backendApiClient = org.mockito.Mockito.mock(BackendApiClient.class);
     private final ObjectStoragePort objectStoragePort = org.mockito.Mockito.mock(ObjectStoragePort.class);
-    private final WorkerJobService service = new WorkerJobService(backendApiClient, objectStoragePort);
+    private final PreprocessPipelineRunner preprocessPipelineRunner = new PreprocessPipelineRunner(
+        PreprocessPresetRegistry.builtIn(),
+        PreprocessStepCatalog.builtIn()
+    );
+    private final WorkerJobService service = new WorkerJobService(
+        backendApiClient,
+        objectStoragePort,
+        preprocessPipelineRunner
+    );
 
     @Test
-    void reportsPipelineNotImplementedUntilPreprocessPipelineIsAdded() {
+    void executesPipelineSkeletonAndReportsNotImplementedBoundary() {
         PreprocessJobMessage message = validMessage();
 
         WorkerJobResult result = service.process(message);
 
         assertThat(result.status()).isEqualTo(WorkerJobStatus.FAILED);
         assertThat(result.failureCode()).isEqualTo(WorkerFailureCode.PIPELINE_NOT_IMPLEMENTED);
+        assertThat(result.message()).contains("skeleton executed 11 steps");
         verify(backendApiClient).reportStarted(message);
         verify(objectStoragePort).prepareDownload("originals/scan.png");
         verify(backendApiClient).reportFailed(
             message,
             WorkerFailureCode.PIPELINE_NOT_IMPLEMENTED,
-            "Preprocess pipeline is not implemented yet."
+            "Preprocess pipeline skeleton executed 11 steps; OpenCV and artifact integration are not implemented yet."
         );
     }
 


### PR DESCRIPTION
## #️⃣ 기능 설명

`preprocess-worker` 내부에 OCR 지향 문서 이미지 전처리 pipeline skeleton을 추가했습니다. 단순 resize가 아니라 `Decode`, `Color Normalize`, `Orientation Normalize`, `Deskew`, `Crop`, `Denoise`, `Contrast Normalize`, `Binarization`, `Morphology Cleanup`, `DPI Normalize`, `Optional Sharpen` 순서를 명시한 `PreprocessStep` 기반 구조입니다.

Closes #43

## 🛠️ 작업 상세 내용

- [x] `domain/preprocess/pipeline` skeleton 추가
- [x] `PreprocessStep`, `PreprocessStepCatalog`, 필수 step class 추가
- [x] `A4_SCAN_300DPI`, `LOW_CONTRAST_SCAN`, `RECEIPT`, `NOISY_SCAN`, `AUTO` preset registry 추가
- [x] `WorkerJobService`가 pipeline skeleton을 실행하도록 연결
- [x] OpenCV/Artifact 미구현 상태이므로 Worker 성공 처리는 하지 않고 `PIPELINE_NOT_IMPLEMENTED` 유지
- [x] pipeline/preset/step/service 단위 테스트 추가
- [x] Worker pipeline 문서와 listener/preset 문서 갱신

## 📁 변경 파일 요약

- `preprocess-worker/src/main/java/com/moonju/preprocess/worker/domain/preprocess/...`
- `preprocess-worker/src/test/java/com/moonju/preprocess/worker/domain/preprocess/...`
- `preprocess-worker/src/main/java/com/moonju/preprocess/worker/domain/workerjob/service/WorkerJobService.java`
- `docs/feature-specs/issue-43-worker-preprocess-pipeline.md`
- `docs/worker/preprocess-pipeline.md`
- `docs/worker/listener-skeleton.md`
- `docs/worker/preset-spec.md`

## ✅ 검증 내용

- [x] `docker run --rm -v "${PWD}\\preprocess-worker:/workspace" -w /workspace gradle:8.12.1-jdk21 gradle clean test --no-daemon`
- [x] `docker run --rm -v "${PWD}\\preprocess-worker:/workspace" -w /workspace gradle:8.12.1-jdk21 gradle build --no-daemon`
- [x] `git diff --check`
- [x] staged diff secret keyword scan

## 🔎 리뷰어가 확인해야 할 부분

- 필수 전처리 단계가 누락 없이 순서대로 들어갔는지 확인해주세요.
- `DPI_NORMALIZE`가 단순 thumbnail resize가 아닌 OCR 품질 보정 단계로 문서화되어 있는지 확인해주세요.
- 실제 OpenCV/image-test 연동은 후속 작업으로 분리했고, 현재 Worker는 skeleton 실행 후에도 성공 처리하지 않는 것이 의도에 맞는지 확인해주세요.

## 📸 스크린샷

없음

## 💬 기타 공유사항 to 리뷰어

- API 서버에는 OpenCV 처리 로직을 추가하지 않았습니다.
- Worker에 OAuth, 화면 API, DB 직접 접근 로직을 추가하지 않았습니다.