### PR TITLE
🧹 [Chore] NGINX routing skeleton 추가

### DIFF
--- a/docs/architecture/nginx-routing.md
+++ b/docs/architecture/nginx-routing.md
@@ -1,0 +1,57 @@
+# NGINX Routing
+
+## Purpose
+
+NGINX is the single local entry point for the browser. It serves the frontend static placeholder and reverse proxies
+API, OAuth, Swagger, and SSE traffic to `backend-api`.
+
+## Local Entry Points
+
+| Path | Target |
+| --- | --- |
+| `/` | Static frontend placeholder from `frontend/public` |
+| `/assets/*` | Static frontend assets |
+| `/api/*` | `backend-api:8080` |
+| `/oauth2/*` | `backend-api:8080` |
+| `/login/oauth2/*` | `backend-api:8080` |
+| `/v3/api-docs` | `backend-api:8080` |
+| `/swagger-ui/*` | `backend-api:8080` |
+| `/api/v1/jobs/*/events` | `backend-api:8080` with SSE buffering disabled |
+| `/grafana/*` | Placeholder until observability stack is added |
+| `/jaeger/*` | Placeholder until observability stack is added |
+
+## SSE Rules
+
+The Job event path disables response buffering:
+
+```nginx
+proxy_buffering off;
+proxy_cache off;
+proxy_read_timeout 1h;
+add_header X-Accel-Buffering no always;
+```
+
+## OAuth Rules
+
+Google OAuth callback must be registered for the NGINX entry point when testing through NGINX:
+
+```text
+http://localhost/login/oauth2/code/google
+```
+
+The direct backend callback is still useful when bypassing NGINX:
+
+```text
+http://localhost:8080/login/oauth2/code/google
+```
+
+## Security Headers
+
+The local skeleton applies basic browser safety headers:
+
+- `X-Frame-Options`
+- `X-Content-Type-Options`
+- `Referrer-Policy`
+- `Permissions-Policy`
+
+Production HTTPS, HSTS, CSP tuning, and admin authentication are deferred to deployment-specific work.

--- a/docs/feature-specs/issue-47-nginx-routing-skeleton.md
+++ b/docs/feature-specs/issue-47-nginx-routing-skeleton.md
@@ -1,0 +1,50 @@
+# Issue 47. NGINX Routing Skeleton
+
+## Goal
+
+Add the local NGINX single entry point skeleton. NGINX serves the frontend static placeholder and routes backend-related
+paths to `backend-api`.
+
+## Overall Order
+
+1. Add `infra/nginx/nginx.conf`.
+2. Add `infra/nginx/conf.d/app.conf`.
+3. Add API and OAuth proxy rules.
+4. Add SSE proxy rule with buffering disabled.
+5. Add admin placeholder routes.
+6. Add shared proxy and security header snippets.
+7. Add a minimal frontend static placeholder.
+8. Add NGINX service to Docker Compose.
+9. Update local Compose environment values.
+10. Add architecture and operation documentation.
+11. Validate NGINX syntax.
+12. Validate Docker Compose config.
+
+## Routing Units
+
+| Route | Handling |
+| --- | --- |
+| `/` | Static frontend placeholder |
+| `/assets/*` | Static assets |
+| `/api/*` | Proxy to backend-api |
+| `/oauth2/*` | Proxy to backend-api |
+| `/login/oauth2/*` | Proxy to backend-api |
+| `/v3/api-docs` | Proxy to backend-api |
+| `/swagger-ui/*` | Proxy to backend-api |
+| `/api/v1/jobs/*/events` | Proxy to backend-api with SSE settings |
+| `/grafana/*` | Placeholder |
+| `/jaeger/*` | Placeholder |
+
+## Out Of Scope
+
+- React/Vite frontend implementation.
+- Production TLS certificates.
+- HSTS/CSP production hardening.
+- Grafana and Jaeger upstream services.
+- Kubernetes ingress.
+
+## Verification
+
+- `nginx -t` validates config syntax.
+- `docker compose config` validates local Compose integration.
+- Secret scan verifies no real OAuth or private key values are committed.

--- a/docs/operation/docker-compose-local.md
+++ b/docs/operation/docker-compose-local.md
@@ -9,10 +9,11 @@ This document explains how to run the local backend stack for development.
 - PostgreSQL
 - RabbitMQ with management UI
 - MinIO
+- NGINX
 - backend-api
 - preprocess-worker
 
-Frontend and NGINX are intentionally excluded from this Compose file. They are handled in the next routing task.
+NGINX serves a minimal frontend placeholder from `frontend/public`. The real React/Vite app is still a later task.
 
 ## First Run
 
@@ -28,7 +29,9 @@ docker compose -f docker-compose.local.yml --env-file .env up -d --build
 
 | Component | URL |
 | --- | --- |
+| NGINX entry point | `http://localhost` |
 | backend-api | `http://localhost:8080` |
+| Swagger through NGINX | `http://localhost/swagger-ui/index.html` |
 | Swagger UI | `http://localhost:8080/swagger-ui/index.html` |
 | RabbitMQ Management | `http://localhost:15672` |
 | MinIO Console | `http://localhost:9001` |
@@ -53,6 +56,20 @@ WORKER_LISTENER_ENABLED=false
 
 This prevents the skeleton Worker from consuming queue messages unintentionally while the OpenCV implementation is not
 complete. Set it to `true` only when testing queue consumption explicitly.
+
+## Google OAuth Redirect URI
+
+When testing through NGINX, add this redirect URI in Google Console:
+
+```text
+http://localhost/login/oauth2/code/google
+```
+
+When bypassing NGINX and using backend-api directly, keep this URI too:
+
+```text
+http://localhost:8080/login/oauth2/code/google
+```
 
 ## Stop
 

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<html lang="ko">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Image Preprocess Platform</title>
+</head>
+<body>
+  <main>
+    <h1>Image Preprocess Platform</h1>
+    <p>Frontend application placeholder. The React/Vite app will replace this static page in a later task.</p>
+  </main>
+</body>
+</html>

--- a/infra/docker-compose/.env.example
+++ b/infra/docker-compose/.env.example
@@ -16,13 +16,14 @@ MINIO_BUCKET=image-preprocess-local
 MINIO_API_PORT=9000
 MINIO_CONSOLE_PORT=9001
 
+NGINX_HTTP_PORT=80
 BACKEND_API_PORT=8080
 JPA_DDL_AUTO=update
 GOOGLE_CLIENT_ID=local-google-client-id
 GOOGLE_CLIENT_SECRET=local-google-client-secret
 JWT_SECRET=local-development-secret-key-at-least-32-bytes
-OAUTH2_SUCCESS_REDIRECT_URI=http://localhost:5173/oauth2/success
-CORS_ALLOWED_ORIGINS=http://localhost:5173
+OAUTH2_SUCCESS_REDIRECT_URI=http://localhost/oauth2/success
+CORS_ALLOWED_ORIGINS=http://localhost,http://localhost:5173
 
 WORKER_ID=local-worker-1
 WORKER_LISTENER_ENABLED=false

--- a/infra/docker-compose/docker-compose.local.yml
+++ b/infra/docker-compose/docker-compose.local.yml
@@ -1,6 +1,22 @@
 name: ${COMPOSE_PROJECT_NAME:-image-preprocess-local}
 
 services:
+  nginx:
+    image: nginx:1.27-alpine
+    container_name: image-preprocess-nginx
+    depends_on:
+      backend-api:
+        condition: service_started
+    ports:
+      - "${NGINX_HTTP_PORT:-80}:80"
+    volumes:
+      - ../nginx/nginx.conf:/etc/nginx/nginx.conf:ro
+      - ../nginx/conf.d:/etc/nginx/conf.d:ro
+      - ../nginx/snippets:/etc/nginx/snippets:ro
+      - ../../frontend/public:/usr/share/nginx/html:ro
+    networks:
+      - image-preprocess
+
   postgres:
     image: postgres:16-alpine
     container_name: image-preprocess-postgres
@@ -104,8 +120,9 @@ services:
       GOOGLE_CLIENT_ID: ${GOOGLE_CLIENT_ID:-local-google-client-id}
       GOOGLE_CLIENT_SECRET: ${GOOGLE_CLIENT_SECRET:-local-google-client-secret}
       JWT_SECRET: ${JWT_SECRET:-local-development-secret-key-at-least-32-bytes}
-      OAUTH2_SUCCESS_REDIRECT_URI: ${OAUTH2_SUCCESS_REDIRECT_URI:-http://localhost:5173/oauth2/success}
-      CORS_ALLOWED_ORIGINS: ${CORS_ALLOWED_ORIGINS:-http://localhost:5173}
+      OAUTH2_SUCCESS_REDIRECT_URI: ${OAUTH2_SUCCESS_REDIRECT_URI:-http://localhost/oauth2/success}
+      CORS_ALLOWED_ORIGINS: ${CORS_ALLOWED_ORIGINS:-http://localhost,http://localhost:5173}
+      SERVER_FORWARD_HEADERS_STRATEGY: framework
       MINIO_ENDPOINT: http://minio:9000
       MINIO_ACCESS_KEY: ${MINIO_ROOT_USER:-minioadmin}
       MINIO_SECRET_KEY: ${MINIO_ROOT_PASSWORD:-minioadmin}

--- a/infra/nginx/conf.d/admin.conf
+++ b/infra/nginx/conf.d/admin.conf
@@ -1,0 +1,9 @@
+location /grafana/ {
+    default_type text/plain;
+    return 503 "Grafana is not configured in the local compose stack yet.\n";
+}
+
+location /jaeger/ {
+    default_type text/plain;
+    return 503 "Jaeger is not configured in the local compose stack yet.\n";
+}

--- a/infra/nginx/conf.d/api.conf
+++ b/infra/nginx/conf.d/api.conf
@@ -1,0 +1,29 @@
+location /api/ {
+    include /etc/nginx/snippets/proxy.conf;
+    proxy_pass http://backend_api;
+}
+
+location /oauth2/ {
+    include /etc/nginx/snippets/proxy.conf;
+    proxy_pass http://backend_api;
+}
+
+location /login/oauth2/ {
+    include /etc/nginx/snippets/proxy.conf;
+    proxy_pass http://backend_api;
+}
+
+location /v3/api-docs {
+    include /etc/nginx/snippets/proxy.conf;
+    proxy_pass http://backend_api;
+}
+
+location /swagger-ui/ {
+    include /etc/nginx/snippets/proxy.conf;
+    proxy_pass http://backend_api;
+}
+
+location = /swagger-ui.html {
+    include /etc/nginx/snippets/proxy.conf;
+    proxy_pass http://backend_api;
+}

--- a/infra/nginx/conf.d/app.conf
+++ b/infra/nginx/conf.d/app.conf
@@ -1,0 +1,33 @@
+upstream backend_api {
+    server backend-api:8080;
+    keepalive 32;
+}
+
+server {
+    listen 80;
+    server_name _;
+
+    root /usr/share/nginx/html;
+    index index.html;
+
+    include /etc/nginx/snippets/security-headers.conf;
+    include /etc/nginx/conf.d/sse.conf;
+    include /etc/nginx/conf.d/api.conf;
+    include /etc/nginx/conf.d/admin.conf;
+
+    location = /health {
+        access_log off;
+        default_type text/plain;
+        return 200 "ok\n";
+    }
+
+    location /assets/ {
+        try_files $uri =404;
+        expires 1h;
+        add_header Cache-Control "public" always;
+    }
+
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+}

--- a/infra/nginx/conf.d/sse.conf
+++ b/infra/nginx/conf.d/sse.conf
@@ -1,0 +1,8 @@
+location ~ ^/api/v1/jobs/[^/]+/events$ {
+    include /etc/nginx/snippets/proxy.conf;
+    proxy_pass http://backend_api;
+    proxy_buffering off;
+    proxy_cache off;
+    proxy_read_timeout 1h;
+    add_header X-Accel-Buffering no always;
+}

--- a/infra/nginx/nginx.conf
+++ b/infra/nginx/nginx.conf
@@ -1,0 +1,23 @@
+worker_processes auto;
+
+events {
+    worker_connections 1024;
+}
+
+http {
+    include /etc/nginx/mime.types;
+    default_type application/octet-stream;
+
+    sendfile on;
+    keepalive_timeout 65;
+    client_max_body_size 2g;
+
+    log_format main '$remote_addr - $remote_user [$time_local] "$request" '
+                    '$status $body_bytes_sent "$http_referer" '
+                    '"$http_user_agent" "$http_x_forwarded_for"';
+
+    access_log /var/log/nginx/access.log main;
+    error_log /var/log/nginx/error.log warn;
+
+    include /etc/nginx/conf.d/app.conf;
+}

--- a/infra/nginx/snippets/proxy.conf
+++ b/infra/nginx/snippets/proxy.conf
@@ -1,0 +1,9 @@
+proxy_http_version 1.1;
+proxy_set_header Host $host;
+proxy_set_header X-Real-IP $remote_addr;
+proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+proxy_set_header X-Forwarded-Host $host;
+proxy_set_header X-Forwarded-Proto $scheme;
+proxy_set_header X-Forwarded-Port $server_port;
+proxy_set_header Connection "";
+proxy_send_timeout 60s;

--- a/infra/nginx/snippets/security-headers.conf
+++ b/infra/nginx/snippets/security-headers.conf
@@ -1,0 +1,4 @@
+add_header X-Frame-Options "SAMEORIGIN" always;
+add_header X-Content-Type-Options "nosniff" always;
+add_header Referrer-Policy "no-referrer-when-downgrade" always;
+add_header Permissions-Policy "camera=(), microphone=(), geolocation=()" always;


### PR DESCRIPTION
## #️⃣ 기능 설명

NGINX 단일 진입점 skeleton을 추가했습니다. `/`는 `frontend/public`의 정적 placeholder를 제공하고, `/api`, `/oauth2`, `/login/oauth2`, Swagger/OpenAPI, SSE 경로는 `backend-api`로 reverse proxy합니다.

Closes #47

## 🛠️ 작업 상세 내용

- [x] `infra/nginx/nginx.conf` 추가
- [x] `infra/nginx/conf.d/app.conf` 추가
- [x] API/OAuth/Swagger proxy 설정 추가
- [x] SSE 전용 buffering off 설정 추가
- [x] Grafana/Jaeger admin placeholder route 추가
- [x] proxy/security header snippet 추가
- [x] Compose에 `nginx` service 추가
- [x] `frontend/public/index.html` placeholder 추가
- [x] NGINX routing 문서와 local compose 문서 갱신

## 📁 변경 파일 요약

- `infra/nginx/nginx.conf`
- `infra/nginx/conf.d/*.conf`
- `infra/nginx/snippets/*.conf`
- `infra/docker-compose/docker-compose.local.yml`
- `infra/docker-compose/.env.example`
- `frontend/public/index.html`
- `docs/architecture/nginx-routing.md`
- `docs/feature-specs/issue-47-nginx-routing-skeleton.md`
- `docs/operation/docker-compose-local.md`

## ✅ 검증 내용

- [x] `docker run --rm --add-host backend-api:127.0.0.1 -v "${PWD}\\infra\\nginx\\nginx.conf:/etc/nginx/nginx.conf:ro" -v "${PWD}\\infra\\nginx\\conf.d:/etc/nginx/conf.d:ro" -v "${PWD}\\infra\\nginx\\snippets:/etc/nginx/snippets:ro" -v "${PWD}\\frontend\\public:/usr/share/nginx/html:ro" nginx:1.27-alpine nginx -t`
- [x] `docker compose -f docker-compose.local.yml --env-file .env.example config`
- [x] `docker compose -f docker-compose.local.yml --env-file .env.example config --services`
- [x] `git diff --cached --check`
- [x] staged diff 실제 OAuth/private key secret scan
- [ ] `docker compose up`은 미실행. 로컬 포트 충돌 가능성을 피하기 위해 config와 `nginx -t`로 대체했습니다.

## 🔎 리뷰어가 확인해야 할 부분

- `/api`, `/oauth2`, `/login/oauth2`, `/v3/api-docs`, `/swagger-ui`가 backend-api로 가는지 확인해주세요.
- `/api/v1/jobs/*/events`에 `proxy_buffering off`가 적용된 것이 맞는지 확인해주세요.
- `frontend/public/index.html`은 실제 React/Vite 구현 전 placeholder입니다. 다음 frontend 작업에서 교체됩니다.

## 📸 스크린샷

없음

## 💬 기타 공유사항 to 리뷰어

- Google OAuth를 NGINX entrypoint로 테스트하려면 `http://localhost/login/oauth2/code/google`을 Google Console redirect URI에 추가해야 합니다.
- 운영 HTTPS/HSTS/CSP/admin auth는 배포 작업에서 별도로 다룹니다.