### PR TITLE
✨ [Feat] Worker ColorNormalizeStep 실제 구현

### DIFF
--- a/docs/feature-specs/issue-69-worker-color-normalize-step.md
+++ b/docs/feature-specs/issue-69-worker-color-normalize-step.md
@@ -1,0 +1,46 @@
+# Issue 69. Worker ColorNormalizeStep
+
+## Feature Summary
+
+This task replaces the Worker `ColorNormalizeStep` skeleton with OpenCV-backed color normalization.
+
+The step normalizes decoded images into BGR so downstream document preprocessing steps can work with a predictable color
+layout.
+
+## Implemented Units
+
+1. `GRAY -> BGR` conversion
+2. `BGRA -> BGR` conversion
+3. `BGR` no-op path
+4. Context holder replacement after conversion
+5. Previous Mat release when holder is replaced
+6. Step notes for before/after color space
+7. Unit tests for GRAY, BGRA, BGR, missing holder, and unsupported channel layout
+
+## Runtime Behavior
+
+After `DecodeStep` stores an `ImageMatHolder`, `ColorNormalizeStep` checks the holder color space:
+
+```text
+GRAY -> BGR
+BGRA -> BGR
+BGR  -> BGR no-op
+```
+
+When conversion creates a new Mat, the context replaces the previous holder and releases the old Mat. If decoded image
+data is not available yet, the step records a deferred note and keeps the current skeleton-compatible pipeline behavior.
+
+Unsupported channel layouts fail the step and are reported by the Worker as `PIPELINE_EXECUTION_FAILED`.
+
+## Out Of Scope
+
+1. Orientation normalization
+2. Deskew
+3. Crop
+4. Denoise
+5. Contrast normalization
+6. Binarization
+7. Morphology cleanup
+8. DPI normalization
+9. Artifact upload
+10. OCR text extraction

--- a/docs/tasks/16-worker-preprocess-pipeline.md
+++ b/docs/tasks/16-worker-preprocess-pipeline.md
@@ -109,6 +109,18 @@ Issue 67 connects Object Storage download bytes to the pipeline:
 5. Decode or later pipeline failures still report `PIPELINE_EXECUTION_FAILED`.
 6. Artifact upload and success callback remain out of scope.
 
+## Current Issue 69 Scope
+
+Issue 69 implements the first downstream OpenCV preprocessing step:
+
+1. `ColorNormalizeStep` converts `GRAY` input to `BGR`.
+2. `ColorNormalizeStep` converts `BGRA` input to `BGR`.
+3. `BGR` input is treated as normalized and remains no-op.
+4. `PreprocessContext` replaces the decoded holder after conversion and releases the previous Mat.
+5. Missing decoded image data is deferred for skeleton compatibility.
+6. Unsupported channel layouts fail the step.
+7. Downstream orientation, deskew, crop, denoise, contrast, binarization, morphology, DPI, and sharpen steps remain out of scope.
+
 ## Done Criteria
 
 1. A simple resize-only step does not exist.

--- a/docs/worker/image-test-integration.md
+++ b/docs/worker/image-test-integration.md
@@ -57,9 +57,13 @@ the decoded holder during execution and releases it when the runner finishes.
 Issue 67 connects Object Storage download bytes to the context before pipeline execution. A valid Worker message can now
 fetch the original object and feed those bytes into `DecodeStep`.
 
+Issue 69 normalizes decoded image color layout to BGR. This keeps downstream OpenCV document preprocessing steps from
+handling multiple input channel layouts.
+
 ## Future Implementation Points
 
-1. Each step updates the processing context with reportable facts.
-2. `domain/artifact` saves processed, preview, report, and debug files to Object Storage.
-3. `domain/report` produces `processing-report.json`.
-4. Worker reports artifact metadata back through Backend internal API.
+1. Orientation normalization updates the processing context with reportable facts.
+2. Each downstream step updates the processing context with reportable facts.
+3. `domain/artifact` saves processed, preview, report, and debug files to Object Storage.
+4. `domain/report` produces `processing-report.json`.
+5. Worker reports artifact metadata back through Backend internal API.

--- a/docs/worker/preprocess-pipeline.md
+++ b/docs/worker/preprocess-pipeline.md
@@ -73,6 +73,15 @@ Issue 67 connects Object Storage download to the context:
 
 The Worker can now decode real downloaded source bytes. Later steps after decode still remain skeleton implementations.
 
+Issue 69 implements `ColorNormalizeStep`:
+
+- `GRAY -> BGR`
+- `BGRA -> BGR`
+- `BGR` no-op
+
+The step replaces the context-owned Mat only when conversion is needed. The remaining downstream steps still remain
+skeleton implementations.
+
 ## Required Execution Order
 
 Every built-in document preset executes the following order:
@@ -125,7 +134,7 @@ that to `PIPELINE_EXECUTION_FAILED` and reports it to the backend Internal Worke
 
 ## Next Implementation Steps
 
-1. Implement color normalization with unit tests.
+1. Implement orientation normalization with unit tests.
 2. Implement downstream steps one by one with unit tests.
 3. Add report generation per step.
 4. Add artifact save service.

--- a/preprocess-worker/src/main/java/com/moonju/preprocess/worker/domain/preprocess/step/ColorNormalizeStep.java
+++ b/preprocess-worker/src/main/java/com/moonju/preprocess/worker/domain/preprocess/step/ColorNormalizeStep.java
@@ -1,12 +1,49 @@
 package com.moonju.preprocess.worker.domain.preprocess.step;
 
+import com.moonju.preprocess.worker.domain.preprocess.model.ImageMatHolder;
+import com.moonju.preprocess.worker.domain.preprocess.pipeline.PreprocessContext;
+import org.opencv.core.Mat;
+import org.opencv.imgproc.Imgproc;
 import org.springframework.stereotype.Component;
 
 @Component
-public class ColorNormalizeStep extends AbstractSkeletonPreprocessStep {
+public class ColorNormalizeStep implements PreprocessStep {
 
     @Override
     public PreprocessStepName name() {
         return PreprocessStepName.COLOR_NORMALIZE;
+    }
+
+    @Override
+    public void execute(PreprocessContext context) {
+        if (context.decodedImage().isEmpty()) {
+            context.recordStep(name(), "Decoded image is not available; color normalization is deferred.");
+            return;
+        }
+
+        ImageMatHolder holder = context.decodedImage().orElseThrow();
+        if (!holder.loaded()) {
+            context.recordStep(name(), "Decoded image is not loaded; color normalization is deferred.");
+            return;
+        }
+
+        String beforeColorSpace = holder.colorSpace();
+        if ("BGR".equals(beforeColorSpace)) {
+            context.recordStep(name(), "Color already normalized: BGR.");
+            return;
+        }
+
+        Mat normalized = new Mat();
+        if ("GRAY".equals(beforeColorSpace)) {
+            Imgproc.cvtColor(holder.mat(), normalized, Imgproc.COLOR_GRAY2BGR);
+        } else if ("BGRA".equals(beforeColorSpace)) {
+            Imgproc.cvtColor(holder.mat(), normalized, Imgproc.COLOR_BGRA2BGR);
+        } else {
+            throw new IllegalStateException("Unsupported color space for normalization: " + beforeColorSpace);
+        }
+
+        ImageMatHolder normalizedHolder = ImageMatHolder.decoded(holder.sourceObjectKey(), normalized);
+        context.storeDecodedImage(normalizedHolder);
+        context.recordStep(name(), "Color normalized: " + beforeColorSpace + " -> " + normalizedHolder.colorSpace());
     }
 }

--- a/preprocess-worker/src/test/java/com/moonju/preprocess/worker/domain/preprocess/step/ColorNormalizeStepTests.java
+++ b/preprocess-worker/src/test/java/com/moonju/preprocess/worker/domain/preprocess/step/ColorNormalizeStepTests.java
@@ -1,0 +1,117 @@
+package com.moonju.preprocess.worker.domain.preprocess.step;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.moonju.preprocess.worker.domain.preprocess.model.ImageMatHolder;
+import com.moonju.preprocess.worker.domain.preprocess.pipeline.PreprocessContext;
+import com.moonju.preprocess.worker.infra.opencv.OpenCvLoader;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.opencv.core.CvType;
+import org.opencv.core.Mat;
+import org.opencv.core.Scalar;
+
+class ColorNormalizeStepTests {
+
+    private final ColorNormalizeStep step = new ColorNormalizeStep();
+
+    @BeforeAll
+    static void loadOpenCv() {
+        new OpenCvLoader().loadIfPresent();
+    }
+
+    @Test
+    void convertsGrayImageToBgrAndReleasesPreviousHolder() {
+        PreprocessContext context = context();
+        ImageMatHolder grayHolder = ImageMatHolder.decoded(
+            "originals/gray.png",
+            new Mat(2, 3, CvType.CV_8UC1, new Scalar(128))
+        );
+        context.storeDecodedImage(grayHolder);
+
+        step.execute(context);
+
+        ImageMatHolder normalizedHolder = context.decodedImage().orElseThrow();
+        assertThat(grayHolder.released()).isTrue();
+        assertThat(normalizedHolder.loaded()).isTrue();
+        assertThat(normalizedHolder.width()).isEqualTo(3);
+        assertThat(normalizedHolder.height()).isEqualTo(2);
+        assertThat(normalizedHolder.colorSpace()).isEqualTo("BGR");
+        assertThat(context.consumeStepNote(PreprocessStepName.COLOR_NORMALIZE)).isEqualTo("Color normalized: GRAY -> BGR");
+        context.releaseDecodedImage();
+    }
+
+    @Test
+    void convertsBgraImageToBgrAndReleasesPreviousHolder() {
+        PreprocessContext context = context();
+        ImageMatHolder bgraHolder = ImageMatHolder.decoded(
+            "originals/bgra.png",
+            new Mat(2, 3, CvType.CV_8UC4, new Scalar(10, 20, 30, 255))
+        );
+        context.storeDecodedImage(bgraHolder);
+
+        step.execute(context);
+
+        ImageMatHolder normalizedHolder = context.decodedImage().orElseThrow();
+        assertThat(bgraHolder.released()).isTrue();
+        assertThat(normalizedHolder.colorSpace()).isEqualTo("BGR");
+        assertThat(context.consumeStepNote(PreprocessStepName.COLOR_NORMALIZE)).isEqualTo("Color normalized: BGRA -> BGR");
+        context.releaseDecodedImage();
+    }
+
+    @Test
+    void keepsBgrImageAsNoOp() {
+        PreprocessContext context = context();
+        ImageMatHolder bgrHolder = ImageMatHolder.decoded(
+            "originals/bgr.png",
+            new Mat(2, 3, CvType.CV_8UC3, new Scalar(10, 20, 30))
+        );
+        context.storeDecodedImage(bgrHolder);
+
+        step.execute(context);
+
+        assertThat(context.decodedImage().orElseThrow()).isSameAs(bgrHolder);
+        assertThat(bgrHolder.released()).isFalse();
+        assertThat(context.consumeStepNote(PreprocessStepName.COLOR_NORMALIZE)).isEqualTo("Color already normalized: BGR.");
+        context.releaseDecodedImage();
+    }
+
+    @Test
+    void defersWhenDecodedImageIsMissing() {
+        PreprocessContext context = context();
+
+        step.execute(context);
+
+        assertThat(context.consumeStepNote(PreprocessStepName.COLOR_NORMALIZE))
+            .contains("not available");
+    }
+
+    @Test
+    void rejectsUnsupportedChannelLayout() {
+        PreprocessContext context = context();
+        ImageMatHolder holder = ImageMatHolder.decoded(
+            "originals/unsupported.png",
+            new Mat(2, 3, CvType.CV_8UC2, new Scalar(1, 2))
+        );
+        context.storeDecodedImage(holder);
+
+        assertThatThrownBy(() -> step.execute(context))
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessageContaining("Unsupported color space");
+        context.releaseDecodedImage();
+    }
+
+    private PreprocessContext context() {
+        return new PreprocessContext(
+            3L,
+            1L,
+            2L,
+            "originals/project/scan.png",
+            "LOW_CONTRAST_SCAN",
+            Map.of(),
+            false
+        );
+    }
+}


### PR DESCRIPTION
## #️⃣ 기능 설명

Worker `ColorNormalizeStep` skeleton을 OpenCV 기반 실제 color normalization으로 교체합니다.
Decode된 Mat을 후속 전처리 단계가 다루기 쉬운 BGR 형태로 정규화합니다.

Closes #69

## 🛠️ 작업 상세 내용

- [x] `GRAY -> BGR` 변환 구현
- [x] `BGRA -> BGR` 변환 구현
- [x] `BGR` 입력 no-op 처리
- [x] 변환 시 context decoded holder 교체 및 기존 Mat release 확인
- [x] color normalization step note에 before/after color space 기록
- [x] missing decoded holder는 skeleton 호환을 위해 deferred note 처리
- [x] unsupported channel layout 실패 테스트 추가
- [x] 관련 worker 문서 갱신

## 📁 변경 파일 요약

- `preprocess-worker/src/main/java/.../ColorNormalizeStep.java`
- `preprocess-worker/src/test/java/.../ColorNormalizeStepTests.java`
- `docs/feature-specs/issue-69-worker-color-normalize-step.md`
- `docs/tasks/16-worker-preprocess-pipeline.md`
- `docs/worker/preprocess-pipeline.md`
- `docs/worker/image-test-integration.md`

## ✅ 검증 내용

- [x] `docker run --rm -v "${PWD}\\preprocess-worker:/workspace" -w /workspace gradle:8.10-jdk21 gradle test --no-daemon`: 통과
- [x] `docker compose -f infra\\docker-compose\\docker-compose.local.yml build preprocess-worker`: 통과
- [x] `git diff --check`: 통과, CRLF 경고만 발생
- [x] `rg "GOCSPX|562142811433|TYnxvK3|googleusercontent" -n`: 매칭 없음

## 🔎 리뷰어가 확인해야 할 부분

- `ColorNormalizeStep`이 GRAY/BGRA만 BGR로 변환하고 BGR은 no-op으로 유지하는지 확인해주세요.
- holder 교체 시 기존 Mat release가 보장되는지 확인해주세요.
- downstream orientation/deskew/crop 작업이 이번 PR에 섞이지 않았는지 확인해주세요.
- OCR 텍스트 추출 기능이 추가되지 않았는지 확인해주세요.

## 📸 스크린샷

없음

## 💬 기타 공유사항 to 리뷰어

- 다음 작업은 `OrientationNormalizeStep` 실제 구현으로 이어가는 것을 추천합니다.