### PR TITLE
✨ [Feat] Worker debug artifact hook contract 추가

### DIFF
--- a/docs/feature-specs/issue-61-worker-debug-artifact-hook.md
+++ b/docs/feature-specs/issue-61-worker-debug-artifact-hook.md
@@ -1,0 +1,50 @@
+# Issue 61. Worker Debug Artifact Hook Contract
+
+## Feature Summary
+
+This task adds a debug artifact hook contract to the Worker preprocessing pipeline. It does not generate or upload image
+files yet. It only records metadata that later OpenCV steps and artifact upload services can use.
+
+## Implemented Units
+
+1. `DebugArtifactDescriptor`
+2. `PreprocessContext.recordDebugArtifact`
+3. `PreprocessResult.debugArtifacts`
+4. `ProcessingReport.debugArtifacts`
+5. `ProcessingReportFactory` propagation from result to report
+6. Unit tests for debug enabled/disabled behavior and report propagation
+
+## Debug Artifact Contract
+
+When `debug=false`, calls to `recordDebugArtifact` are ignored.
+
+When `debug=true`, the pipeline records metadata:
+
+```json
+{
+  "stepName": "DESKEW",
+  "fileName": "02_deskew.png",
+  "objectKey": "processed/{projectId}/{jobId}/{itemId}/debug/02_deskew.png",
+  "contentType": "image/png"
+}
+```
+
+The object key follows the existing storage convention:
+
+```text
+processed/{projectId}/{jobId}/{itemId}/debug/{stepFileName}
+```
+
+## Runtime Boundary
+
+This hook is metadata-only. The Worker still does not create actual debug images in this issue. Future OpenCV step
+implementations will call `recordDebugArtifact` after generating debug images, and artifact services will upload the
+actual files.
+
+## Out Of Scope
+
+1. OpenCV image mutation
+2. Debug image file creation
+3. Object Storage upload
+4. Backend artifact row registration
+5. OCR text extraction

--- a/docs/tasks/16-worker-preprocess-pipeline.md
+++ b/docs/tasks/16-worker-preprocess-pipeline.md
@@ -61,6 +61,18 @@ Issue 59 implements only the timing and failure-report hook:
 5. `ProcessingReportFactory` maps pipeline timing/fallback data into report DTOs.
 6. `WorkerJobService` maps failed pipeline results to `PIPELINE_EXECUTION_FAILED`.
 
+## Current Issue 61 Scope
+
+Issue 61 implements only the debug artifact hook contract:
+
+1. `DebugArtifactDescriptor` records step name, file name, object key, and content type.
+2. `PreprocessContext` exposes `recordDebugArtifact`.
+3. `debug=false` ignores debug artifact records.
+4. `debug=true` records deterministic object keys under `processed/{projectId}/{jobId}/{itemId}/debug/`.
+5. `PreprocessResult` exposes debug artifact descriptors.
+6. `ProcessingReportFactory` carries debug artifact metadata into report DTOs.
+7. Actual debug image generation and upload remain out of scope.
+
 ## Done Criteria
 
 1. A simple resize-only step does not exist.

--- a/docs/worker/preprocess-pipeline.md
+++ b/docs/worker/preprocess-pipeline.md
@@ -35,6 +35,15 @@ Issue 59 adds runtime metadata hooks:
 These hooks are required before implementing the OpenCV-backed steps because reports and debug artifacts need stable
 metadata regardless of which step succeeds or fails.
 
+Issue 61 adds the debug artifact metadata hook:
+
+- `DebugArtifactDescriptor`
+- `PreprocessContext.recordDebugArtifact`
+- `PreprocessResult.debugArtifacts`
+- `ProcessingReport.debugArtifacts`
+
+The hook is metadata-only. Actual debug image generation and upload are deferred to later OpenCV and artifact tasks.
+
 ## Required Execution Order
 
 Every built-in document preset executes the following order:
@@ -88,11 +97,10 @@ that to `PIPELINE_EXECUTION_FAILED` and reports it to the backend Internal Worke
 
 ## Next Implementation Steps
 
-1. Add debug artifact hook contract.
-2. Add image codec adapter and OpenCV loader.
-3. Replace `DecodeStep` skeleton with actual image decode.
-4. Add `ImageMatHolder` and resource cleanup.
-5. Implement steps one by one with unit tests.
-6. Add report generation per step.
-7. Add artifact save service.
-8. Keep OCR text extraction out of the Worker runtime scope.
+1. Add image codec adapter and OpenCV loader.
+2. Replace `DecodeStep` skeleton with actual image decode.
+3. Add `ImageMatHolder` and resource cleanup.
+4. Implement steps one by one with unit tests.
+5. Add report generation per step.
+6. Add artifact save service.
+7. Keep OCR text extraction out of the Worker runtime scope.

--- a/preprocess-worker/src/main/java/com/moonju/preprocess/worker/domain/preprocess/model/DebugArtifactDescriptor.java
+++ b/preprocess-worker/src/main/java/com/moonju/preprocess/worker/domain/preprocess/model/DebugArtifactDescriptor.java
@@ -1,0 +1,27 @@
+package com.moonju.preprocess.worker.domain.preprocess.model;
+
+import com.moonju.preprocess.worker.domain.artifact.model.ArtifactPath;
+import com.moonju.preprocess.worker.domain.artifact.model.ArtifactType;
+import com.moonju.preprocess.worker.domain.preprocess.step.PreprocessStepName;
+
+public record DebugArtifactDescriptor(
+    PreprocessStepName stepName,
+    String fileName,
+    String objectKey,
+    String contentType
+) {
+
+    public static DebugArtifactDescriptor image(
+        PreprocessStepName stepName,
+        Long projectId,
+        Long jobId,
+        Long itemId,
+        String fileName
+    ) {
+        if (stepName == null) {
+            throw new IllegalArgumentException("Debug artifact step name is required.");
+        }
+        ArtifactPath path = ArtifactPath.debug(projectId, jobId, itemId, fileName);
+        return new DebugArtifactDescriptor(stepName, fileName, path.value(), ArtifactType.DEBUG_IMAGE.contentType());
+    }
+}

--- a/preprocess-worker/src/main/java/com/moonju/preprocess/worker/domain/preprocess/pipeline/PreprocessContext.java
+++ b/preprocess-worker/src/main/java/com/moonju/preprocess/worker/domain/preprocess/pipeline/PreprocessContext.java
@@ -1,5 +1,6 @@
 package com.moonju.preprocess.worker.domain.preprocess.pipeline;
 
+import com.moonju.preprocess.worker.domain.preprocess.model.DebugArtifactDescriptor;
 import com.moonju.preprocess.worker.domain.preprocess.model.FallbackNote;
 import com.moonju.preprocess.worker.domain.preprocess.step.PreprocessStepName;
 import com.moonju.preprocess.worker.domain.workerjob.dto.PreprocessJobMessage;
@@ -12,6 +13,7 @@ import java.util.Map;
 public class PreprocessContext {
 
     private final Long jobId;
+    private final Long projectId;
     private final Long itemId;
     private final String originalObjectKey;
     private final String presetName;
@@ -19,6 +21,7 @@ public class PreprocessContext {
     private final boolean debug;
     private final List<PreprocessStepExecution> stepExecutions = new ArrayList<>();
     private final List<FallbackNote> fallbackNotes = new ArrayList<>();
+    private final List<DebugArtifactDescriptor> debugArtifacts = new ArrayList<>();
     private final Map<PreprocessStepName, String> stepNotes = new EnumMap<>(PreprocessStepName.class);
 
     public PreprocessContext(
@@ -29,6 +32,19 @@ public class PreprocessContext {
         Map<String, String> parameters,
         boolean debug
     ) {
+        this(null, jobId, itemId, originalObjectKey, presetName, parameters, debug);
+    }
+
+    public PreprocessContext(
+        Long projectId,
+        Long jobId,
+        Long itemId,
+        String originalObjectKey,
+        String presetName,
+        Map<String, String> parameters,
+        boolean debug
+    ) {
+        this.projectId = projectId;
         this.jobId = jobId;
         this.itemId = itemId;
         this.originalObjectKey = originalObjectKey;
@@ -39,6 +55,7 @@ public class PreprocessContext {
 
     public static PreprocessContext fromMessage(PreprocessJobMessage message) {
         return new PreprocessContext(
+            message.projectId(),
             message.jobId(),
             message.itemId(),
             message.originalObjectKey(),
@@ -65,8 +82,19 @@ public class PreprocessContext {
         fallbackNotes.add(new FallbackNote(stepName.name(), reason, selectedStrategy));
     }
 
+    public void recordDebugArtifact(PreprocessStepName stepName, String fileName) {
+        if (!debug) {
+            return;
+        }
+        debugArtifacts.add(DebugArtifactDescriptor.image(stepName, projectId, jobId, itemId, fileName));
+    }
+
     public Long jobId() {
         return jobId;
+    }
+
+    public Long projectId() {
+        return projectId;
     }
 
     public Long itemId() {
@@ -95,5 +123,9 @@ public class PreprocessContext {
 
     public List<FallbackNote> fallbackNotes() {
         return List.copyOf(fallbackNotes);
+    }
+
+    public List<DebugArtifactDescriptor> debugArtifacts() {
+        return List.copyOf(debugArtifacts);
     }
 }

--- a/preprocess-worker/src/main/java/com/moonju/preprocess/worker/domain/preprocess/pipeline/PreprocessResult.java
+++ b/preprocess-worker/src/main/java/com/moonju/preprocess/worker/domain/preprocess/pipeline/PreprocessResult.java
@@ -1,5 +1,6 @@
 package com.moonju.preprocess.worker.domain.preprocess.pipeline;
 
+import com.moonju.preprocess.worker.domain.preprocess.model.DebugArtifactDescriptor;
 import com.moonju.preprocess.worker.domain.preprocess.model.FallbackNote;
 import com.moonju.preprocess.worker.domain.preprocess.step.PreprocessStepName;
 import java.time.Duration;
@@ -11,6 +12,7 @@ public record PreprocessResult(
     String presetName,
     List<PreprocessStepExecution> stepExecutions,
     List<FallbackNote> fallbackNotes,
+    List<DebugArtifactDescriptor> debugArtifacts,
     Duration wallTime,
     boolean success,
     String errorMessage,
@@ -34,6 +36,7 @@ public record PreprocessResult(
             context.presetName(),
             context.stepExecutions(),
             context.fallbackNotes(),
+            context.debugArtifacts(),
             wallTime,
             success,
             errorMessage,

--- a/preprocess-worker/src/main/java/com/moonju/preprocess/worker/domain/report/dto/ProcessingReport.java
+++ b/preprocess-worker/src/main/java/com/moonju/preprocess/worker/domain/report/dto/ProcessingReport.java
@@ -1,5 +1,6 @@
 package com.moonju.preprocess.worker.domain.report.dto;
 
+import com.moonju.preprocess.worker.domain.preprocess.model.DebugArtifactDescriptor;
 import com.moonju.preprocess.worker.domain.report.model.ProcessingFallbackSummary;
 import com.moonju.preprocess.worker.domain.report.model.ProcessingMemoryUsage;
 import com.moonju.preprocess.worker.domain.report.model.ProcessingTiming;
@@ -13,6 +14,7 @@ public record ProcessingReport(
     ProcessingTiming timing,
     ProcessingMemoryUsage memoryUsage,
     ProcessingFallbackSummary fallbackSummary,
+    List<DebugArtifactDescriptor> debugArtifacts,
     boolean success,
     String errorMessage
 ) {

--- a/preprocess-worker/src/main/java/com/moonju/preprocess/worker/domain/report/service/ProcessingReportFactory.java
+++ b/preprocess-worker/src/main/java/com/moonju/preprocess/worker/domain/report/service/ProcessingReportFactory.java
@@ -24,6 +24,7 @@ public class ProcessingReportFactory {
             ProcessingTiming.wallOnly(result.wallTime()),
             ProcessingMemoryUsage.notSampled(),
             new ProcessingFallbackSummary(result.fallbackNotes()),
+            result.debugArtifacts(),
             result.success() && !result.skeletonOnly(),
             reportErrorMessage(result)
         );

--- a/preprocess-worker/src/test/java/com/moonju/preprocess/worker/domain/preprocess/pipeline/PreprocessPipelineRunnerTests.java
+++ b/preprocess-worker/src/test/java/com/moonju/preprocess/worker/domain/preprocess/pipeline/PreprocessPipelineRunnerTests.java
@@ -123,4 +123,35 @@ class PreprocessPipelineRunnerTests {
         assertThat(context.fallbackNotes().getFirst().stepName()).isEqualTo("DESKEW");
         assertThat(context.fallbackNotes().getFirst().selectedStrategy()).isEqualTo("minAreaRect");
     }
+
+    @Test
+    void recordsDebugArtifactOnlyWhenDebugEnabled() {
+        PreprocessContext debugContext = new PreprocessContext(
+            3L,
+            1L,
+            10L,
+            "originals/project/scan.png",
+            "LOW_CONTRAST_SCAN",
+            Map.of(),
+            true
+        );
+        PreprocessContext normalContext = new PreprocessContext(
+            3L,
+            1L,
+            10L,
+            "originals/project/scan.png",
+            "LOW_CONTRAST_SCAN",
+            Map.of(),
+            false
+        );
+
+        debugContext.recordDebugArtifact(PreprocessStepName.DESKEW, "02_deskew.png");
+        normalContext.recordDebugArtifact(PreprocessStepName.DESKEW, "02_deskew.png");
+
+        assertThat(debugContext.debugArtifacts()).hasSize(1);
+        assertThat(debugContext.debugArtifacts().getFirst().objectKey())
+            .isEqualTo("processed/3/1/10/debug/02_deskew.png");
+        assertThat(debugContext.debugArtifacts().getFirst().contentType()).isEqualTo("image/png");
+        assertThat(normalContext.debugArtifacts()).isEmpty();
+    }
 }

--- a/preprocess-worker/src/test/java/com/moonju/preprocess/worker/domain/report/service/ProcessingReportFactoryTests.java
+++ b/preprocess-worker/src/test/java/com/moonju/preprocess/worker/domain/report/service/ProcessingReportFactoryTests.java
@@ -7,6 +7,7 @@ import com.moonju.preprocess.worker.domain.preprocess.pipeline.PreprocessPipelin
 import com.moonju.preprocess.worker.domain.preprocess.pipeline.PreprocessResult;
 import com.moonju.preprocess.worker.domain.preprocess.preset.PreprocessPresetRegistry;
 import com.moonju.preprocess.worker.domain.preprocess.step.PreprocessStepCatalog;
+import com.moonju.preprocess.worker.domain.preprocess.step.PreprocessStepName;
 import com.moonju.preprocess.worker.domain.report.dto.ProcessingReport;
 import com.moonju.preprocess.worker.domain.report.dto.ProcessingReportJson;
 import java.util.Map;
@@ -43,9 +44,36 @@ class ProcessingReportFactoryTests {
         assertThat(report.steps().getFirst().timing().wallTime()).isNotNull();
         assertThat(report.timing().wallTime()).isNotNull();
         assertThat(report.fallbackSummary().fallbackNotes()).isEmpty();
+        assertThat(report.debugArtifacts()).isEmpty();
         assertThat(report.success()).isFalse();
         assertThat(report.errorMessage()).isEqualTo("PIPELINE_NOT_IMPLEMENTED");
         assertThat(reportJson.fileName()).isEqualTo("processing-report.json");
         assertThat(reportJson.schemaVersion()).isEqualTo("1.0");
+    }
+
+    @Test
+    void carriesDebugArtifactMetadataIntoReport() {
+        PreprocessContext context = new PreprocessContext(
+            3L,
+            1L,
+            2L,
+            "originals/scan.png",
+            "LOW_CONTRAST_SCAN",
+            Map.of(),
+            true
+        );
+        context.recordDebugArtifact(PreprocessStepName.CROP, "03_crop.png");
+        PreprocessResult result = PreprocessResult.from(
+            context,
+            true,
+            java.time.Duration.ofMillis(1),
+            true,
+            null
+        );
+
+        ProcessingReport report = factory.createSkeletonReport(result);
+
+        assertThat(report.debugArtifacts()).hasSize(1);
+        assertThat(report.debugArtifacts().getFirst().objectKey()).isEqualTo("processed/3/1/2/debug/03_crop.png");
     }
 }


### PR DESCRIPTION
## #️⃣ 기능 설명

Worker 전처리 파이프라인에 debug artifact metadata hook contract를 추가합니다.
이번 작업은 실제 debug 이미지 생성/업로드가 아니라, 이후 OpenCV step과 artifact 저장 작업이 사용할 메타데이터 경로 계약만 정의합니다.

Closes #61

## 🛠️ 작업 상세 내용

- [x] `DebugArtifactDescriptor` 추가
- [x] `PreprocessContext.recordDebugArtifact` 추가
- [x] `debug=false`일 때 debug artifact 기록 무시
- [x] `debug=true`일 때 `processed/{projectId}/{jobId}/{itemId}/debug/{fileName}` object key 기록
- [x] `PreprocessResult`와 `ProcessingReport`로 debug artifact metadata 전달
- [x] 관련 worker 문서와 issue feature spec 갱신
- [x] debug enabled/disabled 및 report propagation 테스트 추가

## 📁 변경 파일 요약

- `preprocess-worker/src/main/java/.../DebugArtifactDescriptor.java`
- `preprocess-worker/src/main/java/.../PreprocessContext.java`
- `preprocess-worker/src/main/java/.../PreprocessResult.java`
- `preprocess-worker/src/main/java/.../ProcessingReport.java`
- `preprocess-worker/src/test/java/.../PreprocessPipelineRunnerTests.java`
- `preprocess-worker/src/test/java/.../ProcessingReportFactoryTests.java`
- `docs/feature-specs/issue-61-worker-debug-artifact-hook.md`
- `docs/worker/preprocess-pipeline.md`
- `docs/tasks/16-worker-preprocess-pipeline.md`

## ✅ 검증 내용

- [x] `docker run --rm -v "${PWD}\\preprocess-worker:/workspace" -w /workspace gradle:8.10-jdk21 gradle test --no-daemon`: 통과
- [x] `docker compose -f infra\\docker-compose\\docker-compose.local.yml build preprocess-worker`: 통과
- [x] `git diff --check`: 통과, CRLF 경고만 발생
- [x] `rg "GOCSPX|562142811433|TYnxvK3|googleusercontent" -n`: 매칭 없음

## 🔎 리뷰어가 확인해야 할 부분

- debug artifact가 metadata-only hook으로 유지되는지 확인해주세요.
- object key가 기존 storage convention과 맞는지 확인해주세요.
- OCR 텍스트 추출이나 실제 이미지 생성/업로드가 섞이지 않았는지 확인해주세요.

## 📸 스크린샷

없음

## 💬 기타 공유사항 to 리뷰어

- 실제 OpenCV debug 이미지 생성과 Object Storage 업로드는 다음 작업에서 분리해서 진행합니다.