### PR TITLE
✨ [Feat] Worker DecodeStep 실제 이미지 decode 연결

### DIFF
--- a/docs/feature-specs/issue-65-worker-decode-step.md
+++ b/docs/feature-specs/issue-65-worker-decode-step.md
@@ -1,0 +1,51 @@
+# Issue 65. Worker DecodeStep Image Decode
+
+## Feature Summary
+
+This task connects the Worker `DecodeStep` to the OpenCV image codec boundary added in issue 63.
+
+The Worker still does not run the full document preprocessing pipeline end to end. This issue only adds the source image
+bytes boundary, decoded `ImageMatHolder` ownership in `PreprocessContext`, and release-on-pipeline-finish behavior.
+
+## Implemented Units
+
+1. `ImageDecodePort` domain port
+2. `ImageCodecAdapter implements ImageDecodePort`
+3. `PreprocessContext.withSourceImageBytes`
+4. `PreprocessContext.storeDecodedImage`
+5. `PreprocessContext.releaseDecodedImage`
+6. `DecodeStep` calls `ImageDecodePort.decode` when source bytes are attached
+7. `PreprocessPipelineRunner` releases decoded holder after pipeline completion or failure
+8. Unit tests for decode success, missing bytes deferral, unsupported bytes failure, and runner cleanup
+
+## Decode Behavior
+
+When source image bytes are attached:
+
+```java
+PreprocessContext context = PreprocessContext.fromMessage(message)
+    .withSourceImageBytes(imageBytes);
+```
+
+`DecodeStep` decodes the bytes through `ImageDecodePort`, stores the returned `ImageMatHolder` in context, and records
+the decoded width, height, and color space in the step note.
+
+When source image bytes are not attached, `DecodeStep` records that decode is waiting for storage download and does not
+fail the skeleton pipeline. This keeps the current Worker runtime compatible until real Object Storage download is
+implemented.
+
+When invalid bytes are attached, OpenCV decode failure is propagated as a pipeline step failure.
+
+## Resource Ownership
+
+`PreprocessContext` owns the decoded holder during pipeline execution. `PreprocessPipelineRunner` releases the holder in
+`finally` so future steps can use the Mat during the run without leaking native memory afterward.
+
+## Out Of Scope
+
+1. Real Object Storage download
+2. Processed image upload
+3. Preview image upload
+4. Debug image upload
+5. Color normalization and downstream OpenCV step mutation
+6. OCR text extraction

--- a/docs/tasks/16-worker-preprocess-pipeline.md
+++ b/docs/tasks/16-worker-preprocess-pipeline.md
@@ -85,6 +85,19 @@ Issue 63 implements only the OpenCV loader and codec boundary:
 6. Decode failure handling for empty or unsupported image bytes.
 7. Actual `DecodeStep` replacement and downstream image processing remain out of scope.
 
+## Current Issue 65 Scope
+
+Issue 65 connects `DecodeStep` to the codec boundary:
+
+1. `ImageDecodePort` is the domain port used by `DecodeStep`.
+2. `ImageCodecAdapter` implements the port.
+3. `PreprocessContext` can receive source image bytes.
+4. `PreprocessContext` stores the decoded `ImageMatHolder`.
+5. `PreprocessPipelineRunner` releases decoded Mat resources after pipeline completion.
+6. `DecodeStep` records decoded width, height, and color space when bytes are attached.
+7. Missing source bytes are deferred until the Object Storage download task.
+8. Invalid attached bytes fail the decode step.
+
 ## Done Criteria
 
 1. A simple resize-only step does not exist.

--- a/docs/worker/image-test-integration.md
+++ b/docs/worker/image-test-integration.md
@@ -51,9 +51,12 @@ Issue 63 adds the first real OpenCV runtime boundary:
 This still does not replace the pipeline `DecodeStep`. The next task should connect Object Storage download bytes to
 `DecodeStep` and store the decoded holder in the preprocessing context.
 
+Issue 65 connects the `DecodeStep` to the codec boundary when source bytes are available. The pipeline context now owns
+the decoded holder during execution and releases it when the runner finishes.
+
 ## Future Implementation Points
 
-1. `domain/preprocess/step/DecodeStep` uses the codec adapter.
+1. Object Storage download supplies source bytes to the context.
 2. Each step updates the processing context with reportable facts.
 3. `domain/artifact` saves processed, preview, report, and debug files to Object Storage.
 4. `domain/report` produces `processing-report.json`.

--- a/docs/worker/preprocess-pipeline.md
+++ b/docs/worker/preprocess-pipeline.md
@@ -54,6 +54,17 @@ Issue 63 adds the OpenCV loader and image codec boundary:
 The pipeline steps still remain skeletons. The next implementation should replace `DecodeStep` with Object Storage
 download plus codec decode.
 
+Issue 65 connects `DecodeStep` to the codec boundary:
+
+- `ImageDecodePort`
+- `PreprocessContext.withSourceImageBytes`
+- `PreprocessContext.storeDecodedImage`
+- `PreprocessContext.releaseDecodedImage`
+- `DecodeStep` real decode path when bytes are attached
+
+The actual Object Storage download remains a later task. Until source bytes are attached, `DecodeStep` records a
+deferred note and lets the skeleton pipeline continue.
+
 ## Required Execution Order
 
 Every built-in document preset executes the following order:
@@ -107,9 +118,9 @@ that to `PIPELINE_EXECUTION_FAILED` and reports it to the backend Internal Worke
 
 ## Next Implementation Steps
 
-1. Replace `DecodeStep` skeleton with actual image decode.
-2. Store and release decoded `ImageMatHolder` through the pipeline context.
-3. Implement steps one by one with unit tests.
+1. Connect Object Storage download bytes to `PreprocessContext.withSourceImageBytes`.
+2. Implement color normalization with unit tests.
+3. Implement downstream steps one by one with unit tests.
 4. Add report generation per step.
 5. Add artifact save service.
 6. Keep OCR text extraction out of the Worker runtime scope.

--- a/preprocess-worker/src/main/java/com/moonju/preprocess/worker/domain/preprocess/pipeline/PreprocessContext.java
+++ b/preprocess-worker/src/main/java/com/moonju/preprocess/worker/domain/preprocess/pipeline/PreprocessContext.java
@@ -2,13 +2,16 @@ package com.moonju.preprocess.worker.domain.preprocess.pipeline;
 
 import com.moonju.preprocess.worker.domain.preprocess.model.DebugArtifactDescriptor;
 import com.moonju.preprocess.worker.domain.preprocess.model.FallbackNote;
+import com.moonju.preprocess.worker.domain.preprocess.model.ImageMatHolder;
 import com.moonju.preprocess.worker.domain.preprocess.step.PreprocessStepName;
 import com.moonju.preprocess.worker.domain.workerjob.dto.PreprocessJobMessage;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.EnumMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 public class PreprocessContext {
 
@@ -23,6 +26,8 @@ public class PreprocessContext {
     private final List<FallbackNote> fallbackNotes = new ArrayList<>();
     private final List<DebugArtifactDescriptor> debugArtifacts = new ArrayList<>();
     private final Map<PreprocessStepName, String> stepNotes = new EnumMap<>(PreprocessStepName.class);
+    private byte[] sourceImageBytes;
+    private ImageMatHolder decodedImage;
 
     public PreprocessContext(
         Long jobId,
@@ -87,6 +92,41 @@ public class PreprocessContext {
             return;
         }
         debugArtifacts.add(DebugArtifactDescriptor.image(stepName, projectId, jobId, itemId, fileName));
+    }
+
+    public PreprocessContext withSourceImageBytes(byte[] imageBytes) {
+        if (imageBytes == null) {
+            this.sourceImageBytes = null;
+            return this;
+        }
+        this.sourceImageBytes = Arrays.copyOf(imageBytes, imageBytes.length);
+        return this;
+    }
+
+    public boolean hasSourceImageBytes() {
+        return sourceImageBytes != null && sourceImageBytes.length > 0;
+    }
+
+    public byte[] sourceImageBytes() {
+        if (sourceImageBytes == null) {
+            return new byte[0];
+        }
+        return Arrays.copyOf(sourceImageBytes, sourceImageBytes.length);
+    }
+
+    public void storeDecodedImage(ImageMatHolder imageMatHolder) {
+        releaseDecodedImage();
+        this.decodedImage = imageMatHolder;
+    }
+
+    public Optional<ImageMatHolder> decodedImage() {
+        return Optional.ofNullable(decodedImage);
+    }
+
+    public void releaseDecodedImage() {
+        if (decodedImage != null) {
+            decodedImage.release();
+        }
     }
 
     public Long jobId() {

--- a/preprocess-worker/src/main/java/com/moonju/preprocess/worker/domain/preprocess/pipeline/PreprocessPipelineRunner.java
+++ b/preprocess-worker/src/main/java/com/moonju/preprocess/worker/domain/preprocess/pipeline/PreprocessPipelineRunner.java
@@ -31,22 +31,26 @@ public class PreprocessPipelineRunner {
     }
 
     public PreprocessResult run(PreprocessContext context) {
-        PreprocessPreset preset = presetRegistry.findByName(context.presetName());
-        PreprocessPipeline pipeline = PreprocessPipeline.from(preset, stepCatalog);
         long pipelineStartNanos = System.nanoTime();
         boolean success = true;
         String errorMessage = null;
-        for (PreprocessStep step : pipeline.steps()) {
-            PreprocessStepExecution execution = executeStep(context, step);
-            context.recordStepExecution(execution);
-            if (!execution.success()) {
-                success = false;
-                errorMessage = execution.errorMessage();
-                break;
+        try {
+            PreprocessPreset preset = presetRegistry.findByName(context.presetName());
+            PreprocessPipeline pipeline = PreprocessPipeline.from(preset, stepCatalog);
+            for (PreprocessStep step : pipeline.steps()) {
+                PreprocessStepExecution execution = executeStep(context, step);
+                context.recordStepExecution(execution);
+                if (!execution.success()) {
+                    success = false;
+                    errorMessage = execution.errorMessage();
+                    break;
+                }
             }
+            Duration wallTime = Duration.ofNanos(System.nanoTime() - pipelineStartNanos);
+            return PreprocessResult.from(context, true, wallTime, success, errorMessage);
+        } finally {
+            context.releaseDecodedImage();
         }
-        Duration wallTime = Duration.ofNanos(System.nanoTime() - pipelineStartNanos);
-        return PreprocessResult.from(context, true, wallTime, success, errorMessage);
     }
 
     private PreprocessStepExecution executeStep(PreprocessContext context, PreprocessStep step) {

--- a/preprocess-worker/src/main/java/com/moonju/preprocess/worker/domain/preprocess/service/ImageDecodePort.java
+++ b/preprocess-worker/src/main/java/com/moonju/preprocess/worker/domain/preprocess/service/ImageDecodePort.java
@@ -1,0 +1,9 @@
+package com.moonju.preprocess.worker.domain.preprocess.service;
+
+import com.moonju.preprocess.worker.domain.preprocess.model.ImageMatHolder;
+
+@FunctionalInterface
+public interface ImageDecodePort {
+
+    ImageMatHolder decode(String objectKey, byte[] imageBytes);
+}

--- a/preprocess-worker/src/main/java/com/moonju/preprocess/worker/domain/preprocess/step/DecodeStep.java
+++ b/preprocess-worker/src/main/java/com/moonju/preprocess/worker/domain/preprocess/step/DecodeStep.java
@@ -1,12 +1,41 @@
 package com.moonju.preprocess.worker.domain.preprocess.step;
 
+import com.moonju.preprocess.worker.domain.preprocess.model.ImageMatHolder;
+import com.moonju.preprocess.worker.domain.preprocess.pipeline.PreprocessContext;
+import com.moonju.preprocess.worker.domain.preprocess.service.ImageDecodePort;
 import org.springframework.stereotype.Component;
 
 @Component
-public class DecodeStep extends AbstractSkeletonPreprocessStep {
+public class DecodeStep implements PreprocessStep {
+
+    private final ImageDecodePort imageDecodePort;
+
+    public DecodeStep(ImageDecodePort imageDecodePort) {
+        this.imageDecodePort = imageDecodePort;
+    }
 
     @Override
     public PreprocessStepName name() {
         return PreprocessStepName.DECODE;
+    }
+
+    @Override
+    public void execute(PreprocessContext context) {
+        if (!context.hasSourceImageBytes()) {
+            context.recordStep(name(), "Source image bytes are not attached; decode is waiting for storage download.");
+            return;
+        }
+
+        ImageMatHolder imageMatHolder = imageDecodePort.decode(context.originalObjectKey(), context.sourceImageBytes());
+        context.storeDecodedImage(imageMatHolder);
+        context.recordStep(
+            name(),
+            "Decoded image: width="
+                + imageMatHolder.width()
+                + ", height="
+                + imageMatHolder.height()
+                + ", colorSpace="
+                + imageMatHolder.colorSpace()
+        );
     }
 }

--- a/preprocess-worker/src/main/java/com/moonju/preprocess/worker/domain/preprocess/step/PreprocessStepCatalog.java
+++ b/preprocess-worker/src/main/java/com/moonju/preprocess/worker/domain/preprocess/step/PreprocessStepCatalog.java
@@ -1,6 +1,8 @@
 package com.moonju.preprocess.worker.domain.preprocess.step;
 
 import com.moonju.preprocess.worker.domain.preprocess.exception.PreprocessStepNotFoundException;
+import com.moonju.preprocess.worker.domain.preprocess.model.ImageMatHolder;
+import com.moonju.preprocess.worker.domain.preprocess.service.ImageDecodePort;
 import java.util.EnumMap;
 import java.util.List;
 import java.util.Map;
@@ -19,8 +21,12 @@ public class PreprocessStepCatalog {
     }
 
     public static PreprocessStepCatalog builtIn() {
+        return builtIn((objectKey, imageBytes) -> ImageMatHolder.placeholder(objectKey));
+    }
+
+    public static PreprocessStepCatalog builtIn(ImageDecodePort imageDecodePort) {
         return new PreprocessStepCatalog(List.of(
-            new DecodeStep(),
+            new DecodeStep(imageDecodePort),
             new ColorNormalizeStep(),
             new OrientationNormalizeStep(),
             new DeskewStep(),

--- a/preprocess-worker/src/main/java/com/moonju/preprocess/worker/infra/opencv/ImageCodecAdapter.java
+++ b/preprocess-worker/src/main/java/com/moonju/preprocess/worker/infra/opencv/ImageCodecAdapter.java
@@ -2,13 +2,14 @@ package com.moonju.preprocess.worker.infra.opencv;
 
 import com.moonju.preprocess.worker.domain.preprocess.exception.ImageDecodeFailedException;
 import com.moonju.preprocess.worker.domain.preprocess.model.ImageMatHolder;
+import com.moonju.preprocess.worker.domain.preprocess.service.ImageDecodePort;
 import org.opencv.core.Mat;
 import org.opencv.core.MatOfByte;
 import org.opencv.imgcodecs.Imgcodecs;
 import org.springframework.stereotype.Component;
 
 @Component
-public class ImageCodecAdapter {
+public class ImageCodecAdapter implements ImageDecodePort {
 
     private final OpenCvLoader openCvLoader;
 
@@ -16,6 +17,7 @@ public class ImageCodecAdapter {
         this.openCvLoader = openCvLoader;
     }
 
+    @Override
     public ImageMatHolder decode(String objectKey, byte[] imageBytes) {
         if (objectKey == null || objectKey.isBlank()) {
             throw new ImageDecodeFailedException("Source object key is required for image decode.");

--- a/preprocess-worker/src/test/java/com/moonju/preprocess/worker/domain/preprocess/pipeline/PreprocessPipelineRunnerTests.java
+++ b/preprocess-worker/src/test/java/com/moonju/preprocess/worker/domain/preprocess/pipeline/PreprocessPipelineRunnerTests.java
@@ -6,7 +6,14 @@ import com.moonju.preprocess.worker.domain.preprocess.preset.PreprocessPresetReg
 import com.moonju.preprocess.worker.domain.preprocess.step.PreprocessStep;
 import com.moonju.preprocess.worker.domain.preprocess.step.PreprocessStepCatalog;
 import com.moonju.preprocess.worker.domain.preprocess.step.PreprocessStepName;
+import com.moonju.preprocess.worker.infra.opencv.ImageCodecAdapter;
+import com.moonju.preprocess.worker.infra.opencv.OpenCvLoader;
+import java.awt.Color;
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 import java.util.Map;
+import javax.imageio.ImageIO;
 import org.junit.jupiter.api.Test;
 
 class PreprocessPipelineRunnerTests {
@@ -153,5 +160,96 @@ class PreprocessPipelineRunnerTests {
             .isEqualTo("processed/3/1/10/debug/02_deskew.png");
         assertThat(debugContext.debugArtifacts().getFirst().contentType()).isEqualTo("image/png");
         assertThat(normalContext.debugArtifacts()).isEmpty();
+    }
+
+    @Test
+    void releasesDecodedImageWhenPipelineFinishes() throws IOException {
+        PreprocessPipelineRunner decodeRunner = new PreprocessPipelineRunner(
+            PreprocessPresetRegistry.builtIn(),
+            PreprocessStepCatalog.builtIn(
+                new ImageCodecAdapter(new OpenCvLoader())
+            )
+        );
+        PreprocessContext context = new PreprocessContext(
+            1L,
+            10L,
+            "originals/project/scan.png",
+            "LOW_CONTRAST_SCAN",
+            Map.of(),
+            false
+        ).withSourceImageBytes(pngBytes());
+
+        PreprocessResult result = decodeRunner.run(context);
+
+        assertThat(result.success()).isTrue();
+        assertThat(context.decodedImage()).isPresent();
+        assertThat(context.decodedImage().orElseThrow().released()).isTrue();
+        assertThat(context.decodedImage().orElseThrow().loaded()).isFalse();
+        assertThat(result.stepExecutions().getFirst().note())
+            .contains("width=3")
+            .contains("height=2");
+    }
+
+    @Test
+    void releasesDecodedImageWhenPipelineFailsAfterDecode() throws IOException {
+        PreprocessStep failingColorNormalizeStep = new PreprocessStep() {
+
+            @Override
+            public PreprocessStepName name() {
+                return PreprocessStepName.COLOR_NORMALIZE;
+            }
+
+            @Override
+            public void execute(PreprocessContext context) {
+                throw new IllegalStateException("color normalize failed");
+            }
+        };
+        PreprocessPipelineRunner failingRunner = new PreprocessPipelineRunner(
+            PreprocessPresetRegistry.builtIn(),
+            new PreprocessStepCatalog(java.util.List.of(
+                new com.moonju.preprocess.worker.domain.preprocess.step.DecodeStep(
+                    new ImageCodecAdapter(new OpenCvLoader())
+                ),
+                failingColorNormalizeStep,
+                new com.moonju.preprocess.worker.domain.preprocess.step.OrientationNormalizeStep(),
+                new com.moonju.preprocess.worker.domain.preprocess.step.DeskewStep(),
+                new com.moonju.preprocess.worker.domain.preprocess.step.CropStep(),
+                new com.moonju.preprocess.worker.domain.preprocess.step.DenoiseStep(),
+                new com.moonju.preprocess.worker.domain.preprocess.step.ContrastNormalizeStep(),
+                new com.moonju.preprocess.worker.domain.preprocess.step.BinarizationStep(),
+                new com.moonju.preprocess.worker.domain.preprocess.step.MorphologyCleanupStep(),
+                new com.moonju.preprocess.worker.domain.preprocess.step.DpiNormalizeStep(),
+                new com.moonju.preprocess.worker.domain.preprocess.step.SharpenStep()
+            ))
+        );
+        PreprocessContext context = new PreprocessContext(
+            1L,
+            10L,
+            "originals/project/scan.png",
+            "LOW_CONTRAST_SCAN",
+            Map.of(),
+            false
+        ).withSourceImageBytes(pngBytes());
+
+        PreprocessResult result = failingRunner.run(context);
+
+        assertThat(result.success()).isFalse();
+        assertThat(result.errorMessage()).isEqualTo("color normalize failed");
+        assertThat(context.decodedImage()).isPresent();
+        assertThat(context.decodedImage().orElseThrow().released()).isTrue();
+    }
+
+    private byte[] pngBytes() throws IOException {
+        BufferedImage image = new BufferedImage(3, 2, BufferedImage.TYPE_3BYTE_BGR);
+        image.setRGB(0, 0, Color.BLACK.getRGB());
+        image.setRGB(1, 0, Color.WHITE.getRGB());
+        image.setRGB(2, 0, Color.BLUE.getRGB());
+        image.setRGB(0, 1, Color.RED.getRGB());
+        image.setRGB(1, 1, Color.GREEN.getRGB());
+        image.setRGB(2, 1, Color.YELLOW.getRGB());
+
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        ImageIO.write(image, "png", output);
+        return output.toByteArray();
     }
 }

--- a/preprocess-worker/src/test/java/com/moonju/preprocess/worker/domain/preprocess/step/DecodeStepTests.java
+++ b/preprocess-worker/src/test/java/com/moonju/preprocess/worker/domain/preprocess/step/DecodeStepTests.java
@@ -1,0 +1,84 @@
+package com.moonju.preprocess.worker.domain.preprocess.step;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.moonju.preprocess.worker.domain.preprocess.exception.ImageDecodeFailedException;
+import com.moonju.preprocess.worker.domain.preprocess.pipeline.PreprocessContext;
+import com.moonju.preprocess.worker.infra.opencv.ImageCodecAdapter;
+import com.moonju.preprocess.worker.infra.opencv.OpenCvLoader;
+import java.awt.Color;
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.Map;
+import javax.imageio.ImageIO;
+import org.junit.jupiter.api.Test;
+
+class DecodeStepTests {
+
+    private final DecodeStep decodeStep = new DecodeStep(new ImageCodecAdapter(new OpenCvLoader()));
+
+    @Test
+    void decodesSourceImageBytesIntoContextHolder() throws IOException {
+        PreprocessContext context = context().withSourceImageBytes(pngBytes());
+
+        decodeStep.execute(context);
+
+        assertThat(context.decodedImage()).isPresent();
+        assertThat(context.decodedImage().orElseThrow().loaded()).isTrue();
+        assertThat(context.decodedImage().orElseThrow().width()).isEqualTo(3);
+        assertThat(context.decodedImage().orElseThrow().height()).isEqualTo(2);
+        assertThat(context.consumeStepNote(PreprocessStepName.DECODE))
+            .contains("width=3")
+            .contains("height=2");
+        context.releaseDecodedImage();
+    }
+
+    @Test
+    void defersDecodeWhenSourceBytesAreNotAttached() {
+        PreprocessContext context = context();
+
+        decodeStep.execute(context);
+
+        assertThat(context.decodedImage()).isEmpty();
+        assertThat(context.consumeStepNote(PreprocessStepName.DECODE))
+            .contains("waiting for storage download");
+    }
+
+    @Test
+    void propagatesDecodeFailureForUnsupportedBytes() {
+        PreprocessContext context = context().withSourceImageBytes(new byte[] {1, 2, 3});
+
+        assertThatThrownBy(() -> decodeStep.execute(context))
+            .isInstanceOf(ImageDecodeFailedException.class)
+            .hasMessageContaining("failed to decode");
+        assertThat(context.decodedImage()).isEmpty();
+    }
+
+    private PreprocessContext context() {
+        return new PreprocessContext(
+            3L,
+            1L,
+            2L,
+            "originals/project/scan.png",
+            "LOW_CONTRAST_SCAN",
+            Map.of(),
+            false
+        );
+    }
+
+    private byte[] pngBytes() throws IOException {
+        BufferedImage image = new BufferedImage(3, 2, BufferedImage.TYPE_3BYTE_BGR);
+        image.setRGB(0, 0, Color.BLACK.getRGB());
+        image.setRGB(1, 0, Color.WHITE.getRGB());
+        image.setRGB(2, 0, Color.BLUE.getRGB());
+        image.setRGB(0, 1, Color.RED.getRGB());
+        image.setRGB(1, 1, Color.GREEN.getRGB());
+        image.setRGB(2, 1, Color.YELLOW.getRGB());
+
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        ImageIO.write(image, "png", output);
+        return output.toByteArray();
+    }
+}


### PR DESCRIPTION
## #️⃣ 기능 설명

Worker `DecodeStep`을 OpenCV image codec boundary에 연결합니다.
이번 PR은 source image bytes가 context에 붙어 있을 때 실제 decode를 수행하고, decoded `ImageMatHolder`를 pipeline context가 소유했다가 runner 종료 시 release하는 계약을 추가합니다.

Closes #65

## 🛠️ 작업 상세 내용

- [x] `ImageDecodePort` domain port 추가
- [x] `ImageCodecAdapter`가 `ImageDecodePort`를 구현하도록 변경
- [x] `PreprocessContext.withSourceImageBytes` 추가
- [x] `PreprocessContext.storeDecodedImage` / `releaseDecodedImage` 추가
- [x] `DecodeStep`이 source bytes가 있으면 실제 OpenCV decode를 수행하도록 변경
- [x] source bytes가 없으면 storage download 대기 note를 기록하고 skeleton pipeline 호환 유지
- [x] `PreprocessPipelineRunner`가 성공/실패와 관계없이 decoded holder를 release하도록 변경
- [x] decode 성공/실패/누락 bytes/runner cleanup 테스트 추가
- [x] 관련 worker 문서와 issue feature spec 갱신

## 📁 변경 파일 요약

- `preprocess-worker/src/main/java/.../ImageDecodePort.java`
- `preprocess-worker/src/main/java/.../PreprocessContext.java`
- `preprocess-worker/src/main/java/.../PreprocessPipelineRunner.java`
- `preprocess-worker/src/main/java/.../DecodeStep.java`
- `preprocess-worker/src/main/java/.../PreprocessStepCatalog.java`
- `preprocess-worker/src/main/java/.../ImageCodecAdapter.java`
- `preprocess-worker/src/test/java/.../DecodeStepTests.java`
- `preprocess-worker/src/test/java/.../PreprocessPipelineRunnerTests.java`
- `docs/feature-specs/issue-65-worker-decode-step.md`
- `docs/tasks/16-worker-preprocess-pipeline.md`
- `docs/worker/preprocess-pipeline.md`
- `docs/worker/image-test-integration.md`

## ✅ 검증 내용

- [x] `docker run --rm -v "${PWD}\\preprocess-worker:/workspace" -w /workspace gradle:8.10-jdk21 gradle test --no-daemon`: 통과
- [x] `docker compose -f infra\\docker-compose\\docker-compose.local.yml build preprocess-worker`: 통과
- [x] `git diff --check`: 통과, CRLF 경고만 발생
- [x] `rg "GOCSPX|562142811433|TYnxvK3|googleusercontent" -n`: 매칭 없음

## 🔎 리뷰어가 확인해야 할 부분

- `DecodeStep`이 source bytes가 있을 때만 실제 decode를 수행하고, storage download 통합은 다음 작업으로 남겨둔 점을 확인해주세요.
- decoded `ImageMatHolder`가 pipeline 종료 시 성공/실패와 관계없이 release되는지 확인해주세요.
- API 서버에 OpenCV 처리 로직이 추가되지 않았는지 확인해주세요.
- OCR 텍스트 추출 기능이 추가되지 않았는지 확인해주세요.

## 📸 스크린샷

없음

## 💬 기타 공유사항 to 리뷰어

- 다음 작업은 Object Storage download bytes를 `PreprocessContext.withSourceImageBytes`에 연결하는 작업입니다.