### PR TITLE
✨ [Feat] Worker Object Storage download bytes 연결

### DIFF
--- a/docs/feature-specs/issue-67-worker-storage-download-bytes.md
+++ b/docs/feature-specs/issue-67-worker-storage-download-bytes.md
@@ -1,0 +1,53 @@
+# Issue 67. Worker Object Storage Download Bytes
+
+## Feature Summary
+
+This task connects Worker object storage download to the preprocessing context. The Worker can now fetch original object
+bytes through `ObjectStoragePort.downloadBytes` and pass them to `PreprocessContext.withSourceImageBytes` before running
+the pipeline.
+
+This enables the `DecodeStep` path from issue 65 to decode actual downloaded bytes when a real object exists in storage.
+
+## Implemented Units
+
+1. Worker-only MinIO SDK dependency: `io.minio:minio:9.0.0`
+2. `ObjectStoragePort.downloadBytes`
+3. `MinioObjectStorageClient.downloadBytes`
+4. `ObjectStorageDownloadFailedException`
+5. `WorkerJobService` download bytes -> `PreprocessContext.withSourceImageBytes`
+6. Storage failure still maps to `STORAGE_DOWNLOAD_FAILED`
+7. Pipeline failure still maps to `PIPELINE_EXECUTION_FAILED`
+8. Worker service tests for download invocation and context byte propagation
+
+## Runtime Flow
+
+```text
+WorkerJobService
+  -> ObjectStoragePort.downloadBytes(originalObjectKey)
+  -> PreprocessContext.fromMessage(message).withSourceImageBytes(bytes)
+  -> PreprocessPipelineRunner.run(context)
+  -> DecodeStep decodes bytes through ImageDecodePort
+```
+
+## Failure Behavior
+
+If storage download fails, the Worker reports:
+
+```text
+STORAGE_DOWNLOAD_FAILED, retryable=true
+```
+
+If storage download succeeds but decode or a later pipeline step fails, the Worker reports:
+
+```text
+PIPELINE_EXECUTION_FAILED, retryable=true
+```
+
+## Out Of Scope
+
+1. Processed image upload
+2. Preview image upload
+3. Processing report upload
+4. Debug artifact upload
+5. Worker success callback
+6. OCR text extraction

--- a/docs/operation/storage-operation.md
+++ b/docs/operation/storage-operation.md
@@ -72,6 +72,20 @@ MINIO_BUCKET
 For S3-compatible production storage, equivalent endpoint, region, access key, secret key, and bucket values are
 required.
 
+## Worker Download Flow
+
+The Worker uses `ObjectStoragePort.downloadBytes` to read the original object before running the preprocessing pipeline:
+
+```text
+originalObjectKey
+  -> ObjectStoragePort.downloadBytes
+  -> PreprocessContext.withSourceImageBytes
+  -> DecodeStep
+```
+
+Download failures are reported as `STORAGE_DOWNLOAD_FAILED` and remain retryable. Decode failures after a successful
+download are reported as `PIPELINE_EXECUTION_FAILED`.
+
 ## Operational Checks
 
 - Presigned URL expiration should be short, usually 10 to 30 minutes.

--- a/docs/tasks/16-worker-preprocess-pipeline.md
+++ b/docs/tasks/16-worker-preprocess-pipeline.md
@@ -98,6 +98,17 @@ Issue 65 connects `DecodeStep` to the codec boundary:
 7. Missing source bytes are deferred until the Object Storage download task.
 8. Invalid attached bytes fail the decode step.
 
+## Current Issue 67 Scope
+
+Issue 67 connects Object Storage download bytes to the pipeline:
+
+1. `ObjectStoragePort.downloadBytes` returns original object bytes.
+2. `MinioObjectStorageClient` downloads bytes from the configured bucket.
+3. `WorkerJobService` passes downloaded bytes to `PreprocessContext.withSourceImageBytes`.
+4. Storage download failures still report `STORAGE_DOWNLOAD_FAILED`.
+5. Decode or later pipeline failures still report `PIPELINE_EXECUTION_FAILED`.
+6. Artifact upload and success callback remain out of scope.
+
 ## Done Criteria
 
 1. A simple resize-only step does not exist.

--- a/docs/worker/image-test-integration.md
+++ b/docs/worker/image-test-integration.md
@@ -54,10 +54,12 @@ This still does not replace the pipeline `DecodeStep`. The next task should conn
 Issue 65 connects the `DecodeStep` to the codec boundary when source bytes are available. The pipeline context now owns
 the decoded holder during execution and releases it when the runner finishes.
 
+Issue 67 connects Object Storage download bytes to the context before pipeline execution. A valid Worker message can now
+fetch the original object and feed those bytes into `DecodeStep`.
+
 ## Future Implementation Points
 
-1. Object Storage download supplies source bytes to the context.
-2. Each step updates the processing context with reportable facts.
-3. `domain/artifact` saves processed, preview, report, and debug files to Object Storage.
-4. `domain/report` produces `processing-report.json`.
-5. Worker reports artifact metadata back through Backend internal API.
+1. Each step updates the processing context with reportable facts.
+2. `domain/artifact` saves processed, preview, report, and debug files to Object Storage.
+3. `domain/report` produces `processing-report.json`.
+4. Worker reports artifact metadata back through Backend internal API.

--- a/docs/worker/preprocess-pipeline.md
+++ b/docs/worker/preprocess-pipeline.md
@@ -65,6 +65,14 @@ Issue 65 connects `DecodeStep` to the codec boundary:
 The actual Object Storage download remains a later task. Until source bytes are attached, `DecodeStep` records a
 deferred note and lets the skeleton pipeline continue.
 
+Issue 67 connects Object Storage download to the context:
+
+- `ObjectStoragePort.downloadBytes`
+- `MinioObjectStorageClient.downloadBytes`
+- `WorkerJobService` attaches downloaded bytes through `PreprocessContext.withSourceImageBytes`
+
+The Worker can now decode real downloaded source bytes. Later steps after decode still remain skeleton implementations.
+
 ## Required Execution Order
 
 Every built-in document preset executes the following order:
@@ -105,8 +113,7 @@ PIPELINE_NOT_IMPLEMENTED
 
 This is intentional. A successful Worker result requires all of the following future integrations:
 
-- Actual OpenCV processing.
-- Object Storage download.
+- Actual OpenCV processing after decode.
 - Processed image upload.
 - Preview upload.
 - Processing report upload.
@@ -118,9 +125,8 @@ that to `PIPELINE_EXECUTION_FAILED` and reports it to the backend Internal Worke
 
 ## Next Implementation Steps
 
-1. Connect Object Storage download bytes to `PreprocessContext.withSourceImageBytes`.
-2. Implement color normalization with unit tests.
-3. Implement downstream steps one by one with unit tests.
-4. Add report generation per step.
-5. Add artifact save service.
-6. Keep OCR text extraction out of the Worker runtime scope.
+1. Implement color normalization with unit tests.
+2. Implement downstream steps one by one with unit tests.
+3. Add report generation per step.
+4. Add artifact save service.
+5. Keep OCR text extraction out of the Worker runtime scope.

--- a/preprocess-worker/build.gradle
+++ b/preprocess-worker/build.gradle
@@ -23,6 +23,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'org.springframework.boot:spring-boot-starter-amqp'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'io.minio:minio:9.0.0'
     implementation 'org.openpnp:opencv:4.9.0-0'
 
     compileOnly 'org.projectlombok:lombok'

--- a/preprocess-worker/src/main/java/com/moonju/preprocess/worker/domain/workerjob/service/WorkerJobService.java
+++ b/preprocess-worker/src/main/java/com/moonju/preprocess/worker/domain/workerjob/service/WorkerJobService.java
@@ -41,8 +41,9 @@ public class WorkerJobService {
             return backendReportFailed(message, exception);
         }
 
+        byte[] sourceImageBytes;
         try {
-            objectStoragePort.prepareDownload(message.originalObjectKey());
+            sourceImageBytes = objectStoragePort.downloadBytes(message.originalObjectKey());
         } catch (RuntimeException exception) {
             return reportFailure(message, WorkerFailureCode.STORAGE_DOWNLOAD_FAILED, exception.getMessage(), true);
         }
@@ -54,7 +55,9 @@ public class WorkerJobService {
         }
 
         try {
-            PreprocessResult result = preprocessPipelineRunner.run(PreprocessContext.fromMessage(message));
+            PreprocessContext context = PreprocessContext.fromMessage(message)
+                .withSourceImageBytes(sourceImageBytes);
+            PreprocessResult result = preprocessPipelineRunner.run(context);
             if (!result.success()) {
                 return reportFailure(
                     message,

--- a/preprocess-worker/src/main/java/com/moonju/preprocess/worker/infra/storage/MinioObjectStorageClient.java
+++ b/preprocess-worker/src/main/java/com/moonju/preprocess/worker/infra/storage/MinioObjectStorageClient.java
@@ -1,5 +1,8 @@
 package com.moonju.preprocess.worker.infra.storage;
 
+import io.minio.GetObjectArgs;
+import io.minio.MinioClient;
+import java.io.InputStream;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
@@ -10,18 +13,33 @@ public class MinioObjectStorageClient implements ObjectStoragePort {
     private static final Logger log = LoggerFactory.getLogger(MinioObjectStorageClient.class);
 
     private final StorageProperties properties;
+    private final MinioClient minioClient;
 
     public MinioObjectStorageClient(StorageProperties properties) {
         this.properties = properties;
+        this.minioClient = MinioClient.builder()
+            .endpoint(properties.getEndpoint())
+            .credentials(properties.getAccessKey(), properties.getSecretKey())
+            .build();
     }
 
     @Override
-    public void prepareDownload(String objectKey) {
-        log.info(
-            "Object storage download skeleton: endpoint={}, bucket={}, objectKey={}",
-            properties.getEndpoint(),
-            properties.getBucket(),
-            objectKey
-        );
+    public byte[] downloadBytes(String objectKey) {
+        try (InputStream objectStream = minioClient.getObject(
+            GetObjectArgs.builder()
+                .bucket(properties.getBucket())
+                .object(objectKey)
+                .build()
+        )) {
+            byte[] bytes = objectStream.readAllBytes();
+            log.info("Downloaded object from storage: bucket={}, objectKey={}, bytes={}",
+                properties.getBucket(),
+                objectKey,
+                bytes.length
+            );
+            return bytes;
+        } catch (Exception exception) {
+            throw new ObjectStorageDownloadFailedException(objectKey, exception);
+        }
     }
 }

--- a/preprocess-worker/src/main/java/com/moonju/preprocess/worker/infra/storage/ObjectStorageDownloadFailedException.java
+++ b/preprocess-worker/src/main/java/com/moonju/preprocess/worker/infra/storage/ObjectStorageDownloadFailedException.java
@@ -1,0 +1,8 @@
+package com.moonju.preprocess.worker.infra.storage;
+
+public class ObjectStorageDownloadFailedException extends RuntimeException {
+
+    public ObjectStorageDownloadFailedException(String objectKey, Throwable cause) {
+        super("Failed to download object from storage: " + objectKey, cause);
+    }
+}

--- a/preprocess-worker/src/main/java/com/moonju/preprocess/worker/infra/storage/ObjectStoragePort.java
+++ b/preprocess-worker/src/main/java/com/moonju/preprocess/worker/infra/storage/ObjectStoragePort.java
@@ -2,5 +2,5 @@ package com.moonju.preprocess.worker.infra.storage;
 
 public interface ObjectStoragePort {
 
-    void prepareDownload(String objectKey);
+    byte[] downloadBytes(String objectKey);
 }

--- a/preprocess-worker/src/test/java/com/moonju/preprocess/worker/domain/workerjob/service/WorkerJobServiceTests.java
+++ b/preprocess-worker/src/test/java/com/moonju/preprocess/worker/domain/workerjob/service/WorkerJobServiceTests.java
@@ -2,6 +2,7 @@ package com.moonju.preprocess.worker.domain.workerjob.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -42,6 +43,7 @@ class WorkerJobServiceTests {
     @Test
     void executesPipelineSkeletonAndReportsNotImplementedBoundary() {
         PreprocessJobMessage message = validMessage();
+        when(objectStoragePort.downloadBytes("originals/scan.png")).thenReturn(new byte[] {1, 2, 3});
 
         WorkerJobResult result = service.process(message);
 
@@ -50,7 +52,7 @@ class WorkerJobServiceTests {
         assertThat(result.message()).contains("skeleton executed 11 steps");
         assertThat(result.retryable()).isFalse();
         verify(backendApiClient).reportStarted(message);
-        verify(objectStoragePort).prepareDownload("originals/scan.png");
+        verify(objectStoragePort).downloadBytes("originals/scan.png");
         verify(backendApiClient).reportHeartbeat(message);
         verify(backendApiClient).reportFailed(
             message,
@@ -103,7 +105,7 @@ class WorkerJobServiceTests {
         PreprocessJobMessage message = validMessage();
         doThrow(new RuntimeException("storage unavailable"))
             .when(objectStoragePort)
-            .prepareDownload("originals/scan.png");
+            .downloadBytes("originals/scan.png");
 
         WorkerJobResult result = service.process(message);
 
@@ -120,6 +122,7 @@ class WorkerJobServiceTests {
     @Test
     void reportsPipelineExecutionFailureAsRetryable() {
         PreprocessJobMessage message = validMessage();
+        when(objectStoragePort.downloadBytes("originals/scan.png")).thenReturn(new byte[] {1, 2, 3});
         PreprocessPipelineRunner failingRunner = mock(PreprocessPipelineRunner.class);
         WorkerJobService failingService = new WorkerJobService(backendApiClient, objectStoragePort, failingRunner);
         PreprocessContext context = PreprocessContext.fromMessage(message);
@@ -136,6 +139,8 @@ class WorkerJobServiceTests {
             "decode failed",
             true
         );
+        verify(failingRunner).run(argThat(preprocessContext -> preprocessContext.hasSourceImageBytes()
+            && preprocessContext.sourceImageBytes().length == 3));
     }
 
     private PreprocessJobMessage validMessage() {


### PR DESCRIPTION
## #️⃣ 기능 설명

Worker가 Object Storage에서 원본 object bytes를 받아 `PreprocessContext.withSourceImageBytes`로 전달하도록 연결합니다.
이제 Worker runtime에서 storage download가 성공하면 `DecodeStep`이 실제 다운로드 bytes를 decode할 수 있습니다.

Closes #67

## 🛠️ 작업 상세 내용

- [x] Worker 전용 `io.minio:minio:9.0.0` 의존성 추가
- [x] `ObjectStoragePort.downloadBytes` 추가
- [x] `MinioObjectStorageClient.downloadBytes` 구현
- [x] `ObjectStorageDownloadFailedException` 추가
- [x] `WorkerJobService`가 download bytes를 `PreprocessContext.withSourceImageBytes`에 연결
- [x] storage download 실패 시 `STORAGE_DOWNLOAD_FAILED` 유지
- [x] pipeline/decode 실패 시 `PIPELINE_EXECUTION_FAILED` 유지
- [x] WorkerJobService 테스트 갱신
- [x] 관련 worker/storage 문서 갱신

## 📁 변경 파일 요약

- `preprocess-worker/build.gradle`
- `preprocess-worker/src/main/java/.../WorkerJobService.java`
- `preprocess-worker/src/main/java/.../ObjectStoragePort.java`
- `preprocess-worker/src/main/java/.../MinioObjectStorageClient.java`
- `preprocess-worker/src/main/java/.../ObjectStorageDownloadFailedException.java`
- `preprocess-worker/src/test/java/.../WorkerJobServiceTests.java`
- `docs/feature-specs/issue-67-worker-storage-download-bytes.md`
- `docs/tasks/16-worker-preprocess-pipeline.md`
- `docs/worker/preprocess-pipeline.md`
- `docs/worker/image-test-integration.md`
- `docs/operation/storage-operation.md`

## ✅ 검증 내용

- [x] `docker run --rm -v "${PWD}\\preprocess-worker:/workspace" -w /workspace gradle:8.10-jdk21 gradle test --no-daemon`: 통과
- [x] `docker compose -f infra\\docker-compose\\docker-compose.local.yml build preprocess-worker`: 통과
- [x] `git diff --check`: 통과, CRLF 경고만 발생
- [x] `rg "GOCSPX|562142811433|TYnxvK3|googleusercontent" -n`: 매칭 없음

## 🔎 리뷰어가 확인해야 할 부분

- Worker가 storage bytes를 context에 연결하는 범위까지만 구현했는지 확인해주세요.
- processed/preview/report artifact upload와 success callback이 이번 PR에 섞이지 않았는지 확인해주세요.
- API 서버에 OpenCV 처리 로직이 추가되지 않았는지 확인해주세요.
- OCR 텍스트 추출 기능이 추가되지 않았는지 확인해주세요.

## 📸 스크린샷

없음

## 💬 기타 공유사항 to 리뷰어

- `io.minio:minio:9.0.0`은 Maven Central 기준 최신 버전입니다.
- 다음 작업은 `ColorNormalizeStep` 실제 구현 또는 artifact/report save 쪽으로 갈 수 있습니다. 추천은 전처리 step을 순서대로 진행하는 것입니다.