### PR TITLE
✨ [Feat] Worker debug artifact 이미지 저장 구현

### DIFF
--- a/docs/feature-specs/issue-81-worker-debug-artifact-upload.md
+++ b/docs/feature-specs/issue-81-worker-debug-artifact-upload.md
@@ -1,0 +1,56 @@
+# Issue 81. Worker Debug Artifact Upload
+
+## Goal
+
+Store real per-step Worker debug artifact images when a preprocess job is created with `debug=true`.
+
+This remains OCR preprocessing only. The Worker does not run OCR text extraction and does not persist recognized text.
+
+## Scope
+
+1. Capture a cloned OpenCV `Mat` snapshot after each successful pipeline step when debug mode is enabled.
+2. Keep debug mode disabled by default so normal jobs do not pay the storage and memory cost.
+3. Upload captured snapshots as PNG files to Object Storage.
+4. Keep debug artifact descriptors in `processing-report.json`.
+5. Release cloned debug snapshot Mats after the pipeline completes.
+
+## Runtime Flow
+
+1. `WorkerJobService` downloads the source image from Object Storage.
+2. `PreprocessPipelineRunner` executes the configured preset steps in OCR preprocessing order.
+3. After a step succeeds, the runner asks `PreprocessContext` to capture a debug snapshot.
+4. `PreprocessContext` clones the current context-owned Mat and records a matching `DebugArtifactDescriptor`.
+5. Before runner cleanup, `WorkerJobService` saves processed, preview, and debug artifacts from the output callback.
+6. The runner releases the decoded output Mat and all cloned debug snapshot Mats in `finally`.
+7. `ProcessingReportFactory` writes the debug artifact metadata into `processing-report.json`.
+
+## Debug Output Paths
+
+```text
+processed/{projectId}/{jobId}/{itemId}/debug/00_decoded.png
+processed/{projectId}/{jobId}/{itemId}/debug/01_normalized.png
+processed/{projectId}/{jobId}/{itemId}/debug/02_orientation.png
+processed/{projectId}/{jobId}/{itemId}/debug/03_deskew.png
+processed/{projectId}/{jobId}/{itemId}/debug/04_crop.png
+processed/{projectId}/{jobId}/{itemId}/debug/05_denoise.png
+processed/{projectId}/{jobId}/{itemId}/debug/06_contrast.png
+processed/{projectId}/{jobId}/{itemId}/debug/07_binarized.png
+processed/{projectId}/{jobId}/{itemId}/debug/08_morphology.png
+processed/{projectId}/{jobId}/{itemId}/debug/09_dpi.png
+processed/{projectId}/{jobId}/{itemId}/debug/10_sharpen.png
+```
+
+## Failure Policy
+
+If debug artifact encoding or upload fails, the Worker reports `ARTIFACT_UPLOAD_FAILED`.
+
+This is intentional because `debug=true` means the caller explicitly requested these artifacts as part of the job
+result. The job can be retried through the existing Worker retry path.
+
+## Done Criteria
+
+1. `debug=false` jobs upload only processed, preview, and report artifacts.
+2. `debug=true` jobs upload per-step debug PNG snapshots.
+3. Snapshot Mats are released after runner completion.
+4. Report JSON keeps debug artifact metadata.
+5. Worker tests verify upload and release behavior.

--- a/docs/tasks/18-artifact-report.md
+++ b/docs/tasks/18-artifact-report.md
@@ -23,6 +23,7 @@ This task is not OCR text extraction. The Worker stores processed images and pre
 4. Processing report JSON generation and upload.
 5. Worker success callback with artifact object keys.
 6. Failure mapping for artifact upload failures.
+7. Debug artifact upload for explicitly requested debug jobs.
 
 ## Current Issue 79 Scope
 
@@ -43,13 +44,14 @@ Issue 79 implements the first real artifact/report integration:
 processed/{projectId}/{jobId}/{itemId}/processed.png
 processed/{projectId}/{jobId}/{itemId}/preview.png
 processed/{projectId}/{jobId}/{itemId}/processing-report.json
+processed/{projectId}/{jobId}/{itemId}/debug/{step-file-name}.png
 ```
 
 ## Remaining Work
 
-1. Generate and upload real per-step debug artifact images when `debug=true`.
-2. Add richer report fields for detected skew angle, crop bounds, binarization strategy, and DPI normalization.
-3. Add memory usage sampling if operationally needed.
+1. Add richer report fields for detected skew angle, crop bounds, binarization strategy, and DPI normalization.
+2. Add memory usage sampling if operationally needed.
+3. Add local Docker smoke verification that checks MinIO object existence for processed, preview, report, and debug paths.
 
 ## Done Criteria
 
@@ -58,3 +60,4 @@ processed/{projectId}/{jobId}/{itemId}/processing-report.json
 3. Success callback includes processed, preview, and report object keys.
 4. Pipeline errors still follow failure callback path.
 5. API server still does not execute OpenCV preprocessing.
+6. `debug=true` stores per-step debug PNG snapshots before the success callback.

--- a/docs/worker/image-test-integration.md
+++ b/docs/worker/image-test-integration.md
@@ -79,8 +79,12 @@ Issue 79 persists the pipeline output. The Worker encodes the final Mat as `proc
 `preview.png`, writes `processing-report.json`, uploads all three artifacts to Object Storage, and then calls the Backend
 Internal Worker API success endpoint with the object keys.
 
+Issue 81 persists real debug images when the job request has `debug=true`. The runner clones the current Mat after each
+successful preprocessing step, the Worker uploads those snapshots as PNG files, and the processing report keeps the
+debug artifact object keys.
+
 ## Future Implementation Points
 
-1. Generate and upload real per-step debug images.
-2. Expand report fields with detected image-processing facts.
+1. Expand report fields with detected image-processing facts.
+2. Add an end-to-end MinIO smoke check for all artifact types.
 3. Keep OCR text extraction outside the product runtime.

--- a/docs/worker/preprocess-pipeline.md
+++ b/docs/worker/preprocess-pipeline.md
@@ -126,6 +126,13 @@ Issue 79 connects the pipeline output to artifacts and success reporting:
 - `processing-report.json` upload
 - Backend Internal Worker API success callback with artifact object keys
 
+Issue 81 connects debug artifact snapshots to Object Storage:
+
+- debug snapshots are captured after each successful step only when `debug=true`
+- snapshots clone the current OpenCV Mat so the final output Mat can continue mutating safely
+- debug images are encoded as PNG and uploaded under `processed/{projectId}/{jobId}/{itemId}/debug/`
+- cloned debug Mats are released in the runner cleanup path
+
 ## Required Execution Order
 
 Every built-in document preset executes the following order:
@@ -164,6 +171,20 @@ The Worker now reports success only after these required artifacts are uploaded:
 - `processed/{projectId}/{jobId}/{itemId}/preview.png`
 - `processed/{projectId}/{jobId}/{itemId}/processing-report.json`
 
+When `debug=true`, the Worker also uploads these optional debug artifacts before reporting success:
+
+- `processed/{projectId}/{jobId}/{itemId}/debug/00_decoded.png`
+- `processed/{projectId}/{jobId}/{itemId}/debug/01_normalized.png`
+- `processed/{projectId}/{jobId}/{itemId}/debug/02_orientation.png`
+- `processed/{projectId}/{jobId}/{itemId}/debug/03_deskew.png`
+- `processed/{projectId}/{jobId}/{itemId}/debug/04_crop.png`
+- `processed/{projectId}/{jobId}/{itemId}/debug/05_denoise.png`
+- `processed/{projectId}/{jobId}/{itemId}/debug/06_contrast.png`
+- `processed/{projectId}/{jobId}/{itemId}/debug/07_binarized.png`
+- `processed/{projectId}/{jobId}/{itemId}/debug/08_morphology.png`
+- `processed/{projectId}/{jobId}/{itemId}/debug/09_dpi.png`
+- `processed/{projectId}/{jobId}/{itemId}/debug/10_sharpen.png`
+
 If the pipeline finishes without a real output image, the Worker still reports `PIPELINE_NOT_IMPLEMENTED`. This keeps
 the deferred/no-source skeleton path explicit during tests and local smoke checks.
 
@@ -172,6 +193,6 @@ it to `ARTIFACT_UPLOAD_FAILED`. Backend report failures remain `BACKEND_REPORT_F
 
 ## Next Implementation Steps
 
-1. Generate and upload real debug artifact images for `debug=true`.
-2. Add richer report fields for skew angle, crop bounds, binarization strategy, and DPI normalization.
+1. Add richer report fields for skew angle, crop bounds, binarization strategy, and DPI normalization.
+2. Add a local Docker smoke path that verifies stored artifacts in MinIO.
 3. Keep OCR text extraction out of the Worker runtime scope.

--- a/docs/worker/report-json-spec.md
+++ b/docs/worker/report-json-spec.md
@@ -56,5 +56,5 @@ Examples:
 ## Current Limits
 
 1. Memory usage is currently not sampled and remains `0`.
-2. Debug artifact entries are metadata-only until real debug image generation is implemented.
+2. Debug artifact entries point to uploaded PNG snapshots only when the job request has `debug=true`.
 3. OCR text, confidence, CER, WER, and recognized text are out of scope.

--- a/preprocess-worker/src/main/java/com/moonju/preprocess/worker/domain/artifact/service/DebugArtifactSaveService.java
+++ b/preprocess-worker/src/main/java/com/moonju/preprocess/worker/domain/artifact/service/DebugArtifactSaveService.java
@@ -2,21 +2,49 @@ package com.moonju.preprocess.worker.domain.artifact.service;
 
 import com.moonju.preprocess.worker.domain.artifact.dto.ArtifactUploadRequest;
 import com.moonju.preprocess.worker.domain.artifact.dto.ArtifactUploadResult;
+import com.moonju.preprocess.worker.domain.artifact.exception.ArtifactUploadFailedException;
 import com.moonju.preprocess.worker.domain.artifact.model.ArtifactPath;
 import com.moonju.preprocess.worker.domain.artifact.model.ArtifactType;
+import com.moonju.preprocess.worker.domain.preprocess.model.DebugArtifactSnapshot;
+import com.moonju.preprocess.worker.domain.preprocess.service.ImageEncodePort;
+import java.util.List;
 import org.springframework.stereotype.Service;
 
 @Service
 public class DebugArtifactSaveService {
 
     private final ArtifactSaveService artifactSaveService;
+    private final ImageEncodePort imageEncodePort;
 
-    public DebugArtifactSaveService(ArtifactSaveService artifactSaveService) {
+    public DebugArtifactSaveService(ArtifactSaveService artifactSaveService, ImageEncodePort imageEncodePort) {
         this.artifactSaveService = artifactSaveService;
+        this.imageEncodePort = imageEncodePort;
     }
 
     public ArtifactUploadResult prepare(Long projectId, Long jobId, Long itemId, String stepFileName) {
         ArtifactPath path = ArtifactPath.debug(projectId, jobId, itemId, stepFileName);
         return artifactSaveService.prepareUpload(ArtifactUploadRequest.skeleton(ArtifactType.DEBUG_IMAGE, path));
+    }
+
+    public List<ArtifactUploadResult> saveAll(List<DebugArtifactSnapshot> snapshots) {
+        if (snapshots == null || snapshots.isEmpty()) {
+            return List.of();
+        }
+        return snapshots.stream()
+            .filter(DebugArtifactSnapshot::loaded)
+            .map(this::save)
+            .toList();
+    }
+
+    public ArtifactUploadResult save(DebugArtifactSnapshot snapshot) {
+        ArtifactPath path = new ArtifactPath(snapshot.descriptor().objectKey());
+        try {
+            byte[] content = imageEncodePort.encodePng(path.value(), snapshot.image());
+            return artifactSaveService.upload(ArtifactUploadRequest.upload(ArtifactType.DEBUG_IMAGE, path, content));
+        } catch (ArtifactUploadFailedException exception) {
+            throw exception;
+        } catch (RuntimeException exception) {
+            throw new ArtifactUploadFailedException("Debug artifact save failed: " + path.value(), exception);
+        }
     }
 }

--- a/preprocess-worker/src/main/java/com/moonju/preprocess/worker/domain/preprocess/model/DebugArtifactSnapshot.java
+++ b/preprocess-worker/src/main/java/com/moonju/preprocess/worker/domain/preprocess/model/DebugArtifactSnapshot.java
@@ -1,0 +1,55 @@
+package com.moonju.preprocess.worker.domain.preprocess.model;
+
+import com.moonju.preprocess.worker.domain.preprocess.step.PreprocessStepName;
+import org.opencv.core.Mat;
+
+public final class DebugArtifactSnapshot implements AutoCloseable {
+
+    private final DebugArtifactDescriptor descriptor;
+    private final Mat image;
+    private boolean released;
+
+    private DebugArtifactSnapshot(DebugArtifactDescriptor descriptor, Mat image) {
+        this.descriptor = descriptor;
+        this.image = image;
+    }
+
+    public static DebugArtifactSnapshot image(
+        PreprocessStepName stepName,
+        Long projectId,
+        Long jobId,
+        Long itemId,
+        String fileName,
+        Mat source
+    ) {
+        if (source == null || source.empty()) {
+            throw new IllegalArgumentException("Debug artifact source image is required.");
+        }
+        DebugArtifactDescriptor descriptor = DebugArtifactDescriptor.image(stepName, projectId, jobId, itemId, fileName);
+        return new DebugArtifactSnapshot(descriptor, source.clone());
+    }
+
+    public DebugArtifactDescriptor descriptor() {
+        return descriptor;
+    }
+
+    public Mat image() {
+        return image;
+    }
+
+    public boolean loaded() {
+        return !released && image != null && !image.empty();
+    }
+
+    public void release() {
+        if (!released && image != null) {
+            image.release();
+        }
+        released = true;
+    }
+
+    @Override
+    public void close() {
+        release();
+    }
+}

--- a/preprocess-worker/src/main/java/com/moonju/preprocess/worker/domain/preprocess/pipeline/PreprocessContext.java
+++ b/preprocess-worker/src/main/java/com/moonju/preprocess/worker/domain/preprocess/pipeline/PreprocessContext.java
@@ -1,6 +1,7 @@
 package com.moonju.preprocess.worker.domain.preprocess.pipeline;
 
 import com.moonju.preprocess.worker.domain.preprocess.model.DebugArtifactDescriptor;
+import com.moonju.preprocess.worker.domain.preprocess.model.DebugArtifactSnapshot;
 import com.moonju.preprocess.worker.domain.preprocess.model.FallbackNote;
 import com.moonju.preprocess.worker.domain.preprocess.model.ImageMatHolder;
 import com.moonju.preprocess.worker.domain.preprocess.step.PreprocessStepName;
@@ -25,6 +26,7 @@ public class PreprocessContext {
     private final List<PreprocessStepExecution> stepExecutions = new ArrayList<>();
     private final List<FallbackNote> fallbackNotes = new ArrayList<>();
     private final List<DebugArtifactDescriptor> debugArtifacts = new ArrayList<>();
+    private final List<DebugArtifactSnapshot> debugSnapshots = new ArrayList<>();
     private final Map<PreprocessStepName, String> stepNotes = new EnumMap<>(PreprocessStepName.class);
     private byte[] sourceImageBytes;
     private ImageMatHolder decodedImage;
@@ -94,6 +96,22 @@ public class PreprocessContext {
         debugArtifacts.add(DebugArtifactDescriptor.image(stepName, projectId, jobId, itemId, fileName));
     }
 
+    public void recordDebugSnapshot(PreprocessStepName stepName, String fileName, ImageMatHolder imageMatHolder) {
+        if (!debug || imageMatHolder == null || !imageMatHolder.loaded()) {
+            return;
+        }
+        DebugArtifactSnapshot snapshot = DebugArtifactSnapshot.image(
+            stepName,
+            projectId,
+            jobId,
+            itemId,
+            fileName,
+            imageMatHolder.mat()
+        );
+        debugSnapshots.add(snapshot);
+        debugArtifacts.add(snapshot.descriptor());
+    }
+
     public PreprocessContext withSourceImageBytes(byte[] imageBytes) {
         if (imageBytes == null) {
             this.sourceImageBytes = null;
@@ -126,6 +144,12 @@ public class PreprocessContext {
     public void releaseDecodedImage() {
         if (decodedImage != null) {
             decodedImage.release();
+        }
+    }
+
+    public void releaseDebugSnapshots() {
+        for (DebugArtifactSnapshot snapshot : debugSnapshots) {
+            snapshot.release();
         }
     }
 
@@ -167,5 +191,9 @@ public class PreprocessContext {
 
     public List<DebugArtifactDescriptor> debugArtifacts() {
         return List.copyOf(debugArtifacts);
+    }
+
+    public List<DebugArtifactSnapshot> debugSnapshots() {
+        return List.copyOf(debugSnapshots);
     }
 }

--- a/preprocess-worker/src/main/java/com/moonju/preprocess/worker/domain/preprocess/pipeline/PreprocessPipelineRunner.java
+++ b/preprocess-worker/src/main/java/com/moonju/preprocess/worker/domain/preprocess/pipeline/PreprocessPipelineRunner.java
@@ -63,6 +63,7 @@ public class PreprocessPipelineRunner {
             return PreprocessResult.from(context, !outputImageAvailable, wallTime, success, errorMessage);
         } finally {
             context.releaseDecodedImage();
+            context.releaseDebugSnapshots();
         }
     }
 
@@ -71,6 +72,7 @@ public class PreprocessPipelineRunner {
         long startedNanos = System.nanoTime();
         try {
             step.execute(context);
+            recordDebugSnapshot(context, step);
             Instant endedAt = Instant.now(clock);
             Duration wallTime = Duration.ofNanos(System.nanoTime() - startedNanos);
             return PreprocessStepExecution.succeeded(
@@ -92,5 +94,27 @@ public class PreprocessPipelineRunner {
                 exception.getMessage()
             );
         }
+    }
+
+    private void recordDebugSnapshot(PreprocessContext context, PreprocessStep step) {
+        context.decodedImage()
+            .filter(ImageMatHolder::loaded)
+            .ifPresent(image -> context.recordDebugSnapshot(step.name(), debugFileName(step), image));
+    }
+
+    private String debugFileName(PreprocessStep step) {
+        return switch (step.name()) {
+            case DECODE -> "00_decoded.png";
+            case COLOR_NORMALIZE -> "01_normalized.png";
+            case ORIENTATION_NORMALIZE -> "02_orientation.png";
+            case DESKEW -> "03_deskew.png";
+            case CROP -> "04_crop.png";
+            case DENOISE -> "05_denoise.png";
+            case CONTRAST_NORMALIZE -> "06_contrast.png";
+            case BINARIZATION -> "07_binarized.png";
+            case MORPHOLOGY_CLEANUP -> "08_morphology.png";
+            case DPI_NORMALIZE -> "09_dpi.png";
+            case OPTIONAL_SHARPEN -> "10_sharpen.png";
+        };
     }
 }

--- a/preprocess-worker/src/main/java/com/moonju/preprocess/worker/domain/workerjob/service/WorkerJobService.java
+++ b/preprocess-worker/src/main/java/com/moonju/preprocess/worker/domain/workerjob/service/WorkerJobService.java
@@ -2,6 +2,7 @@ package com.moonju.preprocess.worker.domain.workerjob.service;
 
 import com.moonju.preprocess.worker.domain.artifact.dto.ArtifactUploadResult;
 import com.moonju.preprocess.worker.domain.artifact.exception.ArtifactUploadFailedException;
+import com.moonju.preprocess.worker.domain.artifact.service.DebugArtifactSaveService;
 import com.moonju.preprocess.worker.domain.artifact.service.PreviewImageSaveService;
 import com.moonju.preprocess.worker.domain.artifact.service.ProcessedImageSaveService;
 import com.moonju.preprocess.worker.domain.artifact.service.ProcessingReportSaveService;
@@ -27,6 +28,7 @@ public class WorkerJobService {
     private final PreprocessPipelineRunner preprocessPipelineRunner;
     private final ProcessedImageSaveService processedImageSaveService;
     private final PreviewImageSaveService previewImageSaveService;
+    private final DebugArtifactSaveService debugArtifactSaveService;
     private final ProcessingReportFactory processingReportFactory;
     private final ProcessingReportSaveService processingReportSaveService;
 
@@ -36,6 +38,7 @@ public class WorkerJobService {
         PreprocessPipelineRunner preprocessPipelineRunner,
         ProcessedImageSaveService processedImageSaveService,
         PreviewImageSaveService previewImageSaveService,
+        DebugArtifactSaveService debugArtifactSaveService,
         ProcessingReportFactory processingReportFactory,
         ProcessingReportSaveService processingReportSaveService
     ) {
@@ -44,6 +47,7 @@ public class WorkerJobService {
         this.preprocessPipelineRunner = preprocessPipelineRunner;
         this.processedImageSaveService = processedImageSaveService;
         this.previewImageSaveService = previewImageSaveService;
+        this.debugArtifactSaveService = debugArtifactSaveService;
         this.processingReportFactory = processingReportFactory;
         this.processingReportSaveService = processingReportSaveService;
     }
@@ -92,6 +96,7 @@ public class WorkerJobService {
                     message.itemId(),
                     outputImage
                 ));
+                debugArtifactSaveService.saveAll(context.debugSnapshots());
             });
             if (!result.success()) {
                 return reportFailure(

--- a/preprocess-worker/src/test/java/com/moonju/preprocess/worker/domain/artifact/service/ArtifactSaveServiceTests.java
+++ b/preprocess-worker/src/test/java/com/moonju/preprocess/worker/domain/artifact/service/ArtifactSaveServiceTests.java
@@ -8,8 +8,10 @@ import static org.mockito.Mockito.when;
 
 import com.moonju.preprocess.worker.domain.artifact.dto.ArtifactUploadResult;
 import com.moonju.preprocess.worker.domain.artifact.model.ArtifactType;
+import com.moonju.preprocess.worker.domain.preprocess.model.DebugArtifactSnapshot;
 import com.moonju.preprocess.worker.domain.preprocess.model.ImageMatHolder;
 import com.moonju.preprocess.worker.domain.preprocess.service.ImageEncodePort;
+import com.moonju.preprocess.worker.domain.preprocess.step.PreprocessStepName;
 import com.moonju.preprocess.worker.domain.report.dto.ProcessingReport;
 import com.moonju.preprocess.worker.domain.report.model.ProcessingFallbackSummary;
 import com.moonju.preprocess.worker.domain.report.model.ProcessingMemoryUsage;
@@ -47,7 +49,10 @@ class ArtifactSaveServiceTests {
             artifactSaveService,
             imageEncodePort
         );
-        DebugArtifactSaveService debugArtifactSaveService = new DebugArtifactSaveService(artifactSaveService);
+        DebugArtifactSaveService debugArtifactSaveService = new DebugArtifactSaveService(
+            artifactSaveService,
+            imageEncodePort
+        );
 
         ArtifactUploadResult processed = processedImageSaveService.prepare(1L, 2L, 3L);
         ArtifactUploadResult preview = previewImageSaveService.prepare(1L, 2L, 3L);
@@ -59,6 +64,42 @@ class ArtifactSaveServiceTests {
         assertThat(processed.artifactPath().value()).isEqualTo("processed/1/2/3/processed.png");
         assertThat(preview.artifactPath().value()).isEqualTo("processed/1/2/3/preview.png");
         assertThat(debug.artifactPath().value()).isEqualTo("processed/1/2/3/debug/00_decoded.png");
+    }
+
+    @Test
+    void uploadsDebugArtifactSnapshots() {
+        DebugArtifactSaveService debugArtifactSaveService = new DebugArtifactSaveService(
+            artifactSaveService,
+            imageEncodePort
+        );
+        Mat source = new Mat(2, 3, CvType.CV_8UC1, new Scalar(255));
+        DebugArtifactSnapshot snapshot = DebugArtifactSnapshot.image(
+            PreprocessStepName.DECODE,
+            1L,
+            2L,
+            3L,
+            "00_decoded.png",
+            source
+        );
+        when(imageEncodePort.encodePng(
+            eq("processed/1/2/3/debug/00_decoded.png"),
+            org.mockito.ArgumentMatchers.any()
+        )).thenReturn(new byte[] {9, 8, 7});
+
+        List<ArtifactUploadResult> results = debugArtifactSaveService.saveAll(List.of(snapshot));
+
+        assertThat(results).hasSize(1);
+        assertThat(results.getFirst().artifactType()).isEqualTo(ArtifactType.DEBUG_IMAGE);
+        assertThat(results.getFirst().artifactPath().value()).isEqualTo("processed/1/2/3/debug/00_decoded.png");
+        assertThat(results.getFirst().uploaded()).isTrue();
+        assertThat(results.getFirst().sizeBytes()).isEqualTo(3);
+        verify(objectStoragePort).uploadBytes(
+            eq("processed/1/2/3/debug/00_decoded.png"),
+            org.mockito.ArgumentMatchers.argThat(bytes -> Arrays.equals(bytes, new byte[] {9, 8, 7})),
+            eq("image/png")
+        );
+        snapshot.release();
+        source.release();
     }
 
     @Test

--- a/preprocess-worker/src/test/java/com/moonju/preprocess/worker/domain/preprocess/pipeline/PreprocessPipelineRunnerTests.java
+++ b/preprocess-worker/src/test/java/com/moonju/preprocess/worker/domain/preprocess/pipeline/PreprocessPipelineRunnerTests.java
@@ -191,6 +191,38 @@ class PreprocessPipelineRunnerTests {
     }
 
     @Test
+    void recordsAndReleasesDebugSnapshotsWhenDebugEnabled() throws IOException {
+        PreprocessPipelineRunner decodeRunner = new PreprocessPipelineRunner(
+            PreprocessPresetRegistry.builtIn(),
+            PreprocessStepCatalog.builtIn(
+                new ImageCodecAdapter(new OpenCvLoader())
+            )
+        );
+        PreprocessContext context = new PreprocessContext(
+            3L,
+            1L,
+            10L,
+            "originals/project/scan.png",
+            "LOW_CONTRAST_SCAN",
+            Map.of(),
+            true
+        ).withSourceImageBytes(pngBytes());
+
+        PreprocessResult result = decodeRunner.run(context);
+
+        assertThat(result.success()).isTrue();
+        assertThat(result.debugArtifacts())
+            .extracting(debugArtifact -> debugArtifact.objectKey())
+            .contains(
+                "processed/3/1/10/debug/00_decoded.png",
+                "processed/3/1/10/debug/01_normalized.png",
+                "processed/3/1/10/debug/10_sharpen.png"
+            );
+        assertThat(context.debugSnapshots()).isNotEmpty();
+        assertThat(context.debugSnapshots()).allSatisfy(snapshot -> assertThat(snapshot.loaded()).isFalse());
+    }
+
+    @Test
     void releasesDecodedImageWhenPipelineFailsAfterDecode() throws IOException {
         PreprocessStep failingColorNormalizeStep = new PreprocessStep() {
 

--- a/preprocess-worker/src/test/java/com/moonju/preprocess/worker/domain/workerjob/service/WorkerJobServiceTests.java
+++ b/preprocess-worker/src/test/java/com/moonju/preprocess/worker/domain/workerjob/service/WorkerJobServiceTests.java
@@ -2,6 +2,7 @@ package com.moonju.preprocess.worker.domain.workerjob.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doThrow;
@@ -14,13 +15,16 @@ import com.moonju.preprocess.worker.domain.artifact.dto.ArtifactUploadResult;
 import com.moonju.preprocess.worker.domain.artifact.exception.ArtifactUploadFailedException;
 import com.moonju.preprocess.worker.domain.artifact.model.ArtifactPath;
 import com.moonju.preprocess.worker.domain.artifact.model.ArtifactType;
+import com.moonju.preprocess.worker.domain.artifact.service.DebugArtifactSaveService;
 import com.moonju.preprocess.worker.domain.artifact.service.PreviewImageSaveService;
 import com.moonju.preprocess.worker.domain.artifact.service.ProcessedImageSaveService;
 import com.moonju.preprocess.worker.domain.artifact.service.ProcessingReportSaveService;
+import com.moonju.preprocess.worker.domain.preprocess.model.DebugArtifactSnapshot;
 import com.moonju.preprocess.worker.domain.preprocess.model.ImageMatHolder;
 import com.moonju.preprocess.worker.domain.preprocess.pipeline.PreprocessContext;
 import com.moonju.preprocess.worker.domain.preprocess.pipeline.PreprocessPipelineRunner;
 import com.moonju.preprocess.worker.domain.preprocess.pipeline.PreprocessResult;
+import com.moonju.preprocess.worker.domain.preprocess.step.PreprocessStepName;
 import com.moonju.preprocess.worker.domain.report.dto.ProcessingReport;
 import com.moonju.preprocess.worker.domain.report.service.ProcessingReportFactory;
 import com.moonju.preprocess.worker.domain.workerjob.dto.JobPriority;
@@ -29,11 +33,14 @@ import com.moonju.preprocess.worker.domain.workerjob.dto.WorkerJobResult;
 import com.moonju.preprocess.worker.domain.workerjob.status.WorkerFailureCode;
 import com.moonju.preprocess.worker.domain.workerjob.status.WorkerJobStatus;
 import com.moonju.preprocess.worker.infra.api.BackendApiClient;
+import com.moonju.preprocess.worker.infra.opencv.OpenCvLoader;
 import com.moonju.preprocess.worker.infra.storage.ObjectStoragePort;
 import java.time.Duration;
 import java.time.Instant;
+import java.util.List;
 import java.util.Map;
 import java.util.function.Consumer;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.opencv.core.CvType;
 import org.opencv.core.Mat;
@@ -41,11 +48,17 @@ import org.opencv.core.Scalar;
 
 class WorkerJobServiceTests {
 
+    @BeforeAll
+    static void loadOpenCv() {
+        new OpenCvLoader().loadIfPresent();
+    }
+
     private final BackendApiClient backendApiClient = mock(BackendApiClient.class);
     private final ObjectStoragePort objectStoragePort = mock(ObjectStoragePort.class);
     private final PreprocessPipelineRunner preprocessPipelineRunner = mock(PreprocessPipelineRunner.class);
     private final ProcessedImageSaveService processedImageSaveService = mock(ProcessedImageSaveService.class);
     private final PreviewImageSaveService previewImageSaveService = mock(PreviewImageSaveService.class);
+    private final DebugArtifactSaveService debugArtifactSaveService = mock(DebugArtifactSaveService.class);
     private final ProcessingReportFactory processingReportFactory = new ProcessingReportFactory();
     private final ProcessingReportSaveService processingReportSaveService = mock(ProcessingReportSaveService.class);
     private final WorkerJobService service = new WorkerJobService(
@@ -54,6 +67,7 @@ class WorkerJobServiceTests {
         preprocessPipelineRunner,
         processedImageSaveService,
         previewImageSaveService,
+        debugArtifactSaveService,
         processingReportFactory,
         processingReportSaveService
     );
@@ -78,12 +92,41 @@ class WorkerJobServiceTests {
         verify(backendApiClient).reportStarted(message);
         verify(objectStoragePort).downloadBytes("originals/scan.png");
         verify(backendApiClient).reportHeartbeat(message);
+        verify(debugArtifactSaveService).saveAll(argThat(List::isEmpty));
         verify(backendApiClient).reportSucceeded(
             message,
             "processed/3/1/2/processed.png",
             "processed/3/1/2/preview.png",
             "processed/3/1/2/processing-report.json"
         );
+    }
+
+    @Test
+    void uploadsDebugArtifactsWhenDebugEnabled() {
+        PreprocessJobMessage message = validMessage(true);
+        when(objectStoragePort.downloadBytes("originals/scan.png")).thenReturn(new byte[] {1, 2, 3});
+        when(processedImageSaveService.save(eq(3L), eq(1L), eq(2L), any(ImageMatHolder.class)))
+            .thenReturn(uploaded(ArtifactType.PROCESSED_IMAGE, "processed/3/1/2/processed.png", 10));
+        when(previewImageSaveService.save(eq(3L), eq(1L), eq(2L), any(ImageMatHolder.class)))
+            .thenReturn(uploaded(ArtifactType.PREVIEW_IMAGE, "processed/3/1/2/preview.png", 5));
+        when(processingReportSaveService.save(eq(3L), eq(1L), eq(2L), any(ProcessingReport.class)))
+            .thenReturn(uploaded(ArtifactType.PROCESSING_REPORT, "processed/3/1/2/processing-report.json", 50));
+        doAnswer(invocation -> {
+            List<DebugArtifactSnapshot> snapshots = invocation.getArgument(0);
+            assertThat(snapshots).hasSize(1);
+            assertThat(snapshots.getFirst().loaded()).isTrue();
+            return List.of();
+        }).when(debugArtifactSaveService).saveAll(any());
+        successfulPipelineRun(message);
+
+        WorkerJobResult result = service.process(message);
+
+        assertThat(result.status()).isEqualTo(WorkerJobStatus.SUCCEEDED);
+        verify(debugArtifactSaveService).saveAll(argThat(snapshots ->
+            snapshots.size() == 1
+                && snapshots.getFirst().descriptor().objectKey()
+                    .equals("processed/3/1/2/debug/00_decoded.png")
+        ));
     }
 
     @Test
@@ -217,8 +260,12 @@ class WorkerJobServiceTests {
                 new Mat(2, 3, CvType.CV_8UC1, new Scalar(255))
             );
             try {
+                if (context.debug()) {
+                    context.recordDebugSnapshot(PreprocessStepName.DECODE, "00_decoded.png", outputImage);
+                }
                 outputConsumer.accept(outputImage);
             } finally {
+                context.releaseDebugSnapshots();
                 outputImage.release();
             }
             return PreprocessResult.from(context, false, Duration.ofMillis(3), true, null);
@@ -230,6 +277,10 @@ class WorkerJobServiceTests {
     }
 
     private PreprocessJobMessage validMessage() {
+        return validMessage(false);
+    }
+
+    private PreprocessJobMessage validMessage(boolean debug) {
         return new PreprocessJobMessage(
             "msg",
             1L,
@@ -240,7 +291,7 @@ class WorkerJobServiceTests {
             "originals/scan.png",
             "A4_SCAN_300DPI",
             Map.of("targetDpi", "300"),
-            false,
+            debug,
             JobPriority.NORMAL,
             1,
             "trace",


### PR DESCRIPTION
## #️⃣ 기능 설명

Worker preprocess pipeline에서 `debug=true` 작업일 때 단계별 OpenCV Mat snapshot을 PNG debug artifact로 Object Storage에 저장합니다.

Closes #81

## 🛠️ 작업 상세 내용

- [x] `DebugArtifactSnapshot` 모델 추가 및 `PreprocessContext` snapshot 기록/해제 흐름 추가
- [x] `PreprocessPipelineRunner`가 각 성공 step 이후 debug snapshot을 캡처하도록 연결
- [x] `DebugArtifactSaveService`가 snapshot을 PNG로 인코딩해 Object Storage에 업로드하도록 구현
- [x] `WorkerJobService`가 processed/preview 저장 시점에 debug artifact도 저장하도록 연결
- [x] artifact/report/worker 문서와 issue별 기능 명세 갱신

## 📁 변경 파일 요약

- `preprocess-worker/src/main/java/.../preprocess/model/DebugArtifactSnapshot.java`
- `preprocess-worker/src/main/java/.../preprocess/pipeline/*`
- `preprocess-worker/src/main/java/.../artifact/service/DebugArtifactSaveService.java`
- `preprocess-worker/src/main/java/.../workerjob/service/WorkerJobService.java`
- `preprocess-worker/src/test/java/...`
- `docs/feature-specs/issue-81-worker-debug-artifact-upload.md`
- `docs/worker/*.md`, `docs/tasks/18-artifact-report.md`

## ✅ 검증 내용

- [x] `docker run --rm -v "${PWD}\\preprocess-worker:/workspace" -w /workspace gradle:8.10-jdk21 gradle test --no-daemon`
- [x] `docker run --rm -v "${PWD}\\preprocess-worker:/workspace" -w /workspace gradle:8.10-jdk21 gradle build --no-daemon`
- [x] `docker compose -f infra\\docker-compose\\docker-compose.local.yml build preprocess-worker`
- [x] `git diff --cached --check`
- [x] secret pattern scan: real Google secret not committed

## 🔎 리뷰어가 확인해야 할 부분

- `debug=true`에서 snapshot capture 시점이 runner cleanup 전이라 Mat release 순서가 안전한지 확인해주세요.
- debug artifact upload 실패를 `ARTIFACT_UPLOAD_FAILED`로 처리하는 정책이 맞는지 확인해주세요.

## 📸 스크린샷

없음

## 💬 기타 공유사항 to 리뷰어

- OCR 텍스트 추출은 포함하지 않았습니다.
- `debug=false` 기본 작업은 빈 snapshot list만 전달되어 추가 artifact를 저장하지 않습니다.