### PR TITLE
✨ [Feat] Worker Geometry 1 orientation/deskew 구현

### DIFF
--- a/docs/feature-specs/issue-71-worker-geometry-1-orientation-deskew.md
+++ b/docs/feature-specs/issue-71-worker-geometry-1-orientation-deskew.md
@@ -1,0 +1,61 @@
+# Issue 71. Worker Geometry 1 Orientation And Deskew
+
+## Feature Summary
+
+This task implements the first geometry stage of the Worker preprocessing pipeline.
+
+`OrientationNormalizeStep` and `DeskewStep` are now backed by OpenCV operations. The goal is to make downstream crop,
+quality, and binarization steps operate on a more predictable document geometry.
+
+## Implemented Units
+
+1. `OrientationNormalizeStep`
+2. Landscape-to-portrait 90-degree rotation
+3. Orientation skip/deferred step notes
+4. `DeskewStep`
+5. Foreground extraction with grayscale + Otsu inverse threshold
+6. `minAreaRect` skew correction angle estimation
+7. Max deskew angle guard
+8. Low foreground fallback
+9. Context holder replacement and previous Mat release on applied transforms
+10. Unit tests for orientation rotate/no-op/deferred
+11. Unit tests for deskew applied/blank fallback/deferred
+
+## Orientation Behavior
+
+If the decoded image is landscape, the step rotates it 90 degrees clockwise:
+
+```text
+width > height -> rotate 90 degrees clockwise
+width <= height -> no-op
+```
+
+This is intentionally simple. EXIF orientation and content-aware orientation detection remain out of scope.
+
+## Deskew Behavior
+
+Deskew uses a conservative OpenCV flow:
+
+```text
+BGR/BGRA/GRAY -> grayscale
+grayscale -> Otsu inverse threshold
+foreground mask -> findNonZero
+points -> minAreaRect
+angle -> normalize to correction angle
+correction angle within maxDeskewAngle -> warpAffine
+```
+
+If there are not enough foreground points, the step records a fallback note and skips deskew. If the detected correction
+angle exceeds `maxDeskewAngle`, the step also records a fallback note and skips.
+
+## Out Of Scope
+
+1. Crop
+2. DPI normalization
+3. Denoise
+4. Contrast normalization
+5. Binarization
+6. Morphology cleanup
+7. Sharpen
+8. Artifact upload
+9. OCR text extraction

--- a/docs/tasks/16-worker-preprocess-pipeline.md
+++ b/docs/tasks/16-worker-preprocess-pipeline.md
@@ -121,6 +121,17 @@ Issue 69 implements the first downstream OpenCV preprocessing step:
 6. Unsupported channel layouts fail the step.
 7. Downstream orientation, deskew, crop, denoise, contrast, binarization, morphology, DPI, and sharpen steps remain out of scope.
 
+## Current Issue 71 Scope
+
+Issue 71 implements Geometry 1:
+
+1. `OrientationNormalizeStep` rotates landscape inputs to portrait orientation.
+2. Portrait or square inputs remain no-op.
+3. `DeskewStep` estimates correction angle using grayscale, Otsu inverse threshold, foreground points, and `minAreaRect`.
+4. `DeskewStep` applies `warpAffine` only when angle is within `maxDeskewAngle`.
+5. Low foreground or excessive angle cases record fallback notes and skip.
+6. Crop, DPI normalization, quality steps, artifact upload, and success callback remain out of scope.
+
 ## Done Criteria
 
 1. A simple resize-only step does not exist.

--- a/docs/worker/image-test-integration.md
+++ b/docs/worker/image-test-integration.md
@@ -60,10 +60,13 @@ fetch the original object and feed those bytes into `DecodeStep`.
 Issue 69 normalizes decoded image color layout to BGR. This keeps downstream OpenCV document preprocessing steps from
 handling multiple input channel layouts.
 
+Issue 71 adds the first geometry corrections. Orientation normalization handles obvious landscape scans, and deskew
+uses foreground geometry to correct moderate scan tilt.
+
 ## Future Implementation Points
 
-1. Orientation normalization updates the processing context with reportable facts.
-2. Each downstream step updates the processing context with reportable facts.
+1. Crop and DPI normalization update the processing context with reportable facts.
+2. Quality steps update the processing context with reportable facts.
 3. `domain/artifact` saves processed, preview, report, and debug files to Object Storage.
 4. `domain/report` produces `processing-report.json`.
 5. Worker reports artifact metadata back through Backend internal API.

--- a/docs/worker/preprocess-pipeline.md
+++ b/docs/worker/preprocess-pipeline.md
@@ -82,6 +82,14 @@ Issue 69 implements `ColorNormalizeStep`:
 The step replaces the context-owned Mat only when conversion is needed. The remaining downstream steps still remain
 skeleton implementations.
 
+Issue 71 implements Geometry 1:
+
+- `OrientationNormalizeStep`
+- `DeskewStep`
+
+Orientation normalization rotates landscape input to portrait orientation. Deskew estimates a correction angle from
+foreground pixels and applies `warpAffine` when the angle is within the configured safety bound.
+
 ## Required Execution Order
 
 Every built-in document preset executes the following order:
@@ -134,8 +142,8 @@ that to `PIPELINE_EXECUTION_FAILED` and reports it to the backend Internal Worke
 
 ## Next Implementation Steps
 
-1. Implement orientation normalization with unit tests.
-2. Implement downstream steps one by one with unit tests.
+1. Implement Geometry 2: crop and DPI normalization.
+2. Implement quality steps: denoise, contrast, binarization, morphology cleanup.
 3. Add report generation per step.
 4. Add artifact save service.
 5. Keep OCR text extraction out of the Worker runtime scope.

--- a/preprocess-worker/src/main/java/com/moonju/preprocess/worker/domain/preprocess/step/DeskewStep.java
+++ b/preprocess-worker/src/main/java/com/moonju/preprocess/worker/domain/preprocess/step/DeskewStep.java
@@ -1,12 +1,134 @@
 package com.moonju.preprocess.worker.domain.preprocess.step;
 
+import com.moonju.preprocess.worker.domain.preprocess.model.ImageMatHolder;
+import com.moonju.preprocess.worker.domain.preprocess.pipeline.PreprocessContext;
+import org.opencv.core.Core;
+import org.opencv.core.Mat;
+import org.opencv.core.MatOfPoint;
+import org.opencv.core.MatOfPoint2f;
+import org.opencv.core.Point;
+import org.opencv.core.RotatedRect;
+import org.opencv.core.Scalar;
+import org.opencv.imgproc.Imgproc;
 import org.springframework.stereotype.Component;
 
 @Component
-public class DeskewStep extends AbstractSkeletonPreprocessStep {
+public class DeskewStep implements PreprocessStep {
+
+    private static final double DEFAULT_MAX_DESKEW_ANGLE = 40.0;
+    private static final double MIN_APPLY_ANGLE = 0.3;
+    private static final int MIN_FOREGROUND_POINTS = 20;
 
     @Override
     public PreprocessStepName name() {
         return PreprocessStepName.DESKEW;
+    }
+
+    @Override
+    public void execute(PreprocessContext context) {
+        if (context.decodedImage().isEmpty()) {
+            context.recordStep(name(), "Decoded image is not available; deskew is deferred.");
+            return;
+        }
+
+        ImageMatHolder holder = context.decodedImage().orElseThrow();
+        if (!holder.loaded()) {
+            context.recordStep(name(), "Decoded image is not loaded; deskew is deferred.");
+            return;
+        }
+
+        Mat grayscale = toGrayscale(holder.mat());
+        Mat foregroundMask = new Mat();
+        Imgproc.threshold(grayscale, foregroundMask, 0, 255, Imgproc.THRESH_BINARY_INV + Imgproc.THRESH_OTSU);
+
+        MatOfPoint foregroundPoints = new MatOfPoint();
+        Core.findNonZero(foregroundMask, foregroundPoints);
+        if (foregroundPoints.rows() < MIN_FOREGROUND_POINTS) {
+            release(grayscale, foregroundMask, foregroundPoints);
+            context.recordFallback(name(), "Not enough foreground points for deskew.", "skip");
+            context.recordStep(name(), "Deskew skipped: insufficient foreground points.");
+            return;
+        }
+
+        MatOfPoint2f points = new MatOfPoint2f(foregroundPoints.toArray());
+        RotatedRect rectangle = Imgproc.minAreaRect(points);
+        double correctionAngle = normalizeCorrectionAngle(rectangle.angle);
+        release(grayscale, foregroundMask, foregroundPoints, points);
+
+        double maxDeskewAngle = maxDeskewAngle(context);
+        if (Math.abs(correctionAngle) > maxDeskewAngle) {
+            context.recordFallback(name(), "Detected skew angle exceeds maximum.", "skip");
+            context.recordStep(name(), "Deskew skipped: angle=" + round(correctionAngle) + " exceeds max=" + maxDeskewAngle);
+            return;
+        }
+
+        if (Math.abs(correctionAngle) < MIN_APPLY_ANGLE) {
+            context.recordStep(name(), "Deskew skipped: angle below threshold, angle=" + round(correctionAngle));
+            return;
+        }
+
+        Mat deskewed = new Mat();
+        Mat rotationMatrix = Imgproc.getRotationMatrix2D(
+            new Point(holder.width() / 2.0, holder.height() / 2.0),
+            correctionAngle,
+            1.0
+        );
+        Imgproc.warpAffine(
+            holder.mat(),
+            deskewed,
+            rotationMatrix,
+            holder.mat().size(),
+            Imgproc.INTER_LINEAR,
+            Core.BORDER_REPLICATE,
+            new Scalar(255, 255, 255)
+        );
+        rotationMatrix.release();
+
+        ImageMatHolder deskewedHolder = ImageMatHolder.decoded(holder.sourceObjectKey(), deskewed);
+        context.storeDecodedImage(deskewedHolder);
+        context.recordStep(name(), "Deskew applied: method=minAreaRect, correctionAngle=" + round(correctionAngle));
+    }
+
+    private Mat toGrayscale(Mat source) {
+        Mat grayscale = new Mat();
+        if (source.channels() == 1) {
+            source.copyTo(grayscale);
+        } else if (source.channels() == 3) {
+            Imgproc.cvtColor(source, grayscale, Imgproc.COLOR_BGR2GRAY);
+        } else if (source.channels() == 4) {
+            Imgproc.cvtColor(source, grayscale, Imgproc.COLOR_BGRA2GRAY);
+        } else {
+            throw new IllegalStateException("Unsupported channel layout for deskew: " + source.channels());
+        }
+        return grayscale;
+    }
+
+    private double normalizeCorrectionAngle(double rawAngle) {
+        double normalizedAngle = rawAngle;
+        if (normalizedAngle > 45.0) {
+            normalizedAngle -= 90.0;
+        }
+        if (normalizedAngle < -45.0) {
+            normalizedAngle += 90.0;
+        }
+        return -normalizedAngle;
+    }
+
+    private double maxDeskewAngle(PreprocessContext context) {
+        String configured = context.parameters().get("maxDeskewAngle");
+        if (configured == null || configured.isBlank()) {
+            return DEFAULT_MAX_DESKEW_ANGLE;
+        }
+        return Double.parseDouble(configured);
+    }
+
+    private double round(double value) {
+        return Math.round(value * 100.0) / 100.0;
+    }
+
+    private void release(Mat... mats) {
+        for (Mat mat : mats) {
+            mat.release();
+        }
     }
 }

--- a/preprocess-worker/src/main/java/com/moonju/preprocess/worker/domain/preprocess/step/OrientationNormalizeStep.java
+++ b/preprocess-worker/src/main/java/com/moonju/preprocess/worker/domain/preprocess/step/OrientationNormalizeStep.java
@@ -1,12 +1,47 @@
 package com.moonju.preprocess.worker.domain.preprocess.step;
 
+import com.moonju.preprocess.worker.domain.preprocess.model.ImageMatHolder;
+import com.moonju.preprocess.worker.domain.preprocess.pipeline.PreprocessContext;
+import org.opencv.core.Core;
+import org.opencv.core.Mat;
 import org.springframework.stereotype.Component;
 
 @Component
-public class OrientationNormalizeStep extends AbstractSkeletonPreprocessStep {
+public class OrientationNormalizeStep implements PreprocessStep {
 
     @Override
     public PreprocessStepName name() {
         return PreprocessStepName.ORIENTATION_NORMALIZE;
+    }
+
+    @Override
+    public void execute(PreprocessContext context) {
+        if (context.decodedImage().isEmpty()) {
+            context.recordStep(name(), "Decoded image is not available; orientation normalization is deferred.");
+            return;
+        }
+
+        ImageMatHolder holder = context.decodedImage().orElseThrow();
+        if (!holder.loaded()) {
+            context.recordStep(name(), "Decoded image is not loaded; orientation normalization is deferred.");
+            return;
+        }
+
+        if (holder.width() <= holder.height()) {
+            context.recordStep(name(), "Orientation already normalized: portrait or square.");
+            return;
+        }
+
+        Mat rotated = new Mat();
+        Core.rotate(holder.mat(), rotated, Core.ROTATE_90_CLOCKWISE);
+        ImageMatHolder rotatedHolder = ImageMatHolder.decoded(holder.sourceObjectKey(), rotated);
+        context.storeDecodedImage(rotatedHolder);
+        context.recordStep(
+            name(),
+            "Orientation normalized: landscape -> portrait, width="
+                + rotatedHolder.width()
+                + ", height="
+                + rotatedHolder.height()
+        );
     }
 }

--- a/preprocess-worker/src/test/java/com/moonju/preprocess/worker/domain/preprocess/step/DeskewStepTests.java
+++ b/preprocess-worker/src/test/java/com/moonju/preprocess/worker/domain/preprocess/step/DeskewStepTests.java
@@ -1,0 +1,102 @@
+package com.moonju.preprocess.worker.domain.preprocess.step;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.moonju.preprocess.worker.domain.preprocess.model.ImageMatHolder;
+import com.moonju.preprocess.worker.domain.preprocess.pipeline.PreprocessContext;
+import com.moonju.preprocess.worker.infra.opencv.OpenCvLoader;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.opencv.core.Core;
+import org.opencv.core.CvType;
+import org.opencv.core.Mat;
+import org.opencv.core.Point;
+import org.opencv.core.Scalar;
+import org.opencv.core.Size;
+import org.opencv.imgproc.Imgproc;
+
+class DeskewStepTests {
+
+    private final DeskewStep step = new DeskewStep();
+
+    @BeforeAll
+    static void loadOpenCv() {
+        new OpenCvLoader().loadIfPresent();
+    }
+
+    @Test
+    void appliesDeskewWhenSkewAngleIsDetected() {
+        PreprocessContext context = context(Map.of("maxDeskewAngle", "40"));
+        ImageMatHolder skewedHolder = ImageMatHolder.decoded("originals/skewed.png", skewedDocument());
+        context.storeDecodedImage(skewedHolder);
+
+        step.execute(context);
+
+        ImageMatHolder deskewedHolder = context.decodedImage().orElseThrow();
+        assertThat(skewedHolder.released()).isTrue();
+        assertThat(deskewedHolder.loaded()).isTrue();
+        assertThat(deskewedHolder.colorSpace()).isEqualTo("BGR");
+        assertThat(context.consumeStepNote(PreprocessStepName.DESKEW)).contains("Deskew applied");
+        context.releaseDecodedImage();
+    }
+
+    @Test
+    void skipsBlankImageAndRecordsFallback() {
+        PreprocessContext context = context(Map.of());
+        ImageMatHolder blankHolder = ImageMatHolder.decoded(
+            "originals/blank.png",
+            new Mat(60, 80, CvType.CV_8UC3, new Scalar(255, 255, 255))
+        );
+        context.storeDecodedImage(blankHolder);
+
+        step.execute(context);
+
+        assertThat(context.decodedImage().orElseThrow()).isSameAs(blankHolder);
+        assertThat(blankHolder.released()).isFalse();
+        assertThat(context.fallbackNotes()).hasSize(1);
+        assertThat(context.fallbackNotes().getFirst().selectedStrategy()).isEqualTo("skip");
+        assertThat(context.consumeStepNote(PreprocessStepName.DESKEW)).contains("insufficient");
+        context.releaseDecodedImage();
+    }
+
+    @Test
+    void defersWhenDecodedImageIsMissing() {
+        PreprocessContext context = context(Map.of());
+
+        step.execute(context);
+
+        assertThat(context.consumeStepNote(PreprocessStepName.DESKEW)).contains("not available");
+    }
+
+    private Mat skewedDocument() {
+        Mat document = new Mat(80, 120, CvType.CV_8UC3, new Scalar(255, 255, 255));
+        Imgproc.rectangle(document, new Point(20, 35), new Point(100, 45), new Scalar(0, 0, 0), -1);
+        Mat rotated = new Mat();
+        Mat rotationMatrix = Imgproc.getRotationMatrix2D(new Point(60, 40), 12.0, 1.0);
+        Imgproc.warpAffine(
+            document,
+            rotated,
+            rotationMatrix,
+            new Size(120, 80),
+            Imgproc.INTER_LINEAR,
+            Core.BORDER_CONSTANT,
+            new Scalar(255, 255, 255)
+        );
+        document.release();
+        rotationMatrix.release();
+        return rotated;
+    }
+
+    private PreprocessContext context(Map<String, String> parameters) {
+        return new PreprocessContext(
+            3L,
+            1L,
+            2L,
+            "originals/project/scan.png",
+            "LOW_CONTRAST_SCAN",
+            parameters,
+            false
+        );
+    }
+}

--- a/preprocess-worker/src/test/java/com/moonju/preprocess/worker/domain/preprocess/step/OrientationNormalizeStepTests.java
+++ b/preprocess-worker/src/test/java/com/moonju/preprocess/worker/domain/preprocess/step/OrientationNormalizeStepTests.java
@@ -1,0 +1,84 @@
+package com.moonju.preprocess.worker.domain.preprocess.step;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.moonju.preprocess.worker.domain.preprocess.model.ImageMatHolder;
+import com.moonju.preprocess.worker.domain.preprocess.pipeline.PreprocessContext;
+import com.moonju.preprocess.worker.infra.opencv.OpenCvLoader;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.opencv.core.CvType;
+import org.opencv.core.Mat;
+import org.opencv.core.Scalar;
+
+class OrientationNormalizeStepTests {
+
+    private final OrientationNormalizeStep step = new OrientationNormalizeStep();
+
+    @BeforeAll
+    static void loadOpenCv() {
+        new OpenCvLoader().loadIfPresent();
+    }
+
+    @Test
+    void rotatesLandscapeImageToPortraitAndReleasesPreviousHolder() {
+        PreprocessContext context = context();
+        ImageMatHolder landscapeHolder = ImageMatHolder.decoded(
+            "originals/landscape.png",
+            new Mat(2, 5, CvType.CV_8UC3, new Scalar(255, 255, 255))
+        );
+        context.storeDecodedImage(landscapeHolder);
+
+        step.execute(context);
+
+        ImageMatHolder rotatedHolder = context.decodedImage().orElseThrow();
+        assertThat(landscapeHolder.released()).isTrue();
+        assertThat(rotatedHolder.width()).isEqualTo(2);
+        assertThat(rotatedHolder.height()).isEqualTo(5);
+        assertThat(rotatedHolder.colorSpace()).isEqualTo("BGR");
+        assertThat(context.consumeStepNote(PreprocessStepName.ORIENTATION_NORMALIZE))
+            .contains("landscape -> portrait");
+        context.releaseDecodedImage();
+    }
+
+    @Test
+    void keepsPortraitImageAsNoOp() {
+        PreprocessContext context = context();
+        ImageMatHolder portraitHolder = ImageMatHolder.decoded(
+            "originals/portrait.png",
+            new Mat(5, 2, CvType.CV_8UC3, new Scalar(255, 255, 255))
+        );
+        context.storeDecodedImage(portraitHolder);
+
+        step.execute(context);
+
+        assertThat(context.decodedImage().orElseThrow()).isSameAs(portraitHolder);
+        assertThat(portraitHolder.released()).isFalse();
+        assertThat(context.consumeStepNote(PreprocessStepName.ORIENTATION_NORMALIZE))
+            .contains("already normalized");
+        context.releaseDecodedImage();
+    }
+
+    @Test
+    void defersWhenDecodedImageIsMissing() {
+        PreprocessContext context = context();
+
+        step.execute(context);
+
+        assertThat(context.consumeStepNote(PreprocessStepName.ORIENTATION_NORMALIZE))
+            .contains("not available");
+    }
+
+    private PreprocessContext context() {
+        return new PreprocessContext(
+            3L,
+            1L,
+            2L,
+            "originals/project/scan.png",
+            "LOW_CONTRAST_SCAN",
+            Map.of(),
+            false
+        );
+    }
+}


### PR DESCRIPTION
## #️⃣ 기능 설명

Worker preprocess pipeline 4단계 분할 중 1단계 Geometry 1을 구현합니다.
`OrientationNormalizeStep`과 `DeskewStep`을 OpenCV 기반 실제 처리로 교체하여 문서 방향과 기울기를 보정합니다.

Closes #71

## 🛠️ 작업 상세 내용

- [x] `OrientationNormalizeStep` 실제 구현
- [x] landscape 입력을 portrait 방향으로 90도 회전
- [x] portrait/square 입력 no-op 처리
- [x] `DeskewStep` 실제 구현
- [x] grayscale + Otsu inverse threshold + foreground points + `minAreaRect` 기반 correction angle 추정
- [x] `maxDeskewAngle` 초과 시 fallback note 기록 후 skip
- [x] foreground 부족 시 fallback note 기록 후 skip
- [x] 적용 시 context holder 교체 및 기존 Mat release 보장
- [x] orientation/deskew unit test 추가
- [x] 관련 worker 문서 갱신

## 📁 변경 파일 요약

- `preprocess-worker/src/main/java/.../OrientationNormalizeStep.java`
- `preprocess-worker/src/main/java/.../DeskewStep.java`
- `preprocess-worker/src/test/java/.../OrientationNormalizeStepTests.java`
- `preprocess-worker/src/test/java/.../DeskewStepTests.java`
- `docs/feature-specs/issue-71-worker-geometry-1-orientation-deskew.md`
- `docs/tasks/16-worker-preprocess-pipeline.md`
- `docs/worker/preprocess-pipeline.md`
- `docs/worker/image-test-integration.md`

## ✅ 검증 내용

- [x] `docker run --rm -v "${PWD}\\preprocess-worker:/workspace" -w /workspace gradle:8.10-jdk21 gradle test --no-daemon`: 통과
- [x] `docker compose -f infra\\docker-compose\\docker-compose.local.yml build preprocess-worker`: 통과
- [x] `git diff --check`: 통과, CRLF 경고만 발생
- [x] `rg "GOCSPX|562142811433|TYnxvK3|googleusercontent" -n`: 매칭 없음

## 🔎 리뷰어가 확인해야 할 부분

- Orientation normalize가 단순 landscape -> portrait 규칙으로 제한되어 있는지 확인해주세요.
- Deskew fallback이 foreground 부족과 max angle 초과를 안전하게 skip하는지 확인해주세요.
- Crop/DPI/quality/output 작업이 이번 PR에 섞이지 않았는지 확인해주세요.
- OCR 텍스트 추출 기능이 추가되지 않았는지 확인해주세요.

## 📸 스크린샷

없음

## 💬 기타 공유사항 to 리뷰어

- 다음 단계는 4단계 분할 기준 Geometry 2: `CropStep + DpiNormalizeStep`입니다.