### PR TITLE
✨ [Feat] Job SSE 진행률 skeleton 구현

### DIFF
--- a/backend-api/src/main/java/com/moonju/preprocess/api/domain/job/controller/JobEventController.java
+++ b/backend-api/src/main/java/com/moonju/preprocess/api/domain/job/controller/JobEventController.java
@@ -1,0 +1,26 @@
+package com.moonju.preprocess.api.domain.job.controller;
+
+import com.moonju.preprocess.api.domain.job.service.JobEventService;
+import com.moonju.preprocess.api.global.support.CurrentUser;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+@RestController
+@RequestMapping("/api/v1/jobs")
+public class JobEventController {
+
+    private final JobEventService jobEventService;
+
+    public JobEventController(JobEventService jobEventService) {
+        this.jobEventService = jobEventService;
+    }
+
+    @GetMapping(value = "/{jobId}/events", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
+    public SseEmitter events(@CurrentUser Long currentUserId, @PathVariable Long jobId) {
+        return jobEventService.subscribe(currentUserId, jobId);
+    }
+}

--- a/backend-api/src/main/java/com/moonju/preprocess/api/domain/job/dto/JobEventType.java
+++ b/backend-api/src/main/java/com/moonju/preprocess/api/domain/job/dto/JobEventType.java
@@ -1,0 +1,8 @@
+package com.moonju.preprocess.api.domain.job.dto;
+
+public enum JobEventType {
+    HEARTBEAT,
+    JOB_PROGRESS,
+    JOB_COMPLETED,
+    JOB_FAILED
+}

--- a/backend-api/src/main/java/com/moonju/preprocess/api/domain/job/dto/JobProgressEvent.java
+++ b/backend-api/src/main/java/com/moonju/preprocess/api/domain/job/dto/JobProgressEvent.java
@@ -1,0 +1,38 @@
+package com.moonju.preprocess.api.domain.job.dto;
+
+import java.time.Instant;
+
+public record JobProgressEvent(
+    JobEventType eventType,
+    Long jobId,
+    Integer total,
+    Integer queued,
+    Integer processing,
+    Integer succeeded,
+    Integer failed,
+    Double progressPercent,
+    Instant emittedAt
+) {
+
+    public static JobProgressEvent fromSummary(
+        JobEventType eventType,
+        JobSummaryResponse summary,
+        Instant emittedAt
+    ) {
+        return new JobProgressEvent(
+            eventType,
+            summary.jobId(),
+            summary.total(),
+            summary.queued(),
+            summary.processing(),
+            summary.succeeded(),
+            summary.failed(),
+            summary.progressPercent(),
+            emittedAt
+        );
+    }
+
+    public static JobProgressEvent heartbeat(Long jobId, Instant emittedAt) {
+        return new JobProgressEvent(JobEventType.HEARTBEAT, jobId, null, null, null, null, null, null, emittedAt);
+    }
+}

--- a/backend-api/src/main/java/com/moonju/preprocess/api/domain/job/service/JobEventService.java
+++ b/backend-api/src/main/java/com/moonju/preprocess/api/domain/job/service/JobEventService.java
@@ -1,0 +1,75 @@
+package com.moonju.preprocess.api.domain.job.service;
+
+import com.moonju.preprocess.api.domain.job.dto.JobEventType;
+import com.moonju.preprocess.api.domain.job.dto.JobProgressEvent;
+import com.moonju.preprocess.api.domain.job.dto.JobSummaryResponse;
+import java.time.Clock;
+import org.springframework.stereotype.Service;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+@Service
+public class JobEventService {
+
+    private final JobQueryService jobQueryService;
+    private final SseEmitterRegistry emitterRegistry;
+    private final Clock clock;
+
+    public JobEventService(JobQueryService jobQueryService, SseEmitterRegistry emitterRegistry) {
+        this(jobQueryService, emitterRegistry, Clock.systemUTC());
+    }
+
+    JobEventService(JobQueryService jobQueryService, SseEmitterRegistry emitterRegistry, Clock clock) {
+        this.jobQueryService = jobQueryService;
+        this.emitterRegistry = emitterRegistry;
+        this.clock = clock;
+    }
+
+    public SseEmitter subscribe(Long currentUserId, Long jobId) {
+        JobSummaryResponse summary = jobQueryService.summary(currentUserId, jobId);
+        SseEmitter emitter = emitterRegistry.register(jobId);
+        sendInitialEvents(emitter, summary);
+        return emitter;
+    }
+
+    public int publishProgress(JobSummaryResponse summary) {
+        return emitterRegistry.sendToJob(
+            summary.jobId(),
+            JobProgressEvent.fromSummary(JobEventType.JOB_PROGRESS, summary, clock.instant())
+        );
+    }
+
+    public int publishCompleted(JobSummaryResponse summary) {
+        return emitterRegistry.sendToJob(
+            summary.jobId(),
+            JobProgressEvent.fromSummary(JobEventType.JOB_COMPLETED, summary, clock.instant())
+        );
+    }
+
+    public int publishFailed(JobSummaryResponse summary) {
+        return emitterRegistry.sendToJob(
+            summary.jobId(),
+            JobProgressEvent.fromSummary(JobEventType.JOB_FAILED, summary, clock.instant())
+        );
+    }
+
+    public int publishHeartbeat(Long jobId) {
+        return emitterRegistry.sendToJob(jobId, JobProgressEvent.heartbeat(jobId, clock.instant()));
+    }
+
+    public int connectionCount(Long jobId) {
+        return emitterRegistry.connectionCount(jobId);
+    }
+
+    private void sendInitialEvents(SseEmitter emitter, JobSummaryResponse summary) {
+        try {
+            emitter.send(SseEmitter.event()
+                .name(JobEventType.HEARTBEAT.name())
+                .data(JobProgressEvent.heartbeat(summary.jobId(), clock.instant())));
+            emitter.send(SseEmitter.event()
+                .name(JobEventType.JOB_PROGRESS.name())
+                .data(JobProgressEvent.fromSummary(JobEventType.JOB_PROGRESS, summary, clock.instant())));
+        } catch (Exception exception) {
+            emitter.completeWithError(exception);
+        }
+    }
+}

--- a/backend-api/src/main/java/com/moonju/preprocess/api/domain/job/service/SseEmitterRegistry.java
+++ b/backend-api/src/main/java/com/moonju/preprocess/api/domain/job/service/SseEmitterRegistry.java
@@ -1,0 +1,64 @@
+package com.moonju.preprocess.api.domain.job.service;
+
+import com.moonju.preprocess.api.domain.job.dto.JobProgressEvent;
+import java.io.IOException;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+@Component
+public class SseEmitterRegistry {
+
+    public static final long DEFAULT_TIMEOUT_MILLIS = 30L * 60L * 1000L;
+
+    private final Map<Long, Set<SseEmitter>> emittersByJobId = new ConcurrentHashMap<>();
+
+    public SseEmitter register(Long jobId) {
+        SseEmitter emitter = new SseEmitter(DEFAULT_TIMEOUT_MILLIS);
+        emittersByJobId.computeIfAbsent(jobId, ignored -> ConcurrentHashMap.newKeySet()).add(emitter);
+        emitter.onCompletion(() -> remove(jobId, emitter));
+        emitter.onTimeout(() -> remove(jobId, emitter));
+        emitter.onError(ignored -> remove(jobId, emitter));
+        return emitter;
+    }
+
+    public int sendToJob(Long jobId, JobProgressEvent event) {
+        Set<SseEmitter> emitters = emittersByJobId.getOrDefault(jobId, Set.of());
+        int sentCount = 0;
+        for (SseEmitter emitter : emitters) {
+            if (send(jobId, emitter, event)) {
+                sentCount++;
+            }
+        }
+        return sentCount;
+    }
+
+    public int connectionCount(Long jobId) {
+        return emittersByJobId.getOrDefault(jobId, Set.of()).size();
+    }
+
+    private boolean send(Long jobId, SseEmitter emitter, JobProgressEvent event) {
+        try {
+            emitter.send(SseEmitter.event()
+                .name(event.eventType().name())
+                .data(event));
+            return true;
+        } catch (IOException | IllegalStateException exception) {
+            remove(jobId, emitter);
+            return false;
+        }
+    }
+
+    private void remove(Long jobId, SseEmitter emitter) {
+        Set<SseEmitter> emitters = emittersByJobId.get(jobId);
+        if (emitters == null) {
+            return;
+        }
+        emitters.remove(emitter);
+        if (emitters.isEmpty()) {
+            emittersByJobId.remove(jobId);
+        }
+    }
+}

--- a/backend-api/src/test/java/com/moonju/preprocess/api/domain/job/controller/JobEventControllerTests.java
+++ b/backend-api/src/test/java/com/moonju/preprocess/api/domain/job/controller/JobEventControllerTests.java
@@ -1,0 +1,31 @@
+package com.moonju.preprocess.api.domain.job.controller;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.moonju.preprocess.api.domain.job.service.JobEventService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+@ExtendWith(MockitoExtension.class)
+class JobEventControllerTests {
+
+    @Mock
+    private JobEventService jobEventService;
+
+    @Test
+    void opensJobEventStream() {
+        JobEventController controller = new JobEventController(jobEventService);
+        SseEmitter emitter = new SseEmitter();
+        when(jobEventService.subscribe(20L, 1L)).thenReturn(emitter);
+
+        SseEmitter response = controller.events(20L, 1L);
+
+        assertThat(response).isSameAs(emitter);
+        verify(jobEventService).subscribe(20L, 1L);
+    }
+}

--- a/backend-api/src/test/java/com/moonju/preprocess/api/domain/job/dto/JobProgressEventTests.java
+++ b/backend-api/src/test/java/com/moonju/preprocess/api/domain/job/dto/JobProgressEventTests.java
@@ -1,0 +1,40 @@
+package com.moonju.preprocess.api.domain.job.dto;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Instant;
+import org.junit.jupiter.api.Test;
+
+class JobProgressEventTests {
+
+    @Test
+    void createsProgressEventFromSummary() {
+        JobSummaryResponse summary = new JobSummaryResponse(1L, 10, 2, 1, 6, 1, 70.0);
+        Instant emittedAt = Instant.parse("2026-05-10T00:00:00Z");
+
+        JobProgressEvent event = JobProgressEvent.fromSummary(JobEventType.JOB_PROGRESS, summary, emittedAt);
+
+        assertThat(event.eventType()).isEqualTo(JobEventType.JOB_PROGRESS);
+        assertThat(event.jobId()).isEqualTo(1L);
+        assertThat(event.total()).isEqualTo(10);
+        assertThat(event.queued()).isEqualTo(2);
+        assertThat(event.processing()).isEqualTo(1);
+        assertThat(event.succeeded()).isEqualTo(6);
+        assertThat(event.failed()).isEqualTo(1);
+        assertThat(event.progressPercent()).isEqualTo(70.0);
+        assertThat(event.emittedAt()).isEqualTo(emittedAt);
+    }
+
+    @Test
+    void createsHeartbeatWithoutProgressCounters() {
+        Instant emittedAt = Instant.parse("2026-05-10T00:00:00Z");
+
+        JobProgressEvent event = JobProgressEvent.heartbeat(1L, emittedAt);
+
+        assertThat(event.eventType()).isEqualTo(JobEventType.HEARTBEAT);
+        assertThat(event.jobId()).isEqualTo(1L);
+        assertThat(event.total()).isNull();
+        assertThat(event.progressPercent()).isNull();
+        assertThat(event.emittedAt()).isEqualTo(emittedAt);
+    }
+}

--- a/backend-api/src/test/java/com/moonju/preprocess/api/domain/job/service/JobEventServiceTests.java
+++ b/backend-api/src/test/java/com/moonju/preprocess/api/domain/job/service/JobEventServiceTests.java
@@ -1,0 +1,51 @@
+package com.moonju.preprocess.api.domain.job.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.moonju.preprocess.api.domain.job.dto.JobSummaryResponse;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+@ExtendWith(MockitoExtension.class)
+class JobEventServiceTests {
+
+    private final SseEmitterRegistry emitterRegistry = new SseEmitterRegistry();
+    private final Clock clock = Clock.fixed(Instant.parse("2026-05-10T00:00:00Z"), ZoneOffset.UTC);
+
+    @Mock
+    private JobQueryService jobQueryService;
+
+    @Test
+    void subscribesAfterValidatingReadableJobAndSendsInitialEvents() {
+        JobEventService service = new JobEventService(jobQueryService, emitterRegistry, clock);
+        JobSummaryResponse summary = new JobSummaryResponse(1L, 10, 2, 1, 6, 1, 70.0);
+        when(jobQueryService.summary(20L, 1L)).thenReturn(summary);
+
+        SseEmitter emitter = service.subscribe(20L, 1L);
+
+        assertThat(emitter).isNotNull();
+        assertThat(service.connectionCount(1L)).isEqualTo(1);
+        verify(jobQueryService).summary(20L, 1L);
+    }
+
+    @Test
+    void publishesProgressCompletedFailedAndHeartbeatToRegisteredEmitters() {
+        JobEventService service = new JobEventService(jobQueryService, emitterRegistry, clock);
+        JobSummaryResponse summary = new JobSummaryResponse(1L, 10, 0, 0, 10, 0, 100.0);
+        when(jobQueryService.summary(20L, 1L)).thenReturn(summary);
+        service.subscribe(20L, 1L);
+
+        assertThat(service.publishProgress(summary)).isEqualTo(1);
+        assertThat(service.publishCompleted(summary)).isEqualTo(1);
+        assertThat(service.publishFailed(summary)).isEqualTo(1);
+        assertThat(service.publishHeartbeat(1L)).isEqualTo(1);
+    }
+}

--- a/backend-api/src/test/java/com/moonju/preprocess/api/domain/job/service/SseEmitterRegistryTests.java
+++ b/backend-api/src/test/java/com/moonju/preprocess/api/domain/job/service/SseEmitterRegistryTests.java
@@ -1,0 +1,39 @@
+package com.moonju.preprocess.api.domain.job.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.moonju.preprocess.api.domain.job.dto.JobEventType;
+import com.moonju.preprocess.api.domain.job.dto.JobProgressEvent;
+import com.moonju.preprocess.api.domain.job.dto.JobSummaryResponse;
+import java.time.Instant;
+import org.junit.jupiter.api.Test;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+class SseEmitterRegistryTests {
+
+    private final SseEmitterRegistry registry = new SseEmitterRegistry();
+
+    @Test
+    void registersAndSendsEventsByJobId() {
+        SseEmitter emitter = registry.register(1L);
+        JobSummaryResponse summary = new JobSummaryResponse(1L, 10, 1, 2, 6, 1, 70.0);
+        JobProgressEvent event = JobProgressEvent.fromSummary(
+            JobEventType.JOB_PROGRESS,
+            summary,
+            Instant.parse("2026-05-10T00:00:00Z")
+        );
+
+        int sentCount = registry.sendToJob(1L, event);
+
+        assertThat(emitter).isNotNull();
+        assertThat(registry.connectionCount(1L)).isEqualTo(1);
+        assertThat(sentCount).isEqualTo(1);
+    }
+
+    @Test
+    void returnsZeroWhenNoEmitterExistsForJob() {
+        JobProgressEvent event = JobProgressEvent.heartbeat(99L, Instant.parse("2026-05-10T00:00:00Z"));
+
+        assertThat(registry.sendToJob(99L, event)).isZero();
+    }
+}

--- a/docs/api/job-api.md
+++ b/docs/api/job-api.md
@@ -49,6 +49,7 @@ All endpoints require `Authorization: Bearer <access-token>`.
 | `GET` | `/api/v1/jobs/{jobId}` | Read job detail |
 | `GET` | `/api/v1/jobs/{jobId}/items` | List image-level job items |
 | `GET` | `/api/v1/jobs/{jobId}/summary` | Read progress counters |
+| `GET` | `/api/v1/jobs/{jobId}/events` | Subscribe to progress SSE stream |
 | `POST` | `/api/v1/jobs/{jobId}/cancel` | Request cancellation |
 | `POST` | `/api/v1/jobs/{jobId}/retry` | Retry failed and dead-lettered items |
 | `POST` | `/api/v1/jobs/{jobId}/rerun` | Requeue all non-processing items |
@@ -170,6 +171,44 @@ Response:
 
 `progressPercent` is calculated from `(succeeded + failed) / total * 100`.
 
+## SSE Progress Stream
+
+```text
+GET /api/v1/jobs/{jobId}/events
+Accept: text/event-stream
+```
+
+The stream validates normal Job read permission before opening the connection. On subscribe, the API sends a heartbeat
+event and a current `JOB_PROGRESS` snapshot based on `GET /api/v1/jobs/{jobId}/summary`.
+
+Event types:
+
+| Event | Purpose |
+| --- | --- |
+| `HEARTBEAT` | Keeps the stream alive and verifies the connection |
+| `JOB_PROGRESS` | Sends current progress counters |
+| `JOB_COMPLETED` | Reserved for completed Job transition |
+| `JOB_FAILED` | Reserved for failed Job transition |
+
+Example payload:
+
+```json
+{
+  "eventType": "JOB_PROGRESS",
+  "jobId": 1,
+  "total": 1000,
+  "queued": 120,
+  "processing": 20,
+  "succeeded": 850,
+  "failed": 10,
+  "progressPercent": 86.0,
+  "emittedAt": "2026-05-10T00:00:00Z"
+}
+```
+
+Current limitation: Worker callbacks are not connected yet, so automatic progress publishing on every Worker state
+change is deferred to the Internal Worker API task.
+
 ## Cancel
 
 ```text
@@ -193,6 +232,6 @@ POST /api/v1/jobs/{jobId}/rerun
 
 ## Current Limitations
 
-- SSE progress streaming is not implemented in this issue.
+- SSE progress streaming currently provides the endpoint and initial summary snapshot.
 - Worker success/failure callback API is not implemented in this issue.
 - Artifact listing and ZIP download currently return placeholders.

--- a/docs/feature-specs/issue-53-job-sse-progress.md
+++ b/docs/feature-specs/issue-53-job-sse-progress.md
@@ -1,0 +1,56 @@
+# Issue 53 Job SSE Progress
+
+## Goal
+
+Add a backend SSE skeleton for Job progress streaming.
+
+The endpoint lets the frontend subscribe to `/api/v1/jobs/{jobId}/events`. This PR does not connect Worker callbacks yet;
+it sends an initial heartbeat and current Job summary snapshot after validating the user's read access through the
+existing Job query flow.
+
+## API
+
+```text
+GET /api/v1/jobs/{jobId}/events
+Accept: text/event-stream
+Authorization: Bearer <access-token>
+```
+
+Initial events:
+
+```text
+event: HEARTBEAT
+data: {"eventType":"HEARTBEAT","jobId":1,...}
+
+event: JOB_PROGRESS
+data: {"eventType":"JOB_PROGRESS","jobId":1,"total":100,"queued":10,...}
+```
+
+## Added Components
+
+- `JobEventController`
+- `JobEventService`
+- `SseEmitterRegistry`
+- `JobEventType`
+- `JobProgressEvent`
+
+## Event Types
+
+- `HEARTBEAT`
+- `JOB_PROGRESS`
+- `JOB_COMPLETED`
+- `JOB_FAILED`
+
+## Non-Goals
+
+- No Worker callback API.
+- No direct Worker-to-frontend connection.
+- No OpenCV preprocessing in the API server.
+- No WebSocket implementation.
+- No frontend UI completion.
+
+## Follow-Up
+
+1. Internal Worker API reports item start/success/failure.
+2. Job state transitions publish progress events through `JobEventService`.
+3. Frontend Job detail page consumes the SSE stream and renders counters.

--- a/docs/tasks/13-sse-progress.md
+++ b/docs/tasks/13-sse-progress.md
@@ -1,56 +1,62 @@
 # 13. SSE Progress
 
-## 목표
+## Goal
 
-프론트엔드가 작업 진행률을 실시간으로 받을 수 있는 SSE API를 구현한다.
+Expose a Server-Sent Events endpoint so the frontend can subscribe to Job progress without polling.
 
-## 먼저 읽을 문서
+This task creates the SSE API skeleton. Actual Worker status callbacks and automatic publish on every state transition
+are connected after the Internal Worker API task.
+
+## Documents To Read First
 
 1. `README.md`
 2. `docs/implementation-plan.md`
 3. `docs/tasks/12-job.md`
 4. `docs/api/job-api.md`
-5. `docs/architecture/sequence-diagrams.md`
+5. `docs/architecture/nginx-routing.md`
 
-## 작업 범위
+## Scope
 
 1. Job event controller
 2. SSE emitter registry
-3. Job progress event
-4. heartbeat
-5. NGINX buffering off 연동
+3. Job progress event DTO
+4. Heartbeat/progress/completed/failed event methods
+5. NGINX buffering-off alignment
+6. Tests for controller, service, registry, and event DTO
 
-## 작업 순서
+## Work Order
 
-1. `JobEventController`를 만든다.
-2. `JobEventService`를 만든다.
-3. Job progress event DTO를 만든다.
-4. SSE emitter registry를 구현한다.
-5. 연결 timeout을 설정한다.
-6. 연결 해제 cleanup을 구현한다.
-7. heartbeat event를 구현한다.
-8. `JOB_PROGRESS` event를 구현한다.
-9. `JOB_COMPLETED` event를 구현한다.
-10. `JOB_FAILED` event를 구현한다.
-11. Job 상태 변경 시 이벤트를 발행한다.
-12. NGINX SSE 경로에 `proxy_buffering off`를 적용한다.
-13. 프론트 SSE client와 연결한다.
+1. Create `JobEventController`.
+2. Create `JobEventService`.
+3. Create `JobProgressEvent` and `JobEventType`.
+4. Create `SseEmitterRegistry`.
+5. Configure connection timeout.
+6. Clean up emitters on completion, timeout, and error.
+7. Send initial heartbeat event.
+8. Send initial `JOB_PROGRESS` snapshot event.
+9. Add publish methods for `JOB_PROGRESS`, `JOB_COMPLETED`, and `JOB_FAILED`.
+10. Confirm NGINX SSE route keeps buffering disabled.
+11. Update Job API documentation.
+12. Add tests.
 
-## 산출물
+## Deliverables
 
-1. SSE API
+1. `GET /api/v1/jobs/{jobId}/events`
 2. Job progress event DTO
-3. SSE client 연결 기준
-4. NGINX SSE 설정
+3. SSE emitter registry skeleton
+4. Documentation updates
 
-## 완료 기준
+## Completion Criteria
 
-1. 작업 상세 화면이 새로고침 없이 진행률을 받을 수 있다.
-2. 연결 종료 시 서버 리소스가 정리된다.
-3. NGINX가 SSE 응답을 버퍼링하지 않는다.
+1. The frontend can connect to a Job event stream path.
+2. Server resources are cleaned up when connections finish.
+3. NGINX does not buffer SSE responses.
+4. Unauthorized users cannot subscribe without passing normal Job readability validation.
+5. API server still does not execute image preprocessing logic.
 
-## 금지 사항
+## Forbidden
 
-1. 진행률 조회를 polling만으로 고정하지 않는다.
-2. SSE 연결마다 무제한 리소스를 점유하지 않는다.
-3. 인증 없는 사용자가 다른 사용자의 Job event를 구독하게 하지 않는다.
+1. Do not replace SSE with polling-only progress.
+2. Do not leave unmanaged emitters for every connection.
+3. Do not allow a user to subscribe to another user's Job without permission validation.
+4. Do not implement Worker preprocessing or Worker callbacks in this task.


### PR DESCRIPTION
## #️⃣ 기능 설명

Job 진행률 SSE endpoint skeleton을 추가했습니다. `/api/v1/jobs/{jobId}/events` 구독 시 기존 Job summary 조회 흐름으로 읽기 권한을 검증하고, 초기 heartbeat와 `JOB_PROGRESS` snapshot을 전송합니다.

Closes #53

## 🛠️ 작업 상세 내용

- [x] `JobEventController` 추가
- [x] `JobEventService` 추가
- [x] `SseEmitterRegistry` 추가
- [x] `JobProgressEvent`, `JobEventType` 추가
- [x] heartbeat/progress/completed/failed publish method skeleton 추가
- [x] controller/service/registry/event DTO 테스트 추가
- [x] `docs/api/job-api.md`와 task/feature spec 문서 갱신

## 📁 변경 파일 요약

- `backend-api/src/main/java/com/moonju/preprocess/api/domain/job/controller/JobEventController.java`
- `backend-api/src/main/java/com/moonju/preprocess/api/domain/job/service/JobEventService.java`
- `backend-api/src/main/java/com/moonju/preprocess/api/domain/job/service/SseEmitterRegistry.java`
- `backend-api/src/main/java/com/moonju/preprocess/api/domain/job/dto/JobProgressEvent.java`
- `backend-api/src/test/java/com/moonju/preprocess/api/domain/job/...`
- `docs/api/job-api.md`
- `docs/tasks/13-sse-progress.md`
- `docs/feature-specs/issue-53-job-sse-progress.md`

## ✅ 검증 내용

- [x] `docker run --rm -v "${PWD}:/workspace" -w /workspace/backend-api gradle:8.12.1-jdk21 gradle test`: 통과
- [x] `docker run --rm -v "${PWD}:/workspace" -w /workspace/backend-api gradle:8.12.1-jdk21 gradle build`: 통과
- [x] `git diff --cached --check`: 통과
- [x] backend-api Job domain에 OpenCV/Tesseract/OCR 실행 코드가 없는 것 확인

## 🔎 리뷰어가 확인해야 할 부분

- SSE 구독 시 `jobQueryService.summary()`를 통해 기존 Job 읽기 권한 검증을 재사용하는 방향이 적절한지 확인해주세요.
- initial heartbeat + progress snapshot만 제공하고 Worker callback 연결은 후속 작업으로 둔 범위가 적절한지 확인해주세요.
- `SseEmitterRegistry` cleanup 방식이 skeleton 단계에서 충분한지 확인해주세요.

## 📸 스크린샷

없음

## 💬 기타 공유사항 to 리뷰어

- NGINX SSE buffering off 설정은 기존 `infra/nginx/conf.d/sse.conf`를 사용합니다.
- 실제 Worker 상태 변경 publish는 `14-internal-worker-api` 이후 연결하는 것이 맞습니다.