### PR TITLE
✨ [Feat] Worker Quality 2 morphology/sharpen 구현

### DIFF
--- a/docs/feature-specs/issue-77-worker-quality-2-morphology-sharpen.md
+++ b/docs/feature-specs/issue-77-worker-quality-2-morphology-sharpen.md
@@ -1,0 +1,64 @@
+# Issue 77. Worker Quality 2 Morphology Sharpen
+
+## Purpose
+
+Implement the second Worker quality-processing increment by replacing `MorphologyCleanupStep` and `SharpenStep`
+skeleton behavior with OpenCV-backed document preprocessing.
+
+This remains OCR preprocessing only. It does not add OCR text extraction and does not move image processing into
+`backend-api`.
+
+## Scope
+
+1. `MorphologyCleanupStep`
+   - Reads the context-owned decoded `ImageMatHolder`.
+   - Treats black document strokes as foreground by inverting the binary image internally.
+   - Supports `open`, `close`, and `open_close` cleanup.
+   - Supports `none`, `off`, and `false` as no-op modes.
+   - Falls back to `open_close` for unsupported modes.
+   - Re-inverts the cleaned image to the pipeline's normal black-text-on-white representation.
+
+2. `SharpenStep`
+   - Runs only when `sharpen=true`, `sharpen=on`, or `sharpen=yes`.
+   - Uses unsharp mask with configurable amount and sigma.
+   - Keeps the current channel layout when sharpening.
+   - Skips by default when the preset does not explicitly enable sharpening.
+
+3. Tests
+   - Morphology apply/no-op/fallback/deferred paths.
+   - Sharpen enabled/disabled/missing/deferred paths.
+
+## Parameter Contract
+
+`MorphologyCleanupStep` supports:
+
+| Parameter | Default | Meaning |
+|---|---:|---|
+| `morphologyMode` | `open_close` | `open`, `close`, `open_close`, `none`, `off`, or `false` |
+| `morphologyKernelSize` | `2` | Rectangular morphology kernel width/height |
+
+`SharpenStep` supports:
+
+| Parameter | Default | Meaning |
+|---|---:|---|
+| `sharpen` | `false` | Enables optional sharpening when `true`, `on`, or `yes` |
+| `sharpenAmount` | `0.6` | Unsharp mask weight |
+| `sharpenSigma` | `1.0` | Gaussian blur sigma for unsharp mask |
+
+## Out Of Scope
+
+1. Processed image upload.
+2. Preview generation.
+3. Processing report JSON upload.
+4. Debug artifact image upload.
+5. Worker success callback after artifact persistence.
+6. OCR text extraction.
+
+## Verification
+
+The PR must run:
+
+```bash
+docker run --rm -v "${PWD}\preprocess-worker:/workspace" -w /workspace gradle:8.10-jdk21 gradle test --no-daemon
+docker compose -f infra/docker-compose/docker-compose.local.yml build preprocess-worker
+```

--- a/docs/tasks/16-worker-preprocess-pipeline.md
+++ b/docs/tasks/16-worker-preprocess-pipeline.md
@@ -156,6 +156,17 @@ Issue 75 implements Quality 1:
 6. Unsupported binarization modes record a fallback and use Otsu thresholding.
 7. Morphology cleanup, optional sharpen, artifact upload, and success callback remain out of scope.
 
+## Current Issue 77 Scope
+
+Issue 77 implements Quality 2:
+
+1. `MorphologyCleanupStep` supports `open`, `close`, and `open_close` cleanup.
+2. `MorphologyCleanupStep` inverts binary images internally so black strokes are treated as foreground.
+3. Unsupported morphology modes record a fallback and use `open_close`.
+4. `SharpenStep` applies unsharp mask only when `sharpen` is enabled.
+5. `SharpenStep` skips by default when the preset does not explicitly request sharpening.
+6. Processed image upload, preview upload, report upload, and success callback remain out of scope.
+
 ## Done Criteria
 
 1. A simple resize-only step does not exist.

--- a/docs/worker/image-test-integration.md
+++ b/docs/worker/image-test-integration.md
@@ -71,9 +71,12 @@ Issue 75 adds the first quality-processing increment. Denoise removes scan noise
 contrast normalization applies CLAHE, and binarization produces a single-channel binary image using Otsu or adaptive
 thresholding.
 
+Issue 77 completes the currently planned quality-processing steps. Morphology cleanup applies open/close operations with
+black document strokes treated as foreground, and optional sharpen applies unsharp masking only for presets that enable
+`sharpen`.
+
 ## Future Implementation Points
 
-1. Morphology cleanup and optional sharpen update the processing context with reportable facts.
-2. `domain/artifact` saves processed, preview, report, and debug files to Object Storage.
-3. `domain/report` produces `processing-report.json`.
-4. Worker reports artifact metadata back through Backend internal API.
+1. `domain/artifact` saves processed, preview, report, and debug files to Object Storage.
+2. `domain/report` produces `processing-report.json`.
+3. Worker reports artifact metadata back through Backend internal API.

--- a/docs/worker/preprocess-pipeline.md
+++ b/docs/worker/preprocess-pipeline.md
@@ -109,6 +109,15 @@ Denoise supports median and bilateral filtering. Contrast normalization applies 
 luminance channel of BGR input. Binarization converts the current image to a single-channel binary image with Otsu or
 adaptive thresholding according to preset parameters.
 
+Issue 77 implements Quality 2:
+
+- `MorphologyCleanupStep`
+- `SharpenStep`
+
+Morphology cleanup treats black document strokes as foreground internally by inverting the binary image before open/close
+operations and then inverting back. Optional sharpen applies an unsharp mask only when the preset explicitly enables
+`sharpen`.
+
 ## Required Execution Order
 
 Every built-in document preset executes the following order:
@@ -161,7 +170,7 @@ that to `PIPELINE_EXECUTION_FAILED` and reports it to the backend Internal Worke
 
 ## Next Implementation Steps
 
-1. Implement Quality 2: morphology cleanup and optional sharpen.
-2. Add report generation per step.
-3. Add artifact save service.
+1. Add processed image and preview artifact generation.
+2. Add `processing-report.json` generation/upload.
+3. Add Worker success callback after artifacts are persisted.
 4. Keep OCR text extraction out of the Worker runtime scope.

--- a/preprocess-worker/src/main/java/com/moonju/preprocess/worker/domain/preprocess/step/MorphologyCleanupStep.java
+++ b/preprocess-worker/src/main/java/com/moonju/preprocess/worker/domain/preprocess/step/MorphologyCleanupStep.java
@@ -1,12 +1,125 @@
 package com.moonju.preprocess.worker.domain.preprocess.step;
 
+import com.moonju.preprocess.worker.domain.preprocess.model.ImageMatHolder;
+import com.moonju.preprocess.worker.domain.preprocess.pipeline.PreprocessContext;
+import java.util.Locale;
+import org.opencv.core.Core;
+import org.opencv.core.Mat;
+import org.opencv.core.Size;
+import org.opencv.imgproc.Imgproc;
 import org.springframework.stereotype.Component;
 
 @Component
-public class MorphologyCleanupStep extends AbstractSkeletonPreprocessStep {
+public class MorphologyCleanupStep implements PreprocessStep {
+
+    private static final int DEFAULT_KERNEL_SIZE = 2;
 
     @Override
     public PreprocessStepName name() {
         return PreprocessStepName.MORPHOLOGY_CLEANUP;
+    }
+
+    @Override
+    public void execute(PreprocessContext context) {
+        if (context.decodedImage().isEmpty()) {
+            context.recordStep(name(), "Decoded image is not available; morphology cleanup is deferred.");
+            return;
+        }
+
+        ImageMatHolder holder = context.decodedImage().orElseThrow();
+        if (!holder.loaded()) {
+            context.recordStep(name(), "Decoded image is not loaded; morphology cleanup is deferred.");
+            return;
+        }
+
+        String mode = context.parameters().getOrDefault("morphologyMode", "open_close")
+            .toLowerCase(Locale.ROOT);
+        if ("none".equals(mode) || "off".equals(mode) || "false".equals(mode)) {
+            context.recordStep(name(), "Morphology cleanup skipped: disabled by preset parameters.");
+            return;
+        }
+
+        if (!isSupportedMode(mode)) {
+            context.recordFallback(name(), "Unsupported morphology mode: " + mode, "open_close");
+            mode = "open_close";
+        }
+
+        int kernelSize = kernelSize(context);
+        Mat grayscale = toGrayscale(holder.mat());
+        Mat inverted = new Mat();
+        Core.bitwise_not(grayscale, inverted);
+        Mat cleanedInverted = applyCleanup(inverted, mode, kernelSize);
+        Mat cleaned = new Mat();
+        Core.bitwise_not(cleanedInverted, cleaned);
+
+        release(grayscale, inverted, cleanedInverted);
+
+        ImageMatHolder cleanedHolder = ImageMatHolder.decoded(holder.sourceObjectKey(), cleaned);
+        context.storeDecodedImage(cleanedHolder);
+        context.recordStep(
+            name(),
+            "Morphology cleanup applied: mode="
+                + mode
+                + ", kernelSize="
+                + kernelSize
+        );
+    }
+
+    private Mat applyCleanup(Mat invertedBinary, String mode, int kernelSize) {
+        Mat kernel = Imgproc.getStructuringElement(
+            Imgproc.MORPH_RECT,
+            new Size(kernelSize, kernelSize)
+        );
+        Mat result = invertedBinary.clone();
+        try {
+            if ("open".equals(mode) || "open_close".equals(mode)) {
+                Mat opened = new Mat();
+                Imgproc.morphologyEx(result, opened, Imgproc.MORPH_OPEN, kernel);
+                result.release();
+                result = opened;
+            }
+            if ("close".equals(mode) || "open_close".equals(mode)) {
+                Mat closed = new Mat();
+                Imgproc.morphologyEx(result, closed, Imgproc.MORPH_CLOSE, kernel);
+                result.release();
+                result = closed;
+            }
+            return result;
+        } finally {
+            kernel.release();
+        }
+    }
+
+    private Mat toGrayscale(Mat source) {
+        Mat grayscale = new Mat();
+        if (source.channels() == 1) {
+            source.copyTo(grayscale);
+        } else if (source.channels() == 3) {
+            Imgproc.cvtColor(source, grayscale, Imgproc.COLOR_BGR2GRAY);
+        } else if (source.channels() == 4) {
+            Imgproc.cvtColor(source, grayscale, Imgproc.COLOR_BGRA2GRAY);
+        } else {
+            throw new IllegalStateException("Unsupported channel layout for morphology cleanup: "
+                + source.channels());
+        }
+        return grayscale;
+    }
+
+    private boolean isSupportedMode(String mode) {
+        return "open".equals(mode) || "close".equals(mode) || "open_close".equals(mode);
+    }
+
+    private int kernelSize(PreprocessContext context) {
+        String configured = context.parameters().get("morphologyKernelSize");
+        if (configured == null || configured.isBlank()) {
+            return DEFAULT_KERNEL_SIZE;
+        }
+        return Math.max(1, Integer.parseInt(configured));
+    }
+
+    private void release(Mat... mats) {
+        for (Mat mat : mats) {
+            mat.release();
+        }
     }
 }

--- a/preprocess-worker/src/main/java/com/moonju/preprocess/worker/domain/preprocess/step/SharpenStep.java
+++ b/preprocess-worker/src/main/java/com/moonju/preprocess/worker/domain/preprocess/step/SharpenStep.java
@@ -1,12 +1,80 @@
 package com.moonju.preprocess.worker.domain.preprocess.step;
 
+import com.moonju.preprocess.worker.domain.preprocess.model.ImageMatHolder;
+import com.moonju.preprocess.worker.domain.preprocess.pipeline.PreprocessContext;
+import org.opencv.core.Core;
+import org.opencv.core.Mat;
+import org.opencv.core.Size;
+import org.opencv.imgproc.Imgproc;
 import org.springframework.stereotype.Component;
 
 @Component
-public class SharpenStep extends AbstractSkeletonPreprocessStep {
+public class SharpenStep implements PreprocessStep {
+
+    private static final double DEFAULT_SHARPEN_AMOUNT = 0.6;
+    private static final double DEFAULT_SHARPEN_SIGMA = 1.0;
 
     @Override
     public PreprocessStepName name() {
         return PreprocessStepName.OPTIONAL_SHARPEN;
+    }
+
+    @Override
+    public void execute(PreprocessContext context) {
+        if (context.decodedImage().isEmpty()) {
+            context.recordStep(name(), "Decoded image is not available; optional sharpen is deferred.");
+            return;
+        }
+
+        ImageMatHolder holder = context.decodedImage().orElseThrow();
+        if (!holder.loaded()) {
+            context.recordStep(name(), "Decoded image is not loaded; optional sharpen is deferred.");
+            return;
+        }
+
+        if (!enabled(context)) {
+            context.recordStep(name(), "Optional sharpen skipped: disabled by preset parameters.");
+            return;
+        }
+
+        if (holder.mat().channels() != 1 && holder.mat().channels() != 3) {
+            throw new IllegalStateException("Unsupported channel layout for sharpen: " + holder.mat().channels());
+        }
+
+        double amount = positiveDouble(context.parameters().get("sharpenAmount"), DEFAULT_SHARPEN_AMOUNT);
+        double sigma = positiveDouble(context.parameters().get("sharpenSigma"), DEFAULT_SHARPEN_SIGMA);
+        Mat blurred = new Mat();
+        Imgproc.GaussianBlur(holder.mat(), blurred, new Size(0, 0), sigma);
+
+        Mat sharpened = new Mat();
+        Core.addWeighted(holder.mat(), 1.0 + amount, blurred, -amount, 0.0, sharpened);
+        blurred.release();
+
+        ImageMatHolder sharpenedHolder = ImageMatHolder.decoded(holder.sourceObjectKey(), sharpened);
+        context.storeDecodedImage(sharpenedHolder);
+        context.recordStep(
+            name(),
+            "Optional sharpen applied: method=unsharpMask, amount="
+                + amount
+                + ", sigma="
+                + sigma
+        );
+    }
+
+    private boolean enabled(PreprocessContext context) {
+        String configured = context.parameters().get("sharpen");
+        if (configured == null || configured.isBlank()) {
+            return false;
+        }
+        return "true".equalsIgnoreCase(configured)
+            || "on".equalsIgnoreCase(configured)
+            || "yes".equalsIgnoreCase(configured);
+    }
+
+    private double positiveDouble(String value, double defaultValue) {
+        if (value == null || value.isBlank()) {
+            return defaultValue;
+        }
+        return Math.max(0.1, Double.parseDouble(value));
     }
 }

--- a/preprocess-worker/src/test/java/com/moonju/preprocess/worker/domain/preprocess/step/MorphologyCleanupStepTests.java
+++ b/preprocess-worker/src/test/java/com/moonju/preprocess/worker/domain/preprocess/step/MorphologyCleanupStepTests.java
@@ -1,0 +1,100 @@
+package com.moonju.preprocess.worker.domain.preprocess.step;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.moonju.preprocess.worker.domain.preprocess.model.ImageMatHolder;
+import com.moonju.preprocess.worker.domain.preprocess.pipeline.PreprocessContext;
+import com.moonju.preprocess.worker.infra.opencv.OpenCvLoader;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.opencv.core.CvType;
+import org.opencv.core.Mat;
+import org.opencv.core.Point;
+import org.opencv.core.Scalar;
+import org.opencv.imgproc.Imgproc;
+
+class MorphologyCleanupStepTests {
+
+    private final MorphologyCleanupStep step = new MorphologyCleanupStep();
+
+    @BeforeAll
+    static void loadOpenCv() {
+        new OpenCvLoader().loadIfPresent();
+    }
+
+    @Test
+    void appliesOpenCloseCleanupAndReleasesPreviousHolder() {
+        PreprocessContext context = context(Map.of("morphologyKernelSize", "2"));
+        ImageMatHolder sourceHolder = ImageMatHolder.decoded("originals/binary.png", binaryDocument());
+        context.storeDecodedImage(sourceHolder);
+
+        step.execute(context);
+
+        ImageMatHolder cleanedHolder = context.decodedImage().orElseThrow();
+        assertThat(sourceHolder.released()).isTrue();
+        assertThat(cleanedHolder.loaded()).isTrue();
+        assertThat(cleanedHolder.width()).isEqualTo(16);
+        assertThat(cleanedHolder.height()).isEqualTo(16);
+        assertThat(cleanedHolder.colorSpace()).isEqualTo("GRAY");
+        assertThat(context.consumeStepNote(PreprocessStepName.MORPHOLOGY_CLEANUP)).contains("mode=open_close");
+        context.releaseDecodedImage();
+    }
+
+    @Test
+    void skipsWhenDisabledByParameter() {
+        PreprocessContext context = context(Map.of("morphologyMode", "none"));
+        ImageMatHolder sourceHolder = ImageMatHolder.decoded("originals/binary.png", binaryDocument());
+        context.storeDecodedImage(sourceHolder);
+
+        step.execute(context);
+
+        assertThat(context.decodedImage().orElseThrow()).isSameAs(sourceHolder);
+        assertThat(sourceHolder.released()).isFalse();
+        assertThat(context.consumeStepNote(PreprocessStepName.MORPHOLOGY_CLEANUP)).contains("disabled");
+        context.releaseDecodedImage();
+    }
+
+    @Test
+    void fallsBackToOpenCloseWhenModeIsUnsupported() {
+        PreprocessContext context = context(Map.of("morphologyMode", "unknown"));
+        ImageMatHolder sourceHolder = ImageMatHolder.decoded("originals/binary.png", binaryDocument());
+        context.storeDecodedImage(sourceHolder);
+
+        step.execute(context);
+
+        assertThat(context.fallbackNotes()).hasSize(1);
+        assertThat(context.fallbackNotes().getFirst().stepName()).isEqualTo("MORPHOLOGY_CLEANUP");
+        assertThat(context.fallbackNotes().getFirst().selectedStrategy()).isEqualTo("open_close");
+        assertThat(context.consumeStepNote(PreprocessStepName.MORPHOLOGY_CLEANUP)).contains("mode=open_close");
+        context.releaseDecodedImage();
+    }
+
+    @Test
+    void defersWhenDecodedImageIsMissing() {
+        PreprocessContext context = context(Map.of());
+
+        step.execute(context);
+
+        assertThat(context.consumeStepNote(PreprocessStepName.MORPHOLOGY_CLEANUP)).contains("not available");
+    }
+
+    private Mat binaryDocument() {
+        Mat image = new Mat(16, 16, CvType.CV_8UC1, new Scalar(255));
+        Imgproc.rectangle(image, new Point(3, 5), new Point(12, 7), new Scalar(0), -1);
+        image.put(1, 1, new byte[] {0});
+        return image;
+    }
+
+    private PreprocessContext context(Map<String, String> parameters) {
+        return new PreprocessContext(
+            3L,
+            1L,
+            2L,
+            "originals/project/scan.png",
+            "LOW_CONTRAST_SCAN",
+            parameters,
+            false
+        );
+    }
+}

--- a/preprocess-worker/src/test/java/com/moonju/preprocess/worker/domain/preprocess/step/SharpenStepTests.java
+++ b/preprocess-worker/src/test/java/com/moonju/preprocess/worker/domain/preprocess/step/SharpenStepTests.java
@@ -1,0 +1,103 @@
+package com.moonju.preprocess.worker.domain.preprocess.step;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.moonju.preprocess.worker.domain.preprocess.model.ImageMatHolder;
+import com.moonju.preprocess.worker.domain.preprocess.pipeline.PreprocessContext;
+import com.moonju.preprocess.worker.infra.opencv.OpenCvLoader;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.opencv.core.CvType;
+import org.opencv.core.Mat;
+import org.opencv.core.Scalar;
+
+class SharpenStepTests {
+
+    private final SharpenStep step = new SharpenStep();
+
+    @BeforeAll
+    static void loadOpenCv() {
+        new OpenCvLoader().loadIfPresent();
+    }
+
+    @Test
+    void appliesSharpenWhenEnabledAndReleasesPreviousHolder() {
+        PreprocessContext context = context(Map.of(
+            "sharpen",
+            "true",
+            "sharpenAmount",
+            "0.8",
+            "sharpenSigma",
+            "1.2"
+        ));
+        ImageMatHolder sourceHolder = ImageMatHolder.decoded("originals/processed.png", grayscaleImage());
+        context.storeDecodedImage(sourceHolder);
+
+        step.execute(context);
+
+        ImageMatHolder sharpenedHolder = context.decodedImage().orElseThrow();
+        assertThat(sourceHolder.released()).isTrue();
+        assertThat(sharpenedHolder.loaded()).isTrue();
+        assertThat(sharpenedHolder.width()).isEqualTo(8);
+        assertThat(sharpenedHolder.height()).isEqualTo(8);
+        assertThat(sharpenedHolder.colorSpace()).isEqualTo("GRAY");
+        assertThat(context.consumeStepNote(PreprocessStepName.OPTIONAL_SHARPEN)).contains("unsharpMask");
+        context.releaseDecodedImage();
+    }
+
+    @Test
+    void skipsWhenDisabledByParameter() {
+        PreprocessContext context = context(Map.of("sharpen", "false"));
+        ImageMatHolder sourceHolder = ImageMatHolder.decoded("originals/processed.png", grayscaleImage());
+        context.storeDecodedImage(sourceHolder);
+
+        step.execute(context);
+
+        assertThat(context.decodedImage().orElseThrow()).isSameAs(sourceHolder);
+        assertThat(sourceHolder.released()).isFalse();
+        assertThat(context.consumeStepNote(PreprocessStepName.OPTIONAL_SHARPEN)).contains("disabled");
+        context.releaseDecodedImage();
+    }
+
+    @Test
+    void skipsWhenParameterIsMissing() {
+        PreprocessContext context = context(Map.of());
+        ImageMatHolder sourceHolder = ImageMatHolder.decoded("originals/processed.png", grayscaleImage());
+        context.storeDecodedImage(sourceHolder);
+
+        step.execute(context);
+
+        assertThat(context.decodedImage().orElseThrow()).isSameAs(sourceHolder);
+        assertThat(sourceHolder.released()).isFalse();
+        assertThat(context.consumeStepNote(PreprocessStepName.OPTIONAL_SHARPEN)).contains("disabled");
+        context.releaseDecodedImage();
+    }
+
+    @Test
+    void defersWhenDecodedImageIsMissing() {
+        PreprocessContext context = context(Map.of());
+
+        step.execute(context);
+
+        assertThat(context.consumeStepNote(PreprocessStepName.OPTIONAL_SHARPEN)).contains("not available");
+    }
+
+    private Mat grayscaleImage() {
+        Mat image = new Mat(8, 8, CvType.CV_8UC1, new Scalar(180));
+        image.put(3, 3, new byte[] {60});
+        return image;
+    }
+
+    private PreprocessContext context(Map<String, String> parameters) {
+        return new PreprocessContext(
+            3L,
+            1L,
+            2L,
+            "originals/project/scan.png",
+            "LOW_CONTRAST_SCAN",
+            parameters,
+            false
+        );
+    }
+}


### PR DESCRIPTION
## #️⃣ 기능 설명

Worker 전처리 파이프라인의 Quality 2 단계로 `MorphologyCleanupStep`과 `SharpenStep`을 OpenCV 기반 실제 처리로 구현합니다.

Closes #77

## 🛠️ 작업 상세 내용

- [x] `MorphologyCleanupStep` open/close/open_close/no-op/fallback 처리 구현
- [x] 검은 문서 획을 foreground로 처리하기 위한 internal invert/re-invert 적용
- [x] `SharpenStep` optional unsharp mask 처리 구현
- [x] 각 step 단위 테스트 추가
- [x] worker pipeline/task/feature spec 문서 갱신

## 📁 변경 파일 요약

- `preprocess-worker/src/main/java/.../step/MorphologyCleanupStep.java`
- `preprocess-worker/src/main/java/.../step/SharpenStep.java`
- `preprocess-worker/src/test/java/.../step/MorphologyCleanupStepTests.java`
- `preprocess-worker/src/test/java/.../step/SharpenStepTests.java`
- `docs/feature-specs/issue-77-worker-quality-2-morphology-sharpen.md`
- `docs/worker/preprocess-pipeline.md`
- `docs/worker/image-test-integration.md`
- `docs/tasks/16-worker-preprocess-pipeline.md`

## ✅ 검증 내용

- [x] `docker run --rm -v "${PWD}\\preprocess-worker:/workspace" -w /workspace gradle:8.10-jdk21 gradle test --no-daemon`: 통과
- [x] `docker compose -f infra/docker-compose/docker-compose.local.yml build preprocess-worker`: 통과
- [x] `git diff --check`: 통과
- [x] 시크릿 문자열 스캔: 통과

## 🔎 리뷰어가 확인해야 할 부분

- `MorphologyCleanupStep`이 binary image의 검은 획을 전경으로 보기 위해 invert 후 morphology를 적용하고 다시 되돌리는 정책이 적절한지 확인해주세요.
- `SharpenStep`은 `sharpen=true/on/yes`일 때만 실행하며 기본값은 no-op입니다.
- OCR 텍스트 추출은 포함하지 않았고, API 서버에는 OpenCV 처리를 추가하지 않았습니다.

## 📸 스크린샷

없음

## 💬 기타 공유사항 to 리뷰어

다음 작업은 processed image/preview/report artifact 저장과 Worker success callback 연결을 권장합니다.