### PR TITLE
✨ [Feat] Worker Geometry 2 crop/dpi normalize 구현

### DIFF
--- a/docs/feature-specs/issue-73-worker-geometry-2-crop-dpi.md
+++ b/docs/feature-specs/issue-73-worker-geometry-2-crop-dpi.md
@@ -1,0 +1,75 @@
+# Issue 73. Worker Geometry 2 Crop And DPI Normalize
+
+## Purpose
+
+Implement the second Worker geometry increment by replacing `CropStep` and `DpiNormalizeStep` skeleton behavior with
+real OpenCV-backed processing.
+
+This task is still OCR preprocessing only. It does not add OCR text extraction and does not move image processing into
+`backend-api`.
+
+## Scope
+
+1. `CropStep`
+   - Read the context-owned decoded `ImageMatHolder`.
+   - Convert the current image to grayscale for detection.
+   - Build an inverse Otsu foreground mask.
+   - Find foreground bounds with `Core.findNonZero` and `Imgproc.boundingRect`.
+   - Expand bounds by `cropMarginPixels` and clamp to image size.
+   - Replace the context-owned Mat only when a valid crop is applied.
+   - Record fallback notes when foreground points or bounds are not usable.
+
+2. `DpiNormalizeStep`
+   - Read source DPI from Worker context parameters.
+   - Use `targetDpi` with a default of `300`.
+   - Resize by `targetDpi / sourceDpi` with safe min/max scale bounds.
+   - Replace the context-owned Mat only when scaling is needed.
+   - Record fallback notes when source DPI metadata is missing.
+
+3. Tests
+   - Crop applied path.
+   - Crop blank-image fallback path.
+   - DPI scale path.
+   - DPI no-op path.
+   - DPI missing-metadata fallback path.
+   - Missing decoded image deferred path.
+
+## Parameter Contract
+
+`CropStep` supports:
+
+| Parameter | Default | Meaning |
+|---|---:|---|
+| `cropMarginPixels` | `4` | Extra pixels around detected foreground bounds |
+
+`DpiNormalizeStep` supports:
+
+| Parameter | Default | Meaning |
+|---|---:|---|
+| `targetDpi` | `300` | Desired OCR preprocessing DPI |
+| `sourceDpi` | none | Same source DPI for X/Y axes |
+| `sourceDpiX` / `sourceDpiY` | none | Axis-specific source DPI |
+| `dpi`, `dpiX`, `dpiY`, `xDpi`, `yDpi` | none | Compatibility aliases |
+
+If source DPI is unavailable, `DpiNormalizeStep` records a fallback and keeps the image unchanged. This avoids inventing
+metadata and keeps upload/image metadata extraction as the correct long-term source of truth.
+
+## Out Of Scope
+
+1. Denoise, contrast normalization, binarization, morphology cleanup, and sharpen implementation.
+2. Processed image upload.
+3. Preview generation.
+4. Processing report JSON upload.
+5. Worker success callback after artifact persistence.
+6. OCR text extraction.
+
+## Verification
+
+The PR must run:
+
+```bash
+cd preprocess-worker
+../gradlew test
+```
+
+The PR should also build the Worker Docker image when Docker is available.

--- a/docs/tasks/16-worker-preprocess-pipeline.md
+++ b/docs/tasks/16-worker-preprocess-pipeline.md
@@ -132,6 +132,18 @@ Issue 71 implements Geometry 1:
 5. Low foreground or excessive angle cases record fallback notes and skip.
 6. Crop, DPI normalization, quality steps, artifact upload, and success callback remain out of scope.
 
+## Current Issue 73 Scope
+
+Issue 73 implements Geometry 2:
+
+1. `CropStep` detects foreground bounds using grayscale conversion, inverse Otsu thresholding, and bounding rectangles.
+2. `CropStep` applies a configurable `cropMarginPixels` margin and clamps the crop area to the image dimensions.
+3. Invalid or low-foreground crop detections record fallback notes and keep the current image unchanged.
+4. `DpiNormalizeStep` reads `sourceDpi`, `sourceDpiX/sourceDpiY`, or compatible aliases from context parameters.
+5. `DpiNormalizeStep` resizes toward `targetDpi` with safe min/max scale bounds.
+6. Missing source DPI metadata records a fallback note and keeps the current image unchanged.
+7. Quality steps, artifact upload, and success callback remain out of scope.
+
 ## Done Criteria
 
 1. A simple resize-only step does not exist.

--- a/docs/worker/image-test-integration.md
+++ b/docs/worker/image-test-integration.md
@@ -63,10 +63,13 @@ handling multiple input channel layouts.
 Issue 71 adds the first geometry corrections. Orientation normalization handles obvious landscape scans, and deskew
 uses foreground geometry to correct moderate scan tilt.
 
+Issue 73 adds the second geometry increment. Crop uses foreground bounds to remove surrounding border/background where
+safe, and DPI normalization scales the current Mat only when source DPI metadata is available. Missing source DPI is a
+fallback no-op because OCR-oriented DPI normalization should be based on real metadata, not guessed values.
+
 ## Future Implementation Points
 
-1. Crop and DPI normalization update the processing context with reportable facts.
-2. Quality steps update the processing context with reportable facts.
-3. `domain/artifact` saves processed, preview, report, and debug files to Object Storage.
-4. `domain/report` produces `processing-report.json`.
-5. Worker reports artifact metadata back through Backend internal API.
+1. Quality steps update the processing context with reportable facts.
+2. `domain/artifact` saves processed, preview, report, and debug files to Object Storage.
+3. `domain/report` produces `processing-report.json`.
+4. Worker reports artifact metadata back through Backend internal API.

--- a/docs/worker/preprocess-pipeline.md
+++ b/docs/worker/preprocess-pipeline.md
@@ -90,6 +90,15 @@ Issue 71 implements Geometry 1:
 Orientation normalization rotates landscape input to portrait orientation. Deskew estimates a correction angle from
 foreground pixels and applies `warpAffine` when the angle is within the configured safety bound.
 
+Issue 73 implements Geometry 2:
+
+- `CropStep`
+- `DpiNormalizeStep`
+
+Crop detects foreground bounds from an inverse Otsu mask and replaces the context-owned Mat only when a valid bounded
+crop is available. DPI normalization uses source DPI metadata and `targetDpi` to resize for OCR preprocessing; if source
+DPI metadata is missing, the step records a fallback and leaves the image unchanged.
+
 ## Required Execution Order
 
 Every built-in document preset executes the following order:
@@ -142,8 +151,7 @@ that to `PIPELINE_EXECUTION_FAILED` and reports it to the backend Internal Worke
 
 ## Next Implementation Steps
 
-1. Implement Geometry 2: crop and DPI normalization.
-2. Implement quality steps: denoise, contrast, binarization, morphology cleanup.
-3. Add report generation per step.
-4. Add artifact save service.
-5. Keep OCR text extraction out of the Worker runtime scope.
+1. Implement quality steps: denoise, contrast, binarization, morphology cleanup.
+2. Add report generation per step.
+3. Add artifact save service.
+4. Keep OCR text extraction out of the Worker runtime scope.

--- a/preprocess-worker/src/main/java/com/moonju/preprocess/worker/domain/preprocess/step/CropStep.java
+++ b/preprocess-worker/src/main/java/com/moonju/preprocess/worker/domain/preprocess/step/CropStep.java
@@ -1,12 +1,129 @@
 package com.moonju.preprocess.worker.domain.preprocess.step;
 
+import com.moonju.preprocess.worker.domain.preprocess.model.CropBounds;
+import com.moonju.preprocess.worker.domain.preprocess.model.ImageMatHolder;
+import com.moonju.preprocess.worker.domain.preprocess.pipeline.PreprocessContext;
+import org.opencv.core.Core;
+import org.opencv.core.Mat;
+import org.opencv.core.MatOfPoint;
+import org.opencv.core.Rect;
+import org.opencv.imgproc.Imgproc;
 import org.springframework.stereotype.Component;
 
 @Component
-public class CropStep extends AbstractSkeletonPreprocessStep {
+public class CropStep implements PreprocessStep {
+
+    private static final int DEFAULT_CROP_MARGIN_PIXELS = 4;
+    private static final int MIN_FOREGROUND_POINTS = 20;
+    private static final double MIN_REMAINING_AREA_RATIO = 0.05;
 
     @Override
     public PreprocessStepName name() {
         return PreprocessStepName.CROP;
+    }
+
+    @Override
+    public void execute(PreprocessContext context) {
+        if (context.decodedImage().isEmpty()) {
+            context.recordStep(name(), "Decoded image is not available; crop is deferred.");
+            return;
+        }
+
+        ImageMatHolder holder = context.decodedImage().orElseThrow();
+        if (!holder.loaded()) {
+            context.recordStep(name(), "Decoded image is not loaded; crop is deferred.");
+            return;
+        }
+
+        Mat grayscale = toGrayscale(holder.mat());
+        Mat foregroundMask = new Mat();
+        Imgproc.threshold(grayscale, foregroundMask, 0, 255, Imgproc.THRESH_BINARY_INV + Imgproc.THRESH_OTSU);
+
+        MatOfPoint foregroundPoints = new MatOfPoint();
+        Core.findNonZero(foregroundMask, foregroundPoints);
+        if (foregroundPoints.rows() < MIN_FOREGROUND_POINTS) {
+            release(grayscale, foregroundMask, foregroundPoints);
+            context.recordFallback(name(), "Not enough foreground points for crop.", "skip");
+            context.recordStep(name(), "Crop skipped: insufficient foreground points.");
+            return;
+        }
+
+        Rect detectedBounds = Imgproc.boundingRect(foregroundPoints);
+        release(grayscale, foregroundMask, foregroundPoints);
+
+        Rect cropRect = expandAndClamp(detectedBounds, holder.width(), holder.height(), cropMarginPixels(context));
+        if (!isValidCrop(cropRect, holder.width(), holder.height())) {
+            context.recordFallback(name(), "Detected crop bounds are too small or invalid.", "skip");
+            context.recordStep(name(), "Crop skipped: invalid bounds.");
+            return;
+        }
+
+        if (cropRect.width == holder.width() && cropRect.height == holder.height()) {
+            context.recordStep(name(), "Crop skipped: detected bounds already cover the full image.");
+            return;
+        }
+
+        Mat croppedView = new Mat(holder.mat(), cropRect);
+        Mat cropped = croppedView.clone();
+        croppedView.release();
+
+        ImageMatHolder croppedHolder = ImageMatHolder.decoded(holder.sourceObjectKey(), cropped);
+        context.storeDecodedImage(croppedHolder);
+        CropBounds bounds = new CropBounds(cropRect.x, cropRect.y, cropRect.width, cropRect.height);
+        context.recordStep(
+            name(),
+            "Crop applied: x="
+                + bounds.x()
+                + ", y="
+                + bounds.y()
+                + ", width="
+                + bounds.width()
+                + ", height="
+                + bounds.height()
+        );
+    }
+
+    private Mat toGrayscale(Mat source) {
+        Mat grayscale = new Mat();
+        if (source.channels() == 1) {
+            source.copyTo(grayscale);
+        } else if (source.channels() == 3) {
+            Imgproc.cvtColor(source, grayscale, Imgproc.COLOR_BGR2GRAY);
+        } else if (source.channels() == 4) {
+            Imgproc.cvtColor(source, grayscale, Imgproc.COLOR_BGRA2GRAY);
+        } else {
+            throw new IllegalStateException("Unsupported channel layout for crop: " + source.channels());
+        }
+        return grayscale;
+    }
+
+    private Rect expandAndClamp(Rect bounds, int imageWidth, int imageHeight, int marginPixels) {
+        int x = Math.max(0, bounds.x - marginPixels);
+        int y = Math.max(0, bounds.y - marginPixels);
+        int maxX = Math.min(imageWidth, bounds.x + bounds.width + marginPixels);
+        int maxY = Math.min(imageHeight, bounds.y + bounds.height + marginPixels);
+        return new Rect(x, y, maxX - x, maxY - y);
+    }
+
+    private boolean isValidCrop(Rect cropRect, int imageWidth, int imageHeight) {
+        if (cropRect.width <= 0 || cropRect.height <= 0) {
+            return false;
+        }
+        double remainingAreaRatio = (cropRect.width * (double) cropRect.height) / (imageWidth * (double) imageHeight);
+        return remainingAreaRatio >= MIN_REMAINING_AREA_RATIO;
+    }
+
+    private int cropMarginPixels(PreprocessContext context) {
+        String configured = context.parameters().get("cropMarginPixels");
+        if (configured == null || configured.isBlank()) {
+            return DEFAULT_CROP_MARGIN_PIXELS;
+        }
+        return Math.max(0, Integer.parseInt(configured));
+    }
+
+    private void release(Mat... mats) {
+        for (Mat mat : mats) {
+            mat.release();
+        }
     }
 }

--- a/preprocess-worker/src/main/java/com/moonju/preprocess/worker/domain/preprocess/step/DpiNormalizeStep.java
+++ b/preprocess-worker/src/main/java/com/moonju/preprocess/worker/domain/preprocess/step/DpiNormalizeStep.java
@@ -1,12 +1,134 @@
 package com.moonju.preprocess.worker.domain.preprocess.step;
 
+import com.moonju.preprocess.worker.domain.preprocess.model.DpiInfo;
+import com.moonju.preprocess.worker.domain.preprocess.model.ImageMatHolder;
+import com.moonju.preprocess.worker.domain.preprocess.pipeline.PreprocessContext;
+import java.util.Map;
+import java.util.OptionalInt;
+import org.opencv.core.Mat;
+import org.opencv.core.Size;
+import org.opencv.imgproc.Imgproc;
 import org.springframework.stereotype.Component;
 
 @Component
-public class DpiNormalizeStep extends AbstractSkeletonPreprocessStep {
+public class DpiNormalizeStep implements PreprocessStep {
+
+    private static final int DEFAULT_TARGET_DPI = 300;
+    private static final double MIN_SCALE = 0.25;
+    private static final double MAX_SCALE = 4.0;
+    private static final double NO_OP_SCALE_DELTA = 0.01;
 
     @Override
     public PreprocessStepName name() {
         return PreprocessStepName.DPI_NORMALIZE;
+    }
+
+    @Override
+    public void execute(PreprocessContext context) {
+        if (context.decodedImage().isEmpty()) {
+            context.recordStep(name(), "Decoded image is not available; DPI normalization is deferred.");
+            return;
+        }
+
+        ImageMatHolder holder = context.decodedImage().orElseThrow();
+        if (!holder.loaded()) {
+            context.recordStep(name(), "Decoded image is not loaded; DPI normalization is deferred.");
+            return;
+        }
+
+        DpiInfo dpiInfo = dpiInfo(context.parameters());
+        if (!dpiInfo.sourceKnown()) {
+            context.recordFallback(name(), "Source DPI metadata is missing.", "skip");
+            context.recordStep(name(), "DPI normalization skipped: source DPI is unknown.");
+            return;
+        }
+
+        double scaleX = clampScale(dpiInfo.targetDpi() / (double) dpiInfo.xDpi());
+        double scaleY = clampScale(dpiInfo.targetDpi() / (double) dpiInfo.yDpi());
+        if (isNoOp(scaleX) && isNoOp(scaleY)) {
+            context.recordStep(
+                name(),
+                "DPI already normalized: sourceDpiX="
+                    + dpiInfo.xDpi()
+                    + ", sourceDpiY="
+                    + dpiInfo.yDpi()
+                    + ", targetDpi="
+                    + dpiInfo.targetDpi()
+            );
+            return;
+        }
+
+        int targetWidth = Math.max(1, (int) Math.round(holder.width() * scaleX));
+        int targetHeight = Math.max(1, (int) Math.round(holder.height() * scaleY));
+        Mat normalized = new Mat();
+        Imgproc.resize(
+            holder.mat(),
+            normalized,
+            new Size(targetWidth, targetHeight),
+            0,
+            0,
+            interpolation(scaleX, scaleY)
+        );
+
+        ImageMatHolder normalizedHolder = ImageMatHolder.decoded(holder.sourceObjectKey(), normalized);
+        context.storeDecodedImage(normalizedHolder);
+        context.recordStep(
+            name(),
+            "DPI normalized: sourceDpiX="
+                + dpiInfo.xDpi()
+                + ", sourceDpiY="
+                + dpiInfo.yDpi()
+                + ", targetDpi="
+                + dpiInfo.targetDpi()
+                + ", width="
+                + normalizedHolder.width()
+                + ", height="
+                + normalizedHolder.height()
+        );
+    }
+
+    private DpiInfo dpiInfo(Map<String, String> parameters) {
+        int targetDpi = parsePositiveInt(parameters.get("targetDpi")).orElse(DEFAULT_TARGET_DPI);
+        OptionalInt sameAxisDpi = firstPositiveInt(parameters, "sourceDpi", "dpi", "xDpi");
+        int sourceDpiX = firstPositiveInt(parameters, "sourceDpiX", "dpiX").orElseGet(() -> sameAxisDpi.orElse(0));
+        int sourceDpiY = firstPositiveInt(parameters, "sourceDpiY", "dpiY", "yDpi")
+            .orElseGet(() -> sameAxisDpi.orElse(0));
+        return new DpiInfo(sourceDpiX, sourceDpiY, targetDpi);
+    }
+
+    private OptionalInt firstPositiveInt(Map<String, String> parameters, String... keys) {
+        for (String key : keys) {
+            OptionalInt parsed = parsePositiveInt(parameters.get(key));
+            if (parsed.isPresent()) {
+                return parsed;
+            }
+        }
+        return OptionalInt.empty();
+    }
+
+    private OptionalInt parsePositiveInt(String value) {
+        if (value == null || value.isBlank()) {
+            return OptionalInt.empty();
+        }
+        int parsed = Integer.parseInt(value);
+        if (parsed <= 0) {
+            return OptionalInt.empty();
+        }
+        return OptionalInt.of(parsed);
+    }
+
+    private double clampScale(double scale) {
+        return Math.max(MIN_SCALE, Math.min(MAX_SCALE, scale));
+    }
+
+    private boolean isNoOp(double scale) {
+        return Math.abs(scale - 1.0) < NO_OP_SCALE_DELTA;
+    }
+
+    private int interpolation(double scaleX, double scaleY) {
+        if (scaleX > 1.0 || scaleY > 1.0) {
+            return Imgproc.INTER_CUBIC;
+        }
+        return Imgproc.INTER_AREA;
     }
 }

--- a/preprocess-worker/src/test/java/com/moonju/preprocess/worker/domain/preprocess/step/CropStepTests.java
+++ b/preprocess-worker/src/test/java/com/moonju/preprocess/worker/domain/preprocess/step/CropStepTests.java
@@ -1,0 +1,90 @@
+package com.moonju.preprocess.worker.domain.preprocess.step;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.moonju.preprocess.worker.domain.preprocess.model.ImageMatHolder;
+import com.moonju.preprocess.worker.domain.preprocess.pipeline.PreprocessContext;
+import com.moonju.preprocess.worker.infra.opencv.OpenCvLoader;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.opencv.core.CvType;
+import org.opencv.core.Mat;
+import org.opencv.core.Point;
+import org.opencv.core.Scalar;
+import org.opencv.imgproc.Imgproc;
+
+class CropStepTests {
+
+    private final CropStep step = new CropStep();
+
+    @BeforeAll
+    static void loadOpenCv() {
+        new OpenCvLoader().loadIfPresent();
+    }
+
+    @Test
+    void cropsForegroundBoundsAndReleasesPreviousHolder() {
+        PreprocessContext context = context(Map.of("cropMarginPixels", "2"));
+        ImageMatHolder originalHolder = ImageMatHolder.decoded("originals/crop.png", documentWithBorder());
+        context.storeDecodedImage(originalHolder);
+
+        step.execute(context);
+
+        ImageMatHolder croppedHolder = context.decodedImage().orElseThrow();
+        assertThat(originalHolder.released()).isTrue();
+        assertThat(croppedHolder.loaded()).isTrue();
+        assertThat(croppedHolder.width()).isLessThan(100);
+        assertThat(croppedHolder.height()).isLessThan(100);
+        assertThat(croppedHolder.colorSpace()).isEqualTo("BGR");
+        assertThat(context.consumeStepNote(PreprocessStepName.CROP)).contains("Crop applied");
+        context.releaseDecodedImage();
+    }
+
+    @Test
+    void skipsBlankImageAndRecordsFallback() {
+        PreprocessContext context = context(Map.of());
+        ImageMatHolder blankHolder = ImageMatHolder.decoded(
+            "originals/blank.png",
+            new Mat(80, 100, CvType.CV_8UC3, new Scalar(255, 255, 255))
+        );
+        context.storeDecodedImage(blankHolder);
+
+        step.execute(context);
+
+        assertThat(context.decodedImage().orElseThrow()).isSameAs(blankHolder);
+        assertThat(blankHolder.released()).isFalse();
+        assertThat(context.fallbackNotes()).hasSize(1);
+        assertThat(context.fallbackNotes().getFirst().stepName()).isEqualTo("CROP");
+        assertThat(context.fallbackNotes().getFirst().selectedStrategy()).isEqualTo("skip");
+        assertThat(context.consumeStepNote(PreprocessStepName.CROP)).contains("insufficient");
+        context.releaseDecodedImage();
+    }
+
+    @Test
+    void defersWhenDecodedImageIsMissing() {
+        PreprocessContext context = context(Map.of());
+
+        step.execute(context);
+
+        assertThat(context.consumeStepNote(PreprocessStepName.CROP)).contains("not available");
+    }
+
+    private Mat documentWithBorder() {
+        Mat document = new Mat(100, 100, CvType.CV_8UC3, new Scalar(255, 255, 255));
+        Imgproc.rectangle(document, new Point(25, 30), new Point(75, 70), new Scalar(0, 0, 0), -1);
+        return document;
+    }
+
+    private PreprocessContext context(Map<String, String> parameters) {
+        return new PreprocessContext(
+            3L,
+            1L,
+            2L,
+            "originals/project/scan.png",
+            "LOW_CONTRAST_SCAN",
+            parameters,
+            false
+        );
+    }
+}

--- a/preprocess-worker/src/test/java/com/moonju/preprocess/worker/domain/preprocess/step/DpiNormalizeStepTests.java
+++ b/preprocess-worker/src/test/java/com/moonju/preprocess/worker/domain/preprocess/step/DpiNormalizeStepTests.java
@@ -1,0 +1,101 @@
+package com.moonju.preprocess.worker.domain.preprocess.step;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.moonju.preprocess.worker.domain.preprocess.model.ImageMatHolder;
+import com.moonju.preprocess.worker.domain.preprocess.pipeline.PreprocessContext;
+import com.moonju.preprocess.worker.infra.opencv.OpenCvLoader;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.opencv.core.CvType;
+import org.opencv.core.Mat;
+import org.opencv.core.Scalar;
+
+class DpiNormalizeStepTests {
+
+    private final DpiNormalizeStep step = new DpiNormalizeStep();
+
+    @BeforeAll
+    static void loadOpenCv() {
+        new OpenCvLoader().loadIfPresent();
+    }
+
+    @Test
+    void scalesImageToTargetDpiAndReleasesPreviousHolder() {
+        PreprocessContext context = context(Map.of("sourceDpi", "150", "targetDpi", "300"));
+        ImageMatHolder sourceHolder = ImageMatHolder.decoded(
+            "originals/dpi.png",
+            new Mat(5, 10, CvType.CV_8UC3, new Scalar(255, 255, 255))
+        );
+        context.storeDecodedImage(sourceHolder);
+
+        step.execute(context);
+
+        ImageMatHolder normalizedHolder = context.decodedImage().orElseThrow();
+        assertThat(sourceHolder.released()).isTrue();
+        assertThat(normalizedHolder.width()).isEqualTo(20);
+        assertThat(normalizedHolder.height()).isEqualTo(10);
+        assertThat(normalizedHolder.colorSpace()).isEqualTo("BGR");
+        assertThat(context.consumeStepNote(PreprocessStepName.DPI_NORMALIZE)).contains("DPI normalized");
+        context.releaseDecodedImage();
+    }
+
+    @Test
+    void keepsImageAsNoOpWhenSourceAlreadyMatchesTarget() {
+        PreprocessContext context = context(Map.of("sourceDpiX", "300", "sourceDpiY", "300", "targetDpi", "300"));
+        ImageMatHolder sourceHolder = ImageMatHolder.decoded(
+            "originals/noop.png",
+            new Mat(5, 10, CvType.CV_8UC3, new Scalar(255, 255, 255))
+        );
+        context.storeDecodedImage(sourceHolder);
+
+        step.execute(context);
+
+        assertThat(context.decodedImage().orElseThrow()).isSameAs(sourceHolder);
+        assertThat(sourceHolder.released()).isFalse();
+        assertThat(context.consumeStepNote(PreprocessStepName.DPI_NORMALIZE)).contains("already normalized");
+        context.releaseDecodedImage();
+    }
+
+    @Test
+    void skipsWhenSourceDpiIsMissingAndRecordsFallback() {
+        PreprocessContext context = context(Map.of("targetDpi", "300"));
+        ImageMatHolder sourceHolder = ImageMatHolder.decoded(
+            "originals/missing-dpi.png",
+            new Mat(5, 10, CvType.CV_8UC3, new Scalar(255, 255, 255))
+        );
+        context.storeDecodedImage(sourceHolder);
+
+        step.execute(context);
+
+        assertThat(context.decodedImage().orElseThrow()).isSameAs(sourceHolder);
+        assertThat(sourceHolder.released()).isFalse();
+        assertThat(context.fallbackNotes()).hasSize(1);
+        assertThat(context.fallbackNotes().getFirst().stepName()).isEqualTo("DPI_NORMALIZE");
+        assertThat(context.fallbackNotes().getFirst().selectedStrategy()).isEqualTo("skip");
+        assertThat(context.consumeStepNote(PreprocessStepName.DPI_NORMALIZE)).contains("unknown");
+        context.releaseDecodedImage();
+    }
+
+    @Test
+    void defersWhenDecodedImageIsMissing() {
+        PreprocessContext context = context(Map.of());
+
+        step.execute(context);
+
+        assertThat(context.consumeStepNote(PreprocessStepName.DPI_NORMALIZE)).contains("not available");
+    }
+
+    private PreprocessContext context(Map<String, String> parameters) {
+        return new PreprocessContext(
+            3L,
+            1L,
+            2L,
+            "originals/project/scan.png",
+            "LOW_CONTRAST_SCAN",
+            parameters,
+            false
+        );
+    }
+}


### PR DESCRIPTION
## #️⃣ 기능 설명

Worker 전처리 파이프라인의 Geometry 2 단계로 `CropStep`과 `DpiNormalizeStep`을 OpenCV 기반 실제 처리로 구현합니다.

Closes #73

## 🛠️ 작업 상세 내용

- [x] `CropStep` 전경 bounds 기반 crop 구현
- [x] `DpiNormalizeStep` source/target DPI 기반 resize 구현
- [x] missing decoded image, low foreground, missing DPI fallback/no-op 정책 추가
- [x] Crop/DPI step 단위 테스트 추가
- [x] worker pipeline/task/feature spec 문서 갱신

## 📁 변경 파일 요약

- `preprocess-worker/src/main/java/.../step/CropStep.java`
- `preprocess-worker/src/main/java/.../step/DpiNormalizeStep.java`
- `preprocess-worker/src/test/java/.../step/CropStepTests.java`
- `preprocess-worker/src/test/java/.../step/DpiNormalizeStepTests.java`
- `docs/feature-specs/issue-73-worker-geometry-2-crop-dpi.md`
- `docs/worker/preprocess-pipeline.md`
- `docs/worker/image-test-integration.md`
- `docs/tasks/16-worker-preprocess-pipeline.md`

## ✅ 검증 내용

- [x] `git diff --check`: 통과
- [x] 시크릿 문자열 스캔: 통과
- [ ] `docker run ... gradle test --no-daemon`: Docker Desktop Linux engine 미가동으로 실행 불가
- [ ] `docker compose -f infra/docker-compose/docker-compose.local.yml build preprocess-worker`: Docker Desktop Linux engine 미가동으로 실행 불가

Docker 오류:

```text
open //./pipe/dockerDesktopLinuxEngine: The system cannot find the file specified.
```

## 🔎 리뷰어가 확인해야 할 부분

- `CropStep`이 문서 전체 edge crop이 아니라 현재 단계에서는 foreground bounds 기반 crop으로 동작하는 점이 MVP 범위에 맞는지 확인해주세요.
- `DpiNormalizeStep`이 source DPI가 없을 때 추정하지 않고 fallback no-op 하는 정책이 upload/image metadata 연동 전 단계에 적절한지 확인해주세요.
- OCR 텍스트 추출은 포함하지 않았고, API 서버에는 OpenCV 처리를 추가하지 않았습니다.

## 📸 스크린샷

없음

## 💬 기타 공유사항 to 리뷰어

Docker Desktop이 켜진 환경에서 `preprocess-worker` 테스트와 이미지 build를 추가 확인해야 합니다.