### PR TITLE
✨ [Feat] Worker Quality 1 denoise/contrast/binarization 구현

### DIFF
--- a/docs/feature-specs/issue-75-worker-quality-1-denoise-contrast-binarization.md
+++ b/docs/feature-specs/issue-75-worker-quality-1-denoise-contrast-binarization.md
@@ -1,0 +1,82 @@
+# Issue 75. Worker Quality 1 Denoise Contrast Binarization
+
+## Purpose
+
+Implement the first Worker quality-processing increment by replacing `DenoiseStep`, `ContrastNormalizeStep`, and
+`BinarizationStep` skeleton behavior with OpenCV-backed document preprocessing.
+
+This remains OCR preprocessing only. It does not add OCR text extraction and does not move image processing into
+`backend-api`.
+
+## Scope
+
+1. `DenoiseStep`
+   - Reads the context-owned decoded `ImageMatHolder`.
+   - Supports `median` denoise by default.
+   - Supports `bilateral` denoise when explicitly configured.
+   - Supports `none`, `off`, and `false` as no-op modes.
+   - Falls back to `median` for unsupported modes.
+
+2. `ContrastNormalizeStep`
+   - Applies CLAHE contrast normalization.
+   - Keeps grayscale input grayscale.
+   - Converts BGR input to Lab, applies CLAHE to luminance, then converts back to BGR.
+   - Uses preset-configurable `contrastClipLimit` and `contrastTileGridSize`.
+
+3. `BinarizationStep`
+   - Converts current image to grayscale.
+   - Supports `otsu` thresholding.
+   - Supports `adaptive` thresholding.
+   - Falls back to `otsu` for unsupported modes.
+   - Produces a single-channel binary image for downstream morphology cleanup.
+
+4. Tests
+   - Denoise apply/no-op/fallback/deferred paths.
+   - Contrast BGR/GRAY/deferred paths.
+   - Binarization Otsu/adaptive/fallback/deferred paths.
+
+## Parameter Contract
+
+`DenoiseStep` supports:
+
+| Parameter | Default | Meaning |
+|---|---:|---|
+| `denoiseMode` | `median` | `median`, `bilateral`, `none`, `off`, or `false` |
+| `denoiseKernelSize` | `3` | Odd kernel size for median blur |
+| `denoiseDiameter` | `5` | Odd diameter for bilateral filtering |
+
+`ContrastNormalizeStep` supports:
+
+| Parameter | Default | Meaning |
+|---|---:|---|
+| `contrastClipLimit` | `1.2` | CLAHE clip limit |
+| `contrastTileGridSize` | `8` | CLAHE tile grid width/height |
+
+`BinarizationStep` supports:
+
+| Parameter | Default | Meaning |
+|---|---:|---|
+| `binarizationMode` | `otsu` | `otsu` or `adaptive` |
+| `adaptiveBlockSize` | `31` | Odd block size for adaptive threshold |
+| `adaptiveC` | `7.0` | Constant subtracted in adaptive threshold |
+
+## Out Of Scope
+
+1. Morphology cleanup.
+2. Optional sharpen.
+3. Processed image upload.
+4. Preview generation.
+5. Processing report JSON upload.
+6. Worker success callback after artifact persistence.
+7. OCR text extraction.
+
+## Verification
+
+The PR must run:
+
+```bash
+cd preprocess-worker
+../gradlew test
+```
+
+If the repository still has no Gradle wrapper at the root, use the existing Docker-based Gradle verification path.

--- a/docs/tasks/16-worker-preprocess-pipeline.md
+++ b/docs/tasks/16-worker-preprocess-pipeline.md
@@ -144,6 +144,18 @@ Issue 73 implements Geometry 2:
 6. Missing source DPI metadata records a fallback note and keeps the current image unchanged.
 7. Quality steps, artifact upload, and success callback remain out of scope.
 
+## Current Issue 75 Scope
+
+Issue 75 implements Quality 1:
+
+1. `DenoiseStep` supports median blur by default.
+2. `DenoiseStep` supports bilateral filtering when `denoiseMode=bilateral`.
+3. Unsupported denoise modes record a fallback and use median blur.
+4. `ContrastNormalizeStep` applies CLAHE to grayscale input or BGR luminance.
+5. `BinarizationStep` supports Otsu and adaptive thresholding.
+6. Unsupported binarization modes record a fallback and use Otsu thresholding.
+7. Morphology cleanup, optional sharpen, artifact upload, and success callback remain out of scope.
+
 ## Done Criteria
 
 1. A simple resize-only step does not exist.

--- a/docs/worker/image-test-integration.md
+++ b/docs/worker/image-test-integration.md
@@ -67,9 +67,13 @@ Issue 73 adds the second geometry increment. Crop uses foreground bounds to remo
 safe, and DPI normalization scales the current Mat only when source DPI metadata is available. Missing source DPI is a
 fallback no-op because OCR-oriented DPI normalization should be based on real metadata, not guessed values.
 
+Issue 75 adds the first quality-processing increment. Denoise removes scan noise with median or bilateral filtering,
+contrast normalization applies CLAHE, and binarization produces a single-channel binary image using Otsu or adaptive
+thresholding.
+
 ## Future Implementation Points
 
-1. Quality steps update the processing context with reportable facts.
+1. Morphology cleanup and optional sharpen update the processing context with reportable facts.
 2. `domain/artifact` saves processed, preview, report, and debug files to Object Storage.
 3. `domain/report` produces `processing-report.json`.
 4. Worker reports artifact metadata back through Backend internal API.

--- a/docs/worker/preprocess-pipeline.md
+++ b/docs/worker/preprocess-pipeline.md
@@ -99,6 +99,16 @@ Crop detects foreground bounds from an inverse Otsu mask and replaces the contex
 crop is available. DPI normalization uses source DPI metadata and `targetDpi` to resize for OCR preprocessing; if source
 DPI metadata is missing, the step records a fallback and leaves the image unchanged.
 
+Issue 75 implements Quality 1:
+
+- `DenoiseStep`
+- `ContrastNormalizeStep`
+- `BinarizationStep`
+
+Denoise supports median and bilateral filtering. Contrast normalization applies CLAHE to grayscale input or to the
+luminance channel of BGR input. Binarization converts the current image to a single-channel binary image with Otsu or
+adaptive thresholding according to preset parameters.
+
 ## Required Execution Order
 
 Every built-in document preset executes the following order:
@@ -151,7 +161,7 @@ that to `PIPELINE_EXECUTION_FAILED` and reports it to the backend Internal Worke
 
 ## Next Implementation Steps
 
-1. Implement quality steps: denoise, contrast, binarization, morphology cleanup.
+1. Implement Quality 2: morphology cleanup and optional sharpen.
 2. Add report generation per step.
 3. Add artifact save service.
 4. Keep OCR text extraction out of the Worker runtime scope.

--- a/preprocess-worker/src/main/java/com/moonju/preprocess/worker/domain/preprocess/step/BinarizationStep.java
+++ b/preprocess-worker/src/main/java/com/moonju/preprocess/worker/domain/preprocess/step/BinarizationStep.java
@@ -1,12 +1,109 @@
 package com.moonju.preprocess.worker.domain.preprocess.step;
 
+import com.moonju.preprocess.worker.domain.preprocess.model.ImageMatHolder;
+import com.moonju.preprocess.worker.domain.preprocess.pipeline.PreprocessContext;
+import java.util.Locale;
+import org.opencv.core.Mat;
+import org.opencv.imgproc.Imgproc;
 import org.springframework.stereotype.Component;
 
 @Component
-public class BinarizationStep extends AbstractSkeletonPreprocessStep {
+public class BinarizationStep implements PreprocessStep {
+
+    private static final int DEFAULT_ADAPTIVE_BLOCK_SIZE = 31;
+    private static final double DEFAULT_ADAPTIVE_C = 7.0;
 
     @Override
     public PreprocessStepName name() {
         return PreprocessStepName.BINARIZATION;
+    }
+
+    @Override
+    public void execute(PreprocessContext context) {
+        if (context.decodedImage().isEmpty()) {
+            context.recordStep(name(), "Decoded image is not available; binarization is deferred.");
+            return;
+        }
+
+        ImageMatHolder holder = context.decodedImage().orElseThrow();
+        if (!holder.loaded()) {
+            context.recordStep(name(), "Decoded image is not loaded; binarization is deferred.");
+            return;
+        }
+
+        Mat grayscale = toGrayscale(holder.mat());
+        Mat binary = new Mat();
+        String mode = context.parameters().getOrDefault("binarizationMode", "otsu")
+            .toLowerCase(Locale.ROOT);
+        if ("adaptive".equals(mode)) {
+            int blockSize = positiveOddInt(
+                context.parameters().get("adaptiveBlockSize"),
+                DEFAULT_ADAPTIVE_BLOCK_SIZE
+            );
+            double c = doubleValue(context.parameters().get("adaptiveC"), DEFAULT_ADAPTIVE_C);
+            Imgproc.adaptiveThreshold(
+                grayscale,
+                binary,
+                255,
+                Imgproc.ADAPTIVE_THRESH_GAUSSIAN_C,
+                Imgproc.THRESH_BINARY,
+                blockSize,
+                c
+            );
+            replaceImage(context, holder, grayscale, binary, "Binarized image: mode=adaptive, blockSize="
+                + blockSize
+                + ", c="
+                + c);
+            return;
+        }
+
+        if (!"otsu".equals(mode)) {
+            context.recordFallback(name(), "Unsupported binarization mode: " + mode, "otsu");
+        }
+
+        Imgproc.threshold(grayscale, binary, 0, 255, Imgproc.THRESH_BINARY + Imgproc.THRESH_OTSU);
+        replaceImage(context, holder, grayscale, binary, "Binarized image: mode=otsu.");
+    }
+
+    private Mat toGrayscale(Mat source) {
+        Mat grayscale = new Mat();
+        if (source.channels() == 1) {
+            source.copyTo(grayscale);
+        } else if (source.channels() == 3) {
+            Imgproc.cvtColor(source, grayscale, Imgproc.COLOR_BGR2GRAY);
+        } else if (source.channels() == 4) {
+            Imgproc.cvtColor(source, grayscale, Imgproc.COLOR_BGRA2GRAY);
+        } else {
+            throw new IllegalStateException("Unsupported channel layout for binarization: " + source.channels());
+        }
+        return grayscale;
+    }
+
+    private void replaceImage(
+        PreprocessContext context,
+        ImageMatHolder holder,
+        Mat grayscale,
+        Mat binary,
+        String note
+    ) {
+        grayscale.release();
+        ImageMatHolder binaryHolder = ImageMatHolder.decoded(holder.sourceObjectKey(), binary);
+        context.storeDecodedImage(binaryHolder);
+        context.recordStep(name(), note);
+    }
+
+    private int positiveOddInt(String value, int defaultValue) {
+        if (value == null || value.isBlank()) {
+            return defaultValue;
+        }
+        int parsed = Math.max(3, Integer.parseInt(value));
+        return parsed % 2 == 0 ? parsed + 1 : parsed;
+    }
+
+    private double doubleValue(String value, double defaultValue) {
+        if (value == null || value.isBlank()) {
+            return defaultValue;
+        }
+        return Double.parseDouble(value);
     }
 }

--- a/preprocess-worker/src/main/java/com/moonju/preprocess/worker/domain/preprocess/step/ContrastNormalizeStep.java
+++ b/preprocess-worker/src/main/java/com/moonju/preprocess/worker/domain/preprocess/step/ContrastNormalizeStep.java
@@ -1,12 +1,109 @@
 package com.moonju.preprocess.worker.domain.preprocess.step;
 
+import com.moonju.preprocess.worker.domain.preprocess.model.ImageMatHolder;
+import com.moonju.preprocess.worker.domain.preprocess.pipeline.PreprocessContext;
+import java.util.ArrayList;
+import java.util.List;
+import org.opencv.core.Core;
+import org.opencv.core.Mat;
+import org.opencv.core.Size;
+import org.opencv.imgproc.CLAHE;
+import org.opencv.imgproc.Imgproc;
 import org.springframework.stereotype.Component;
 
 @Component
-public class ContrastNormalizeStep extends AbstractSkeletonPreprocessStep {
+public class ContrastNormalizeStep implements PreprocessStep {
+
+    private static final double DEFAULT_CLIP_LIMIT = 1.2;
+    private static final int DEFAULT_TILE_GRID_SIZE = 8;
 
     @Override
     public PreprocessStepName name() {
         return PreprocessStepName.CONTRAST_NORMALIZE;
+    }
+
+    @Override
+    public void execute(PreprocessContext context) {
+        if (context.decodedImage().isEmpty()) {
+            context.recordStep(name(), "Decoded image is not available; contrast normalization is deferred.");
+            return;
+        }
+
+        ImageMatHolder holder = context.decodedImage().orElseThrow();
+        if (!holder.loaded()) {
+            context.recordStep(name(), "Decoded image is not loaded; contrast normalization is deferred.");
+            return;
+        }
+
+        double clipLimit = positiveDouble(context.parameters().get("contrastClipLimit"), DEFAULT_CLIP_LIMIT);
+        int tileGridSize = positiveInt(context.parameters().get("contrastTileGridSize"), DEFAULT_TILE_GRID_SIZE);
+        Mat normalized = normalizeContrast(holder.mat(), clipLimit, tileGridSize);
+        ImageMatHolder normalizedHolder = ImageMatHolder.decoded(holder.sourceObjectKey(), normalized);
+        context.storeDecodedImage(normalizedHolder);
+        context.recordStep(
+            name(),
+            "Contrast normalized: method=CLAHE, clipLimit="
+                + clipLimit
+                + ", tileGridSize="
+                + tileGridSize
+        );
+    }
+
+    private Mat normalizeContrast(Mat source, double clipLimit, int tileGridSize) {
+        CLAHE clahe = Imgproc.createCLAHE(clipLimit, new Size(tileGridSize, tileGridSize));
+        try {
+            if (source.channels() == 1) {
+                Mat normalized = new Mat();
+                clahe.apply(source, normalized);
+                return normalized;
+            }
+
+            if (source.channels() != 3) {
+                throw new IllegalStateException("Unsupported channel layout for contrast normalization: "
+                    + source.channels());
+            }
+
+            Mat lab = new Mat();
+            Imgproc.cvtColor(source, lab, Imgproc.COLOR_BGR2Lab);
+            List<Mat> channels = new ArrayList<>(3);
+            Core.split(lab, channels);
+            Mat normalizedLuminance = new Mat();
+            clahe.apply(channels.get(0), normalizedLuminance);
+            Mat originalLuminance = channels.set(0, normalizedLuminance);
+            originalLuminance.release();
+            Core.merge(channels, lab);
+
+            Mat normalized = new Mat();
+            Imgproc.cvtColor(lab, normalized, Imgproc.COLOR_Lab2BGR);
+            release(lab);
+            release(channels);
+            return normalized;
+        } finally {
+            clahe.collectGarbage();
+        }
+    }
+
+    private double positiveDouble(String value, double defaultValue) {
+        if (value == null || value.isBlank()) {
+            return defaultValue;
+        }
+        return Math.max(0.1, Double.parseDouble(value));
+    }
+
+    private int positiveInt(String value, int defaultValue) {
+        if (value == null || value.isBlank()) {
+            return defaultValue;
+        }
+        return Math.max(1, Integer.parseInt(value));
+    }
+
+    private void release(Mat mat) {
+        mat.release();
+    }
+
+    private void release(List<Mat> mats) {
+        for (Mat mat : mats) {
+            mat.release();
+        }
     }
 }

--- a/preprocess-worker/src/main/java/com/moonju/preprocess/worker/domain/preprocess/step/DenoiseStep.java
+++ b/preprocess-worker/src/main/java/com/moonju/preprocess/worker/domain/preprocess/step/DenoiseStep.java
@@ -1,12 +1,74 @@
 package com.moonju.preprocess.worker.domain.preprocess.step;
 
+import com.moonju.preprocess.worker.domain.preprocess.model.ImageMatHolder;
+import com.moonju.preprocess.worker.domain.preprocess.pipeline.PreprocessContext;
+import java.util.Locale;
+import org.opencv.core.Mat;
+import org.opencv.imgproc.Imgproc;
 import org.springframework.stereotype.Component;
 
 @Component
-public class DenoiseStep extends AbstractSkeletonPreprocessStep {
+public class DenoiseStep implements PreprocessStep {
+
+    private static final int DEFAULT_MEDIAN_KERNEL_SIZE = 3;
 
     @Override
     public PreprocessStepName name() {
         return PreprocessStepName.DENOISE;
+    }
+
+    @Override
+    public void execute(PreprocessContext context) {
+        if (context.decodedImage().isEmpty()) {
+            context.recordStep(name(), "Decoded image is not available; denoise is deferred.");
+            return;
+        }
+
+        ImageMatHolder holder = context.decodedImage().orElseThrow();
+        if (!holder.loaded()) {
+            context.recordStep(name(), "Decoded image is not loaded; denoise is deferred.");
+            return;
+        }
+
+        String mode = context.parameters().getOrDefault("denoiseMode", "median")
+            .toLowerCase(Locale.ROOT);
+        if ("none".equals(mode) || "off".equals(mode) || "false".equals(mode)) {
+            context.recordStep(name(), "Denoise skipped: disabled by preset parameters.");
+            return;
+        }
+
+        if (holder.mat().channels() != 1 && holder.mat().channels() != 3) {
+            throw new IllegalStateException("Unsupported channel layout for denoise: " + holder.mat().channels());
+        }
+
+        Mat denoised = new Mat();
+        if ("bilateral".equals(mode)) {
+            int diameter = positiveOddInt(context.parameters().get("denoiseDiameter"), 5);
+            Imgproc.bilateralFilter(holder.mat(), denoised, diameter, 75.0, 75.0);
+            replaceImage(context, holder, denoised, "Denoise applied: mode=bilateral, diameter=" + diameter);
+            return;
+        }
+
+        if (!"median".equals(mode)) {
+            context.recordFallback(name(), "Unsupported denoise mode: " + mode, "median");
+        }
+
+        int kernelSize = positiveOddInt(context.parameters().get("denoiseKernelSize"), DEFAULT_MEDIAN_KERNEL_SIZE);
+        Imgproc.medianBlur(holder.mat(), denoised, kernelSize);
+        replaceImage(context, holder, denoised, "Denoise applied: mode=median, kernelSize=" + kernelSize);
+    }
+
+    private void replaceImage(PreprocessContext context, ImageMatHolder holder, Mat result, String note) {
+        ImageMatHolder denoisedHolder = ImageMatHolder.decoded(holder.sourceObjectKey(), result);
+        context.storeDecodedImage(denoisedHolder);
+        context.recordStep(name(), note);
+    }
+
+    private int positiveOddInt(String value, int defaultValue) {
+        if (value == null || value.isBlank()) {
+            return defaultValue;
+        }
+        int parsed = Math.max(3, Integer.parseInt(value));
+        return parsed % 2 == 0 ? parsed + 1 : parsed;
     }
 }

--- a/preprocess-worker/src/test/java/com/moonju/preprocess/worker/domain/preprocess/step/BinarizationStepTests.java
+++ b/preprocess-worker/src/test/java/com/moonju/preprocess/worker/domain/preprocess/step/BinarizationStepTests.java
@@ -1,0 +1,107 @@
+package com.moonju.preprocess.worker.domain.preprocess.step;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.moonju.preprocess.worker.domain.preprocess.model.ImageMatHolder;
+import com.moonju.preprocess.worker.domain.preprocess.pipeline.PreprocessContext;
+import com.moonju.preprocess.worker.infra.opencv.OpenCvLoader;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.opencv.core.CvType;
+import org.opencv.core.Mat;
+import org.opencv.core.Point;
+import org.opencv.core.Scalar;
+import org.opencv.imgproc.Imgproc;
+
+class BinarizationStepTests {
+
+    private final BinarizationStep step = new BinarizationStep();
+
+    @BeforeAll
+    static void loadOpenCv() {
+        new OpenCvLoader().loadIfPresent();
+    }
+
+    @Test
+    void appliesOtsuBinarizationAndReleasesPreviousHolder() {
+        PreprocessContext context = context(Map.of("binarizationMode", "otsu"));
+        ImageMatHolder sourceHolder = ImageMatHolder.decoded("originals/text.png", documentLikeImage());
+        context.storeDecodedImage(sourceHolder);
+
+        step.execute(context);
+
+        ImageMatHolder binaryHolder = context.decodedImage().orElseThrow();
+        assertThat(sourceHolder.released()).isTrue();
+        assertThat(binaryHolder.loaded()).isTrue();
+        assertThat(binaryHolder.colorSpace()).isEqualTo("GRAY");
+        assertThat(binaryHolder.mat().channels()).isEqualTo(1);
+        assertThat(context.consumeStepNote(PreprocessStepName.BINARIZATION)).contains("mode=otsu");
+        context.releaseDecodedImage();
+    }
+
+    @Test
+    void appliesAdaptiveBinarization() {
+        PreprocessContext context = context(Map.of(
+            "binarizationMode",
+            "adaptive",
+            "adaptiveBlockSize",
+            "3",
+            "adaptiveC",
+            "5"
+        ));
+        ImageMatHolder sourceHolder = ImageMatHolder.decoded("originals/text.png", documentLikeImage());
+        context.storeDecodedImage(sourceHolder);
+
+        step.execute(context);
+
+        ImageMatHolder binaryHolder = context.decodedImage().orElseThrow();
+        assertThat(sourceHolder.released()).isTrue();
+        assertThat(binaryHolder.colorSpace()).isEqualTo("GRAY");
+        assertThat(context.consumeStepNote(PreprocessStepName.BINARIZATION)).contains("mode=adaptive");
+        context.releaseDecodedImage();
+    }
+
+    @Test
+    void fallsBackToOtsuWhenModeIsUnsupported() {
+        PreprocessContext context = context(Map.of("binarizationMode", "unknown"));
+        ImageMatHolder sourceHolder = ImageMatHolder.decoded("originals/text.png", documentLikeImage());
+        context.storeDecodedImage(sourceHolder);
+
+        step.execute(context);
+
+        assertThat(context.fallbackNotes()).hasSize(1);
+        assertThat(context.fallbackNotes().getFirst().stepName()).isEqualTo("BINARIZATION");
+        assertThat(context.fallbackNotes().getFirst().selectedStrategy()).isEqualTo("otsu");
+        assertThat(context.consumeStepNote(PreprocessStepName.BINARIZATION)).contains("mode=otsu");
+        context.releaseDecodedImage();
+    }
+
+    @Test
+    void defersWhenDecodedImageIsMissing() {
+        PreprocessContext context = context(Map.of());
+
+        step.execute(context);
+
+        assertThat(context.consumeStepNote(PreprocessStepName.BINARIZATION)).contains("not available");
+    }
+
+    private Mat documentLikeImage() {
+        Mat image = new Mat(16, 16, CvType.CV_8UC3, new Scalar(255, 255, 255));
+        Imgproc.rectangle(image, new Point(3, 4), new Point(13, 6), new Scalar(0, 0, 0), -1);
+        Imgproc.rectangle(image, new Point(3, 10), new Point(10, 12), new Scalar(40, 40, 40), -1);
+        return image;
+    }
+
+    private PreprocessContext context(Map<String, String> parameters) {
+        return new PreprocessContext(
+            3L,
+            1L,
+            2L,
+            "originals/project/scan.png",
+            "LOW_CONTRAST_SCAN",
+            parameters,
+            false
+        );
+    }
+}

--- a/preprocess-worker/src/test/java/com/moonju/preprocess/worker/domain/preprocess/step/ContrastNormalizeStepTests.java
+++ b/preprocess-worker/src/test/java/com/moonju/preprocess/worker/domain/preprocess/step/ContrastNormalizeStepTests.java
@@ -1,0 +1,87 @@
+package com.moonju.preprocess.worker.domain.preprocess.step;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.moonju.preprocess.worker.domain.preprocess.model.ImageMatHolder;
+import com.moonju.preprocess.worker.domain.preprocess.pipeline.PreprocessContext;
+import com.moonju.preprocess.worker.infra.opencv.OpenCvLoader;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.opencv.core.CvType;
+import org.opencv.core.Mat;
+import org.opencv.core.Scalar;
+
+class ContrastNormalizeStepTests {
+
+    private final ContrastNormalizeStep step = new ContrastNormalizeStep();
+
+    @BeforeAll
+    static void loadOpenCv() {
+        new OpenCvLoader().loadIfPresent();
+    }
+
+    @Test
+    void normalizesBgrContrastAndReleasesPreviousHolder() {
+        PreprocessContext context = context(Map.of("contrastClipLimit", "1.6", "contrastTileGridSize", "4"));
+        ImageMatHolder sourceHolder = ImageMatHolder.decoded("originals/low-contrast.png", lowContrastBgrImage());
+        context.storeDecodedImage(sourceHolder);
+
+        step.execute(context);
+
+        ImageMatHolder normalizedHolder = context.decodedImage().orElseThrow();
+        assertThat(sourceHolder.released()).isTrue();
+        assertThat(normalizedHolder.loaded()).isTrue();
+        assertThat(normalizedHolder.width()).isEqualTo(8);
+        assertThat(normalizedHolder.height()).isEqualTo(8);
+        assertThat(normalizedHolder.colorSpace()).isEqualTo("BGR");
+        assertThat(context.consumeStepNote(PreprocessStepName.CONTRAST_NORMALIZE)).contains("method=CLAHE");
+        context.releaseDecodedImage();
+    }
+
+    @Test
+    void normalizesGrayContrastAndKeepsGrayOutput() {
+        PreprocessContext context = context(Map.of("contrastClipLimit", "1.4"));
+        ImageMatHolder sourceHolder = ImageMatHolder.decoded(
+            "originals/gray.png",
+            new Mat(8, 8, CvType.CV_8UC1, new Scalar(120))
+        );
+        context.storeDecodedImage(sourceHolder);
+
+        step.execute(context);
+
+        ImageMatHolder normalizedHolder = context.decodedImage().orElseThrow();
+        assertThat(sourceHolder.released()).isTrue();
+        assertThat(normalizedHolder.colorSpace()).isEqualTo("GRAY");
+        assertThat(context.consumeStepNote(PreprocessStepName.CONTRAST_NORMALIZE)).contains("clipLimit=1.4");
+        context.releaseDecodedImage();
+    }
+
+    @Test
+    void defersWhenDecodedImageIsMissing() {
+        PreprocessContext context = context(Map.of());
+
+        step.execute(context);
+
+        assertThat(context.consumeStepNote(PreprocessStepName.CONTRAST_NORMALIZE)).contains("not available");
+    }
+
+    private Mat lowContrastBgrImage() {
+        Mat image = new Mat(8, 8, CvType.CV_8UC3, new Scalar(120, 120, 120));
+        image.put(0, 0, new byte[] {100, 100, 100});
+        image.put(7, 7, new byte[] {(byte) 140, (byte) 140, (byte) 140});
+        return image;
+    }
+
+    private PreprocessContext context(Map<String, String> parameters) {
+        return new PreprocessContext(
+            3L,
+            1L,
+            2L,
+            "originals/project/scan.png",
+            "LOW_CONTRAST_SCAN",
+            parameters,
+            false
+        );
+    }
+}

--- a/preprocess-worker/src/test/java/com/moonju/preprocess/worker/domain/preprocess/step/DenoiseStepTests.java
+++ b/preprocess-worker/src/test/java/com/moonju/preprocess/worker/domain/preprocess/step/DenoiseStepTests.java
@@ -1,0 +1,97 @@
+package com.moonju.preprocess.worker.domain.preprocess.step;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.moonju.preprocess.worker.domain.preprocess.model.ImageMatHolder;
+import com.moonju.preprocess.worker.domain.preprocess.pipeline.PreprocessContext;
+import com.moonju.preprocess.worker.infra.opencv.OpenCvLoader;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.opencv.core.CvType;
+import org.opencv.core.Mat;
+import org.opencv.core.Scalar;
+
+class DenoiseStepTests {
+
+    private final DenoiseStep step = new DenoiseStep();
+
+    @BeforeAll
+    static void loadOpenCv() {
+        new OpenCvLoader().loadIfPresent();
+    }
+
+    @Test
+    void appliesMedianDenoiseAndReleasesPreviousHolder() {
+        PreprocessContext context = context(Map.of("denoiseKernelSize", "3"));
+        ImageMatHolder sourceHolder = ImageMatHolder.decoded("originals/noisy.png", noisyImage());
+        context.storeDecodedImage(sourceHolder);
+
+        step.execute(context);
+
+        ImageMatHolder denoisedHolder = context.decodedImage().orElseThrow();
+        assertThat(sourceHolder.released()).isTrue();
+        assertThat(denoisedHolder.loaded()).isTrue();
+        assertThat(denoisedHolder.width()).isEqualTo(5);
+        assertThat(denoisedHolder.height()).isEqualTo(5);
+        assertThat(denoisedHolder.colorSpace()).isEqualTo("BGR");
+        assertThat(context.consumeStepNote(PreprocessStepName.DENOISE)).contains("mode=median");
+        context.releaseDecodedImage();
+    }
+
+    @Test
+    void skipsWhenDisabledByParameter() {
+        PreprocessContext context = context(Map.of("denoiseMode", "none"));
+        ImageMatHolder sourceHolder = ImageMatHolder.decoded("originals/clean.png", noisyImage());
+        context.storeDecodedImage(sourceHolder);
+
+        step.execute(context);
+
+        assertThat(context.decodedImage().orElseThrow()).isSameAs(sourceHolder);
+        assertThat(sourceHolder.released()).isFalse();
+        assertThat(context.consumeStepNote(PreprocessStepName.DENOISE)).contains("disabled");
+        context.releaseDecodedImage();
+    }
+
+    @Test
+    void fallsBackToMedianWhenModeIsUnsupported() {
+        PreprocessContext context = context(Map.of("denoiseMode", "unknown"));
+        ImageMatHolder sourceHolder = ImageMatHolder.decoded("originals/noisy.png", noisyImage());
+        context.storeDecodedImage(sourceHolder);
+
+        step.execute(context);
+
+        assertThat(context.fallbackNotes()).hasSize(1);
+        assertThat(context.fallbackNotes().getFirst().stepName()).isEqualTo("DENOISE");
+        assertThat(context.fallbackNotes().getFirst().selectedStrategy()).isEqualTo("median");
+        assertThat(context.consumeStepNote(PreprocessStepName.DENOISE)).contains("mode=median");
+        context.releaseDecodedImage();
+    }
+
+    @Test
+    void defersWhenDecodedImageIsMissing() {
+        PreprocessContext context = context(Map.of());
+
+        step.execute(context);
+
+        assertThat(context.consumeStepNote(PreprocessStepName.DENOISE)).contains("not available");
+    }
+
+    private Mat noisyImage() {
+        Mat image = new Mat(5, 5, CvType.CV_8UC3, new Scalar(180, 180, 180));
+        image.put(2, 2, new byte[] {0, 0, 0});
+        return image;
+    }
+
+    private PreprocessContext context(Map<String, String> parameters) {
+        return new PreprocessContext(
+            3L,
+            1L,
+            2L,
+            "originals/project/scan.png",
+            "LOW_CONTRAST_SCAN",
+            parameters,
+            false
+        );
+    }
+}


### PR DESCRIPTION
## #️⃣ 기능 설명

Worker 전처리 파이프라인의 Quality 1 단계로 `DenoiseStep`, `ContrastNormalizeStep`, `BinarizationStep`을 OpenCV 기반 실제 처리로 구현합니다.

Closes #75

## 🛠️ 작업 상세 내용

- [x] `DenoiseStep` median/bilateral/no-op/fallback 처리 구현
- [x] `ContrastNormalizeStep` CLAHE 기반 대비 정규화 구현
- [x] `BinarizationStep` Otsu/adaptive/fallback 처리 구현
- [x] 각 step 단위 테스트 추가
- [x] worker pipeline/task/feature spec 문서 갱신

## 📁 변경 파일 요약

- `preprocess-worker/src/main/java/.../step/DenoiseStep.java`
- `preprocess-worker/src/main/java/.../step/ContrastNormalizeStep.java`
- `preprocess-worker/src/main/java/.../step/BinarizationStep.java`
- `preprocess-worker/src/test/java/.../step/DenoiseStepTests.java`
- `preprocess-worker/src/test/java/.../step/ContrastNormalizeStepTests.java`
- `preprocess-worker/src/test/java/.../step/BinarizationStepTests.java`
- `docs/feature-specs/issue-75-worker-quality-1-denoise-contrast-binarization.md`
- `docs/worker/preprocess-pipeline.md`
- `docs/worker/image-test-integration.md`
- `docs/tasks/16-worker-preprocess-pipeline.md`

## ✅ 검증 내용

- [x] `docker run --rm -v "${PWD}\\preprocess-worker:/workspace" -w /workspace gradle:8.10-jdk21 gradle test --no-daemon`: 통과
- [x] `docker compose -f infra/docker-compose/docker-compose.local.yml build preprocess-worker`: 통과
- [x] `git diff --check`: 통과
- [x] 시크릿 문자열 스캔: 통과

## 🔎 리뷰어가 확인해야 할 부분

- `DenoiseStep` 기본값을 `median`으로 둔 정책이 preset 기본 동작으로 적절한지 확인해주세요.
- `ContrastNormalizeStep`이 BGR 입력에서는 Lab luminance에만 CLAHE를 적용하고 BGR로 되돌리는 방식이 현재 파이프라인에 맞는지 확인해주세요.
- `BinarizationStep` 이후 이미지는 `GRAY` 단일 채널 binary가 되므로 다음 PR의 morphology/sharpen 구현은 이 전제를 사용합니다.
- OCR 텍스트 추출은 포함하지 않았고, API 서버에는 OpenCV 처리를 추가하지 않았습니다.

## 📸 스크린샷

없음

## 💬 기타 공유사항 to 리뷰어

다음 작업은 Quality 2로 `MorphologyCleanupStep`과 `SharpenStep` 구현을 권장합니다.