### PR TITLE
✨ [Feat] 다중 이미지 업로드와 SaaS형 업로드 UX 개선

### DIFF
--- a/backend-api/src/main/java/com/moonju/preprocess/api/domain/auth/service/OAuth2LoginSuccessHandler.java
+++ b/backend-api/src/main/java/com/moonju/preprocess/api/domain/auth/service/OAuth2LoginSuccessHandler.java
@@ -51,8 +51,7 @@ public class OAuth2LoginSuccessHandler implements AuthenticationSuccessHandler {
             refreshTokenCookieService.createRefreshCookie(tokenPair.refreshToken()).toString()
         );
         String redirectUri = UriComponentsBuilder.fromUriString(successRedirectUri)
-            .queryParam("accessToken", tokenPair.accessToken())
-            .queryParam("accessTokenExpiresAt", tokenPair.accessTokenExpiresAt())
+            .queryParam("login", "success")
             .build()
             .toUriString();
         redirectStrategy.sendRedirect(request, response, redirectUri);

--- a/backend-api/src/main/java/com/moonju/preprocess/api/domain/job/controller/JobController.java
+++ b/backend-api/src/main/java/com/moonju/preprocess/api/domain/job/controller/JobController.java
@@ -4,6 +4,7 @@ import com.moonju.preprocess.api.domain.job.dto.JobArtifactResponse;
 import com.moonju.preprocess.api.domain.job.dto.JobCancelResponse;
 import com.moonju.preprocess.api.domain.job.dto.JobCreateRequest;
 import com.moonju.preprocess.api.domain.job.dto.JobCreateResponse;
+import com.moonju.preprocess.api.domain.job.dto.JobItemDownloadUrlResponse;
 import com.moonju.preprocess.api.domain.job.dto.JobItemResponse;
 import com.moonju.preprocess.api.domain.job.dto.JobResponse;
 import com.moonju.preprocess.api.domain.job.dto.JobRetryResponse;
@@ -22,6 +23,7 @@ import org.springframework.data.web.PageableDefault;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -75,6 +77,16 @@ public class JobController {
         @PageableDefault(size = 50) Pageable pageable
     ) {
         return ApiResponse.success(jobQueryService.findItems(currentUserId, jobId, pageable));
+    }
+
+    @GetMapping("/{jobId}/items/{itemId}/download")
+    public ApiResponse<JobItemDownloadUrlResponse> downloadItemArtifact(
+        @CurrentUser Long currentUserId,
+        @PathVariable Long jobId,
+        @PathVariable Long itemId,
+        @RequestParam String type
+    ) {
+        return ApiResponse.success(jobQueryService.createItemArtifactDownloadUrl(currentUserId, jobId, itemId, type));
     }
 
     @GetMapping("/{jobId}/summary")

--- a/backend-api/src/main/java/com/moonju/preprocess/api/domain/job/dto/JobItemDownloadUrlResponse.java
+++ b/backend-api/src/main/java/com/moonju/preprocess/api/domain/job/dto/JobItemDownloadUrlResponse.java
@@ -1,0 +1,31 @@
+package com.moonju.preprocess.api.domain.job.dto;
+
+import com.moonju.preprocess.api.domain.job.entity.JobItemArtifactDownloadType;
+import com.moonju.preprocess.api.infra.storage.PresignedDownloadTarget;
+import java.time.Instant;
+
+public record JobItemDownloadUrlResponse(
+    Long jobId,
+    Long itemId,
+    JobItemArtifactDownloadType type,
+    String objectKey,
+    String downloadUrl,
+    Instant expiresAt
+) {
+
+    public static JobItemDownloadUrlResponse of(
+        Long jobId,
+        Long itemId,
+        JobItemArtifactDownloadType type,
+        PresignedDownloadTarget target
+    ) {
+        return new JobItemDownloadUrlResponse(
+            jobId,
+            itemId,
+            type,
+            target.objectKey(),
+            target.downloadUrl(),
+            target.expiresAt()
+        );
+    }
+}

--- a/backend-api/src/main/java/com/moonju/preprocess/api/domain/job/entity/JobItemArtifactDownloadType.java
+++ b/backend-api/src/main/java/com/moonju/preprocess/api/domain/job/entity/JobItemArtifactDownloadType.java
@@ -1,0 +1,25 @@
+package com.moonju.preprocess.api.domain.job.entity;
+
+import java.util.Locale;
+
+public enum JobItemArtifactDownloadType {
+    PROCESSED,
+    PREVIEW,
+    REPORT;
+
+    public static JobItemArtifactDownloadType from(String value) {
+        try {
+            return JobItemArtifactDownloadType.valueOf(value.toUpperCase(Locale.ROOT));
+        } catch (IllegalArgumentException | NullPointerException exception) {
+            throw new IllegalArgumentException("Unsupported job item artifact type.");
+        }
+    }
+
+    public String objectKey(JobItem item) {
+        return switch (this) {
+            case PROCESSED -> item.getProcessedObjectKey();
+            case PREVIEW -> item.getPreviewObjectKey();
+            case REPORT -> item.getReportObjectKey();
+        };
+    }
+}

--- a/backend-api/src/main/java/com/moonju/preprocess/api/domain/job/service/JobQueryService.java
+++ b/backend-api/src/main/java/com/moonju/preprocess/api/domain/job/service/JobQueryService.java
@@ -1,15 +1,24 @@
 package com.moonju.preprocess.api.domain.job.service;
 
 import com.moonju.preprocess.api.domain.job.dto.JobArtifactResponse;
+import com.moonju.preprocess.api.domain.job.dto.JobItemDownloadUrlResponse;
 import com.moonju.preprocess.api.domain.job.dto.JobItemResponse;
 import com.moonju.preprocess.api.domain.job.dto.JobResponse;
 import com.moonju.preprocess.api.domain.job.dto.JobSummaryResponse;
 import com.moonju.preprocess.api.domain.job.entity.Job;
+import com.moonju.preprocess.api.domain.job.entity.JobItem;
+import com.moonju.preprocess.api.domain.job.entity.JobItemArtifactDownloadType;
 import com.moonju.preprocess.api.domain.job.exception.JobNotFoundException;
 import com.moonju.preprocess.api.domain.job.repository.JobItemRepository;
 import com.moonju.preprocess.api.domain.job.repository.JobRepository;
 import com.moonju.preprocess.api.domain.project.service.ProjectPermissionService;
+import com.moonju.preprocess.api.global.error.BusinessException;
+import com.moonju.preprocess.api.global.error.ErrorCode;
 import com.moonju.preprocess.api.global.response.PageResponse;
+import com.moonju.preprocess.api.infra.storage.PresignedDownloadCommand;
+import com.moonju.preprocess.api.infra.storage.PresignedDownloadTarget;
+import com.moonju.preprocess.api.infra.storage.PresignedDownloadUrlGenerator;
+import java.time.Duration;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -17,18 +26,23 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 public class JobQueryService {
 
+    private static final Duration DOWNLOAD_URL_EXPIRES_IN = Duration.ofMinutes(10);
+
     private final JobRepository jobRepository;
     private final JobItemRepository jobItemRepository;
     private final ProjectPermissionService projectPermissionService;
+    private final PresignedDownloadUrlGenerator presignedDownloadUrlGenerator;
 
     public JobQueryService(
         JobRepository jobRepository,
         JobItemRepository jobItemRepository,
-        ProjectPermissionService projectPermissionService
+        ProjectPermissionService projectPermissionService,
+        PresignedDownloadUrlGenerator presignedDownloadUrlGenerator
     ) {
         this.jobRepository = jobRepository;
         this.jobItemRepository = jobItemRepository;
         this.projectPermissionService = projectPermissionService;
+        this.presignedDownloadUrlGenerator = presignedDownloadUrlGenerator;
     }
 
     @Transactional(readOnly = true)
@@ -59,6 +73,27 @@ public class JobQueryService {
     }
 
     @Transactional(readOnly = true)
+    public JobItemDownloadUrlResponse createItemArtifactDownloadUrl(
+        Long currentUserId,
+        Long jobId,
+        Long itemId,
+        String typeValue
+    ) {
+        Job job = findReadableJob(currentUserId, jobId);
+        JobItem item = jobItemRepository.findByIdAndJobId(itemId, job.getId())
+            .orElseThrow(() -> new BusinessException(ErrorCode.COMMON_NOT_FOUND, "Job item not found."));
+        JobItemArtifactDownloadType type = parseItemArtifactType(typeValue);
+        String objectKey = type.objectKey(item);
+        if (objectKey == null || objectKey.isBlank()) {
+            throw new BusinessException(ErrorCode.COMMON_NOT_FOUND, "Job item artifact is not ready.");
+        }
+        PresignedDownloadTarget target = presignedDownloadUrlGenerator.generateDownloadUrl(
+            new PresignedDownloadCommand(objectKey, DOWNLOAD_URL_EXPIRES_IN)
+        );
+        return JobItemDownloadUrlResponse.of(job.getId(), item.getId(), type, target);
+    }
+
+    @Transactional(readOnly = true)
     public Job findReadableJob(Long currentUserId, Long jobId) {
         Job job = findById(jobId);
         projectPermissionService.validateReadable(job.getProjectId(), currentUserId);
@@ -74,5 +109,13 @@ public class JobQueryService {
 
     private Job findById(Long jobId) {
         return jobRepository.findById(jobId).orElseThrow(JobNotFoundException::new);
+    }
+
+    private JobItemArtifactDownloadType parseItemArtifactType(String typeValue) {
+        try {
+            return JobItemArtifactDownloadType.from(typeValue);
+        } catch (IllegalArgumentException exception) {
+            throw new BusinessException(ErrorCode.VALIDATION_ERROR, "Unsupported job item artifact type.");
+        }
     }
 }

--- a/backend-api/src/main/java/com/moonju/preprocess/api/infra/security/RestAccessDeniedHandler.java
+++ b/backend-api/src/main/java/com/moonju/preprocess/api/infra/security/RestAccessDeniedHandler.java
@@ -1,0 +1,37 @@
+package com.moonju.preprocess.api.infra.security;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.moonju.preprocess.api.global.error.ErrorCode;
+import com.moonju.preprocess.api.global.error.ErrorResponse;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import org.springframework.http.MediaType;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+@Component
+public class RestAccessDeniedHandler implements AccessDeniedHandler {
+
+    private final ObjectMapper objectMapper;
+
+    public RestAccessDeniedHandler(ObjectMapper objectMapper) {
+        this.objectMapper = objectMapper;
+    }
+
+    @Override
+    public void handle(
+        HttpServletRequest request,
+        HttpServletResponse response,
+        AccessDeniedException accessDeniedException
+    ) throws IOException, ServletException {
+        ErrorCode errorCode = ErrorCode.COMMON_FORBIDDEN;
+        response.setStatus(errorCode.getHttpStatus().value());
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding(StandardCharsets.UTF_8.name());
+        objectMapper.writeValue(response.getWriter(), ErrorResponse.of(errorCode));
+    }
+}

--- a/backend-api/src/main/java/com/moonju/preprocess/api/infra/security/RestAuthenticationEntryPoint.java
+++ b/backend-api/src/main/java/com/moonju/preprocess/api/infra/security/RestAuthenticationEntryPoint.java
@@ -1,0 +1,37 @@
+package com.moonju.preprocess.api.infra.security;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.moonju.preprocess.api.global.error.ErrorCode;
+import com.moonju.preprocess.api.global.error.ErrorResponse;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+@Component
+public class RestAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    private final ObjectMapper objectMapper;
+
+    public RestAuthenticationEntryPoint(ObjectMapper objectMapper) {
+        this.objectMapper = objectMapper;
+    }
+
+    @Override
+    public void commence(
+        HttpServletRequest request,
+        HttpServletResponse response,
+        AuthenticationException authException
+    ) throws IOException, ServletException {
+        ErrorCode errorCode = ErrorCode.COMMON_UNAUTHORIZED;
+        response.setStatus(errorCode.getHttpStatus().value());
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding(StandardCharsets.UTF_8.name());
+        objectMapper.writeValue(response.getWriter(), ErrorResponse.of(errorCode));
+    }
+}

--- a/backend-api/src/main/java/com/moonju/preprocess/api/infra/security/SecurityConfig.java
+++ b/backend-api/src/main/java/com/moonju/preprocess/api/infra/security/SecurityConfig.java
@@ -18,15 +18,21 @@ public class SecurityConfig {
     private final OAuth2LoginSuccessHandler oauth2LoginSuccessHandler;
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
     private final WorkerAuthenticationFilter workerAuthenticationFilter;
+    private final RestAuthenticationEntryPoint restAuthenticationEntryPoint;
+    private final RestAccessDeniedHandler restAccessDeniedHandler;
 
     public SecurityConfig(
         OAuth2LoginSuccessHandler oauth2LoginSuccessHandler,
         JwtAuthenticationFilter jwtAuthenticationFilter,
-        WorkerAuthenticationFilter workerAuthenticationFilter
+        WorkerAuthenticationFilter workerAuthenticationFilter,
+        RestAuthenticationEntryPoint restAuthenticationEntryPoint,
+        RestAccessDeniedHandler restAccessDeniedHandler
     ) {
         this.oauth2LoginSuccessHandler = oauth2LoginSuccessHandler;
         this.jwtAuthenticationFilter = jwtAuthenticationFilter;
         this.workerAuthenticationFilter = workerAuthenticationFilter;
+        this.restAuthenticationEntryPoint = restAuthenticationEntryPoint;
+        this.restAccessDeniedHandler = restAccessDeniedHandler;
     }
 
     @Bean
@@ -52,6 +58,11 @@ public class SecurityConfig {
             )
             .oauth2Login(oauth2 -> oauth2
                 .successHandler(oauth2LoginSuccessHandler)
+            )
+            .exceptionHandling(exception -> exception
+                .defaultAuthenticationEntryPointFor(restAuthenticationEntryPoint, antMatcher("/api/**"))
+                .defaultAuthenticationEntryPointFor(restAuthenticationEntryPoint, antMatcher("/internal/**"))
+                .accessDeniedHandler(restAccessDeniedHandler)
             )
             .addFilterBefore(workerAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
             .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);

--- a/backend-api/src/test/java/com/moonju/preprocess/api/domain/job/service/JobQueryServiceTests.java
+++ b/backend-api/src/test/java/com/moonju/preprocess/api/domain/job/service/JobQueryServiceTests.java
@@ -1,17 +1,28 @@
 package com.moonju.preprocess.api.domain.job.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.moonju.preprocess.api.domain.job.dto.JobItemDownloadUrlResponse;
 import com.moonju.preprocess.api.domain.job.dto.JobResponse;
 import com.moonju.preprocess.api.domain.job.dto.JobSummaryResponse;
 import com.moonju.preprocess.api.domain.job.entity.Job;
+import com.moonju.preprocess.api.domain.job.entity.JobItem;
+import com.moonju.preprocess.api.domain.job.entity.JobItemArtifactDownloadType;
+import com.moonju.preprocess.api.domain.job.entity.JobItemStatus;
 import com.moonju.preprocess.api.domain.job.entity.JobPriority;
 import com.moonju.preprocess.api.domain.job.repository.JobItemRepository;
 import com.moonju.preprocess.api.domain.job.repository.JobRepository;
 import com.moonju.preprocess.api.domain.project.service.ProjectPermissionService;
+import com.moonju.preprocess.api.global.error.BusinessException;
 import com.moonju.preprocess.api.global.response.PageResponse;
+import com.moonju.preprocess.api.infra.storage.PresignedDownloadCommand;
+import com.moonju.preprocess.api.infra.storage.PresignedDownloadTarget;
+import com.moonju.preprocess.api.infra.storage.PresignedDownloadUrlGenerator;
+import java.time.Instant;
 import java.util.Map;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
@@ -34,6 +45,9 @@ class JobQueryServiceTests {
 
     @Mock
     private ProjectPermissionService projectPermissionService;
+
+    @Mock
+    private PresignedDownloadUrlGenerator presignedDownloadUrlGenerator;
 
     @InjectMocks
     private JobQueryService service;
@@ -75,10 +89,57 @@ class JobQueryServiceTests {
         assertThat(response.progressPercent()).isEqualTo(100.0);
     }
 
+    @Test
+    void createsJobItemArtifactDownloadUrl() {
+        Job job = job(1L);
+        JobItem item = succeededItem(2L, job.getId());
+        when(jobRepository.findById(1L)).thenReturn(Optional.of(job));
+        when(projectPermissionService.validateReadable(10L, 20L)).thenReturn(null);
+        when(jobItemRepository.findByIdAndJobId(2L, 1L)).thenReturn(Optional.of(item));
+        when(presignedDownloadUrlGenerator.generateDownloadUrl(any(PresignedDownloadCommand.class)))
+            .thenReturn(new PresignedDownloadTarget(
+                "processed/10/1/2/processed.png",
+                "http://localhost:9000/image-preprocess-local/processed.png",
+                Instant.parse("2026-05-15T09:00:00Z"),
+                Map.of()
+            ));
+
+        JobItemDownloadUrlResponse response = service.createItemArtifactDownloadUrl(20L, 1L, 2L, "processed");
+
+        assertThat(response.jobId()).isEqualTo(1L);
+        assertThat(response.itemId()).isEqualTo(2L);
+        assertThat(response.type()).isEqualTo(JobItemArtifactDownloadType.PROCESSED);
+        assertThat(response.downloadUrl()).contains("localhost:9000");
+    }
+
+    @Test
+    void rejectsUnsupportedJobItemArtifactType() {
+        Job job = job(1L);
+        JobItem item = succeededItem(2L, job.getId());
+        when(jobRepository.findById(1L)).thenReturn(Optional.of(job));
+        when(projectPermissionService.validateReadable(10L, 20L)).thenReturn(null);
+        when(jobItemRepository.findByIdAndJobId(2L, 1L)).thenReturn(Optional.of(item));
+
+        assertThatThrownBy(() -> service.createItemArtifactDownloadUrl(20L, 1L, 2L, "debug"))
+            .isInstanceOf(BusinessException.class)
+            .hasMessage("Unsupported job item artifact type.");
+    }
+
     private Job job(Long id) {
         Job job = Job.create(10L, 20L, "A4_SCAN_300DPI", Map.of(), false, JobPriority.NORMAL, 2);
         ReflectionTestUtils.setField(job, "id", id);
         job.markQueued(2);
         return job;
+    }
+
+    private JobItem succeededItem(Long id, Long jobId) {
+        JobItem item = new JobItem(jobId, 100L, JobItemStatus.SUCCEEDED, 1);
+        item.registerArtifacts(
+            "processed/10/1/2/processed.png",
+            "processed/10/1/2/preview.png",
+            "processed/10/1/2/processing-report.json"
+        );
+        ReflectionTestUtils.setField(item, "id", id);
+        return item;
     }
 }

--- a/backend-api/src/test/java/com/moonju/preprocess/api/infra/security/RestAccessDeniedHandlerTests.java
+++ b/backend-api/src/test/java/com/moonju/preprocess/api/infra/security/RestAccessDeniedHandlerTests.java
@@ -1,0 +1,23 @@
+package com.moonju.preprocess.api.infra.security;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.access.AccessDeniedException;
+
+class RestAccessDeniedHandlerTests {
+
+    @Test
+    void writesJsonForbiddenResponse() throws Exception {
+        RestAccessDeniedHandler handler = new RestAccessDeniedHandler(new ObjectMapper());
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        handler.handle(new MockHttpServletRequest(), response, new AccessDeniedException("denied"));
+
+        assertThat(response.getStatus()).isEqualTo(403);
+        assertThat(response.getContentAsString()).contains("\"code\":\"common403\"");
+    }
+}

--- a/backend-api/src/test/java/com/moonju/preprocess/api/infra/security/RestAuthenticationEntryPointTests.java
+++ b/backend-api/src/test/java/com/moonju/preprocess/api/infra/security/RestAuthenticationEntryPointTests.java
@@ -1,0 +1,24 @@
+package com.moonju.preprocess.api.infra.security;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.core.AuthenticationException;
+
+class RestAuthenticationEntryPointTests {
+
+    @Test
+    void writesJsonUnauthorizedResponse() throws Exception {
+        RestAuthenticationEntryPoint entryPoint = new RestAuthenticationEntryPoint(new ObjectMapper());
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        entryPoint.commence(new MockHttpServletRequest(), response, new AuthenticationException("missing") {
+        });
+
+        assertThat(response.getStatus()).isEqualTo(401);
+        assertThat(response.getContentAsString()).contains("\"code\":\"common401\"");
+    }
+}

--- a/docs/api/auth-token-flow.md
+++ b/docs/api/auth-token-flow.md
@@ -596,3 +596,18 @@ Frontend
 - frontend의 access token 저장 위치는 backend에서 강제하지 않는다.
 - cross-origin 환경에서는 refresh/logout 요청 시 cookie 전달 설정을 frontend와 CORS 정책에서 맞춰야 한다.
 
+## API 401 And Refresh Retry
+
+`/api/**` and `/internal/**` requests must not redirect to Google OAuth when authentication is missing or expired.
+Those paths return JSON `401 common401` through `RestAuthenticationEntryPoint`.
+
+Frontend behavior:
+
+1. A protected API request receives `401`.
+2. The frontend calls `POST /api/v1/auth/refresh` with `credentials: include`.
+3. If the HttpOnly refresh cookie is valid, the response body returns a new short-lived access token.
+4. The frontend stores the new access token and retries the original request once.
+5. If refresh fails, the stored access token is cleared and the user must log in again.
+
+This prevents browser `fetch` from following a backend `302` redirect to `accounts.google.com`, which would fail with a
+CORS error and surface only as `Failed to fetch` in the upload UI.

--- a/docs/api/auth-token-flow.md
+++ b/docs/api/auth-token-flow.md
@@ -154,7 +154,7 @@ tokenService.issue(user)
 
 | 토큰 | 목적 | 저장 위치 |
 | --- | --- | --- |
-| access token | 보호 API 호출 인증 | DB 저장 안 함. frontend로 전달 |
+| access token | 보호 API 호출 인증 | DB 저장 안 함. refresh API 응답으로 frontend에 전달 |
 | refresh token | 새 access token 발급 | 원문은 cookie, hash는 DB |
 
 ## Access Token 처리
@@ -206,10 +206,12 @@ JWT payload에는 다음 claim이 들어간다.
 
 ### access token 전달 방식
 
-로그인 성공 후 backend는 access token을 frontend redirect URL의 query parameter로 전달한다.
+로그인 성공 후 backend는 access token을 URL query parameter로 전달하지 않는다.
+대신 refresh token을 HttpOnly cookie로 설정하고, frontend는 OAuth success page에서 refresh API를 호출해 짧은 access token을 받는다.
 
 ```text
-{OAUTH2_SUCCESS_REDIRECT_URI}?accessToken=<jwt>&accessTokenExpiresAt=<instant>
+POST /api/v1/auth/refresh
+Cookie: refresh_token=<raw-refresh-token>
 ```
 
 로컬 기본 redirect URI는 다음이다.
@@ -221,13 +223,13 @@ http://localhost:5173/oauth2/success
 즉, Google login 완료 후 최종적으로 브라우저는 다음과 유사한 주소로 이동한다.
 
 ```text
-http://localhost:5173/oauth2/success?accessToken=<jwt>&accessTokenExpiresAt=2026-05-08T10:00:00Z
+http://localhost:5173/oauth2/success?login=success
 ```
 
 backend는 access token을 DB에 저장하지 않는다.
 
-frontend는 이 access token을 읽어서 이후 보호 API 호출에 사용해야 한다. 현재 backend 코드는 frontend가 이 값을 memory,
-session storage, local storage 중 어디에 보관할지 강제하지 않는다.
+frontend는 refresh API 응답의 access token을 이후 보호 API 호출에 사용한다. 현재 frontend는 로컬 MVP 검증을 위해
+브라우저 storage에 저장하지만, token 원문을 화면이나 URL에 노출하지 않는다.
 
 ### 보호 API에서 access token 사용
 
@@ -361,7 +363,7 @@ REFRESH_TOKEN_COOKIE_SAME_SITE=Lax
 Google 로그인 성공 후 backend 응답은 두 가지를 동시에 한다.
 
 1. `Set-Cookie`로 raw refresh token을 HttpOnly cookie에 저장한다.
-2. frontend success URL로 redirect하면서 access token을 query parameter로 넘긴다.
+2. frontend success URL로 redirect하면서 민감하지 않은 로그인 상태만 query parameter로 넘긴다.
 
 결과적으로 브라우저는 다음 상태가 된다.
 
@@ -370,7 +372,7 @@ Google 로그인 성공 후 backend 응답은 두 가지를 동시에 한다.
 refresh_token=<raw-refresh-token>; HttpOnly
 
 브라우저 주소:
-http://localhost:5173/oauth2/success?accessToken=<jwt>&accessTokenExpiresAt=<instant>
+http://localhost:5173/oauth2/success?login=success
 ```
 
 ## Access Token 재발급 흐름
@@ -552,10 +554,11 @@ TokenService
 Backend response
   -> Set-Cookie: refresh_token=<raw>; HttpOnly
   -> frontend success URL로 redirect
-  -> redirect query에 accessToken 포함
+  -> redirect query에는 login=success 같은 비민감 상태만 포함
 
 Frontend
-  -> access token을 읽어서 보호 API 호출에 사용
+  -> POST /api/v1/auth/refresh 호출
+  -> refresh API 응답의 access token을 보호 API 호출에 사용
   -> Authorization: Bearer <access-token>
   -> access token 만료 시 /api/v1/auth/refresh 호출
   -> logout 시 /api/v1/auth/logout 호출
@@ -567,7 +570,7 @@ Frontend
 | --- | --- | --- |
 | 형식 | JWT HS256 | 48 bytes random hex string |
 | 기본 수명 | 30분 | 14일 |
-| frontend 전달 | redirect query, refresh response body | HttpOnly cookie |
+| frontend 전달 | refresh response body | HttpOnly cookie |
 | DB 저장 | 저장하지 않음 | SHA-256 hash만 저장 |
 | API 사용 방식 | `Authorization: Bearer` header | browser cookie 자동 전송 |
 | refresh 시 | 새 access token 발급 | 기존 token revoke 후 새 token 발급 |

--- a/docs/api/job-api.md
+++ b/docs/api/job-api.md
@@ -48,6 +48,9 @@ All endpoints require `Authorization: Bearer <access-token>`.
 | `GET` | `/api/v1/jobs` | List my jobs |
 | `GET` | `/api/v1/jobs/{jobId}` | Read job detail |
 | `GET` | `/api/v1/jobs/{jobId}/items` | List image-level job items |
+| `GET` | `/api/v1/jobs/{jobId}/items/{itemId}/download?type=processed` | Create processed image download URL |
+| `GET` | `/api/v1/jobs/{jobId}/items/{itemId}/download?type=preview` | Create preview image download URL |
+| `GET` | `/api/v1/jobs/{jobId}/items/{itemId}/download?type=report` | Create processing report download URL |
 | `GET` | `/api/v1/jobs/{jobId}/summary` | Read progress counters |
 | `GET` | `/api/v1/jobs/{jobId}/events` | Subscribe to progress SSE stream |
 | `POST` | `/api/v1/jobs/{jobId}/cancel` | Request cancellation |
@@ -150,6 +153,41 @@ GET /api/v1/jobs/{jobId}/items?page=0&size=50
 ```
 
 `GET /api/v1/jobs` lists jobs created by the current user. Detail and item APIs validate project read permission.
+
+## JobItem Artifact Download
+
+```text
+GET /api/v1/jobs/{jobId}/items/{itemId}/download?type=processed
+GET /api/v1/jobs/{jobId}/items/{itemId}/download?type=preview
+GET /api/v1/jobs/{jobId}/items/{itemId}/download?type=report
+```
+
+The API validates that the current user can read the Job's project, finds the requested JobItem, maps the requested
+artifact type to the Worker-registered object key, and returns a temporary Object Storage download URL.
+
+Response:
+
+```json
+{
+  "isSuccess": true,
+  "code": "common200",
+  "message": "Request succeeded.",
+  "result": {
+    "jobId": 1,
+    "itemId": 10,
+    "type": "PROCESSED",
+    "objectKey": "processed/1/1/10/processed.png",
+    "downloadUrl": "http://localhost:9000/image-preprocess-local/processed/1/1/10/processed.png?...",
+    "expiresAt": "2026-05-15T09:00:00Z"
+  }
+}
+```
+
+Rules:
+
+- `type` must be one of `processed`, `preview`, or `report`.
+- If the Worker has not registered the requested object key yet, the API returns `common404`.
+- Debug artifact expansion remains separate from this JobItem-level result download flow.
 
 ## Summary
 

--- a/docs/api/swagger-openapi.md
+++ b/docs/api/swagger-openapi.md
@@ -66,11 +66,13 @@ Expected result:
 1. Start the backend.
 2. Open `http://localhost:8080/oauth2/authorization/google`.
 3. Complete Google login.
-4. Copy the `accessToken` query parameter from the OAuth success redirect URL.
-5. Open `http://localhost:8080/swagger-ui/index.html`.
-6. Click `Authorize`.
-7. Paste only the access token value.
-8. Run protected endpoints such as `GET /api/v1/auth/me` or `GET /api/v1/projects`.
+4. The backend redirects to the configured OAuth success URL without exposing the access token in the URL.
+5. Use the frontend OAuth success page to refresh and store the short-lived access token, or call
+   `POST /api/v1/auth/refresh` from a client that includes the `refresh_token` cookie.
+6. Open `http://localhost:8080/swagger-ui/index.html`.
+7. Click `Authorize`.
+8. Paste only the access token value.
+9. Run protected endpoints such as `GET /api/v1/auth/me` or `GET /api/v1/projects`.
 
 Do not paste the `Bearer ` prefix. Swagger applies the Bearer scheme automatically.
 

--- a/docs/feature-specs/issue-83-local-mvp-image-preprocess-smoke-flow.md
+++ b/docs/feature-specs/issue-83-local-mvp-image-preprocess-smoke-flow.md
@@ -25,7 +25,8 @@ The smoke flow is still OCR preprocessing only. It does not run OCR text extract
 ```text
 Browser
   -> /oauth2/authorization/google
-  -> /oauth2/success?accessToken=...
+  -> /oauth2/success?login=success
+  -> POST /api/v1/auth/refresh
   -> /upload
   -> POST /api/v1/projects
   -> POST /api/v1/projects/{projectId}/upload-sessions
@@ -92,6 +93,6 @@ The summary API currently returns counts and progress percentage, not a textual 
 
 ## Known Limits
 
-1. The smoke page is intentionally minimal and not a full production upload UI.
-2. Result image preview/download UI is not included yet; object keys are displayed for MinIO verification.
+1. The original issue 83 smoke page handled one image. Issue 85 extends this into a multi-image batch upload console.
+2. Result image preview/download UI was completed after the original smoke page and is extended per item in issue 85.
 3. SSE still needs an auth-compatible frontend integration. This page uses polling for local smoke verification.

--- a/docs/feature-specs/issue-85-batch-upload-secure-saas-ux.md
+++ b/docs/feature-specs/issue-85-batch-upload-secure-saas-ux.md
@@ -90,12 +90,13 @@ The Worker stores result object keys on each `JobItem` after preprocessing succe
 - `previewObjectKey`
 - `reportObjectKey`
 
-The batch console does not access MinIO object keys directly. It calls:
+The API still supports item-level artifact download URLs for internal verification. The batch console only exposes the
+processed image download to users and does not surface preview or report downloads as final results.
+
+The batch console does not access MinIO object keys directly. It calls the processed endpoint:
 
 ```text
 GET /api/v1/jobs/{jobId}/items/{itemId}/download?type=processed
-GET /api/v1/jobs/{jobId}/items/{itemId}/download?type=preview
-GET /api/v1/jobs/{jobId}/items/{itemId}/download?type=report
 ```
 
 The API validates project read permission and returns a temporary presigned download URL for the selected artifact.
@@ -108,7 +109,7 @@ The API validates project read permission and returns a temporary presigned down
 4. NGINX routes exact `/oauth2/success` to the frontend while keeping `/oauth2/authorization/google` on backend-api.
 5. The frontend can run a multi-image batch through the existing backend API and Worker.
 6. The UI shows selected file count, total size, job progress, and item-level artifact downloads.
-7. Processed image, preview, and report buttons open temporary download URLs returned by the API.
+7. The batch console exposes only processed image downloads as user-facing results.
 8. The sidebar shows either a Google sign-in action or the current account identity and sign-out action.
 
 ## Sidebar Account UX

--- a/docs/feature-specs/issue-85-batch-upload-secure-saas-ux.md
+++ b/docs/feature-specs/issue-85-batch-upload-secure-saas-ux.md
@@ -37,6 +37,7 @@ Reference URLs:
 10. Poll job summary and item list, then display per-item artifact download actions.
 11. Refresh the frontend visual system into a SaaS-style batch operations console.
 12. Add the JobItem artifact download API used by the batch console for processed image, preview, and report links.
+13. Move sign-in and signed-in account controls to the bottom of the sidebar instead of a primary login dashboard link.
 
 ## Updated OAuth Flow
 
@@ -108,6 +109,21 @@ The API validates project read permission and returns a temporary presigned down
 5. The frontend can run a multi-image batch through the existing backend API and Worker.
 6. The UI shows selected file count, total size, job progress, and item-level artifact downloads.
 7. Processed image, preview, and report buttons open temporary download URLs returned by the API.
+8. The sidebar shows either a Google sign-in action or the current account identity and sign-out action.
+
+## Sidebar Account UX
+
+The app keeps `/login` as a fallback route, but it is not shown in the primary navigation. The left sidebar owns the
+normal authentication entry point:
+
+```text
+unauthenticated -> bottom sidebar "Continue with Google"
+authenticated   -> bottom sidebar avatar, name/email, sign out
+```
+
+The sidebar reads `GET /api/v1/auth/me` through the shared API client. If the stored access token is expired, the client
+uses the HttpOnly refresh cookie through `POST /api/v1/auth/refresh` and retries once. Token values are not rendered in
+the sidebar, upload page, OAuth success page, or browser URL.
 
 ## Local Static Cache Policy
 

--- a/docs/feature-specs/issue-85-batch-upload-secure-saas-ux.md
+++ b/docs/feature-specs/issue-85-batch-upload-secure-saas-ux.md
@@ -124,3 +124,10 @@ visible immediately after a Docker rebuild.
 The upload console wraps each workflow step with a step label before surfacing an error. Object Storage upload failures
 also include the page origin and target origin so local CORS/proxy issues can be diagnosed from the screen without
 opening server logs.
+
+API authentication failures are handled as JSON responses. `/api/**` must not redirect to Google OAuth because browser
+`fetch` would follow the redirect to `accounts.google.com` and fail with a CORS error. When a protected API returns
+`401`, the frontend refreshes the access token once through `POST /api/v1/auth/refresh` and retries the original request.
+
+The backend enforces this with `RestAuthenticationEntryPoint` for `/api/**` and `/internal/**` so expired access tokens
+return JSON `401 common401` instead of OAuth redirects.

--- a/docs/feature-specs/issue-85-batch-upload-secure-saas-ux.md
+++ b/docs/feature-specs/issue-85-batch-upload-secure-saas-ux.md
@@ -36,6 +36,7 @@ Reference URLs:
 9. Resolve newly created image metadata rows and create one preprocessing job with multiple `imageIds`.
 10. Poll job summary and item list, then display per-item artifact download actions.
 11. Refresh the frontend visual system into a SaaS-style batch operations console.
+12. Add the JobItem artifact download API used by the batch console for processed image, preview, and report links.
 
 ## Updated OAuth Flow
 
@@ -71,6 +72,24 @@ Browser
   -> GET /api/v1/jobs/{jobId}/items/{itemId}/download?type=processed|preview|report
 ```
 
+## JobItem Artifact Download
+
+The Worker stores result object keys on each `JobItem` after preprocessing succeeds:
+
+- `processedObjectKey`
+- `previewObjectKey`
+- `reportObjectKey`
+
+The batch console does not access MinIO object keys directly. It calls:
+
+```text
+GET /api/v1/jobs/{jobId}/items/{itemId}/download?type=processed
+GET /api/v1/jobs/{jobId}/items/{itemId}/download?type=preview
+GET /api/v1/jobs/{jobId}/items/{itemId}/download?type=report
+```
+
+The API validates project read permission and returns a temporary presigned download URL for the selected artifact.
+
 ## Completion Criteria
 
 1. The upload page accepts multiple images.
@@ -79,6 +98,7 @@ Browser
 4. NGINX routes exact `/oauth2/success` to the frontend while keeping `/oauth2/authorization/google` on backend-api.
 5. The frontend can run a multi-image batch through the existing backend API and Worker.
 6. The UI shows selected file count, total size, job progress, and item-level artifact downloads.
+7. Processed image, preview, and report buttons open temporary download URLs returned by the API.
 
 ## Local Static Cache Policy
 

--- a/docs/feature-specs/issue-85-batch-upload-secure-saas-ux.md
+++ b/docs/feature-specs/issue-85-batch-upload-secure-saas-ux.md
@@ -76,5 +76,6 @@ Browser
 1. The upload page accepts multiple images.
 2. Access token raw value is not rendered in the UI.
 3. OAuth success URL no longer contains `accessToken`.
-4. The frontend can run a multi-image batch through the existing backend API and Worker.
-5. The UI shows selected file count, total size, job progress, and item-level artifact downloads.
+4. NGINX routes exact `/oauth2/success` to the frontend while keeping `/oauth2/authorization/google` on backend-api.
+5. The frontend can run a multi-image batch through the existing backend API and Worker.
+6. The UI shows selected file count, total size, job progress, and item-level artifact downloads.

--- a/docs/feature-specs/issue-85-batch-upload-secure-saas-ux.md
+++ b/docs/feature-specs/issue-85-batch-upload-secure-saas-ux.md
@@ -1,0 +1,80 @@
+# Issue 85. Batch Upload And Secure SaaS Upload UX
+
+## Goal
+
+Extend the local MVP upload screen from a single-image smoke flow to a batch upload console and remove access token
+exposure from the OAuth success URL and upload UI.
+
+The feature is still OCR preprocessing only. It does not run OCR text extraction.
+
+## Design References
+
+The UI direction follows common SaaS dashboard patterns without copying a specific product:
+
+1. Vercel dashboard documentation: scope-aware dashboard, activity/status surfaces, and recent item panels.
+2. Vercel dashboard redesign notes: fast access to important project status and deployment-like status cards.
+3. Linear dashboards documentation: metric blocks, tables, filters, and high-level plus drill-down views.
+4. Dropbox upload documentation: web upload supports selecting multiple files in a single upload action.
+
+Reference URLs:
+
+- `https://vercel.com/docs/concepts/dashboard-features`
+- `https://vercel.com/blog/dashboard-redesign`
+- `https://linear.app/docs/dashboards`
+- `https://help.dropbox.com/create-upload/add-files`
+
+## Scope
+
+1. Remove the visible access token input from `/upload`.
+2. Remove access token query parameters from OAuth success redirects.
+3. Let `OAuthSuccessPage` obtain an access token through `POST /api/v1/auth/refresh` using the HttpOnly refresh cookie.
+4. Support selecting multiple document image files in `/upload`.
+5. Create one upload session with `expectedFileCount = selectedFiles.length`.
+6. Request presigned upload URLs for all selected files in one API call.
+7. Upload all selected original files directly to MinIO.
+8. Complete the upload session with all issued upload file IDs.
+9. Resolve newly created image metadata rows and create one preprocessing job with multiple `imageIds`.
+10. Poll job summary and item list, then display per-item artifact download actions.
+11. Refresh the frontend visual system into a SaaS-style batch operations console.
+
+## Updated OAuth Flow
+
+```text
+Browser
+  -> /oauth2/authorization/google
+  -> /login/oauth2/code/google
+  -> backend sets refresh_token HttpOnly cookie
+  -> backend redirects to /oauth2/success?login=success
+  -> frontend calls POST /api/v1/auth/refresh with credentials
+  -> backend rotates refresh token cookie and returns a short-lived access token
+  -> frontend stores the access token for API calls
+```
+
+If an older backend still redirects with `accessToken` in the URL, the frontend stores it and immediately removes the
+token query parameters with `history.replaceState`.
+
+## Batch Upload Flow
+
+```text
+Browser
+  -> select N images
+  -> POST /api/v1/projects or reuse selected project
+  -> GET /api/v1/projects/{projectId}/images
+  -> POST /api/v1/projects/{projectId}/upload-sessions
+  -> POST /api/v1/upload-sessions/{sessionId}/files/presigned-url with N files
+  -> PUT each file to MinIO presigned URL
+  -> POST /api/v1/upload-sessions/{sessionId}/complete with N uploadFileIds
+  -> GET /api/v1/projects/{projectId}/images
+  -> POST /api/v1/jobs with N imageIds
+  -> GET /api/v1/jobs/{jobId}/summary
+  -> GET /api/v1/jobs/{jobId}/items
+  -> GET /api/v1/jobs/{jobId}/items/{itemId}/download?type=processed|preview|report
+```
+
+## Completion Criteria
+
+1. The upload page accepts multiple images.
+2. Access token raw value is not rendered in the UI.
+3. OAuth success URL no longer contains `accessToken`.
+4. The frontend can run a multi-image batch through the existing backend API and Worker.
+5. The UI shows selected file count, total size, job progress, and item-level artifact downloads.

--- a/docs/feature-specs/issue-85-batch-upload-secure-saas-ux.md
+++ b/docs/feature-specs/issue-85-batch-upload-secure-saas-ux.md
@@ -79,3 +79,13 @@ Browser
 4. NGINX routes exact `/oauth2/success` to the frontend while keeping `/oauth2/authorization/google` on backend-api.
 5. The frontend can run a multi-image batch through the existing backend API and Worker.
 6. The UI shows selected file count, total size, job progress, and item-level artifact downloads.
+
+## Local Static Cache Policy
+
+The local frontend container disables long-lived caching for the SPA shell so OAuth callback and upload UI changes are
+visible immediately after a Docker rebuild.
+
+- `index.html` and fallback SPA routes use `Cache-Control: no-store, no-cache, must-revalidate`.
+- `/assets/*` uses `Cache-Control: no-cache, must-revalidate`.
+- This is a local verification policy. A production deployment can later use immutable hashed assets after the release
+  pipeline guarantees content hashes change for every changed bundle.

--- a/docs/feature-specs/issue-85-batch-upload-secure-saas-ux.md
+++ b/docs/feature-specs/issue-85-batch-upload-secure-saas-ux.md
@@ -72,6 +72,15 @@ Browser
   -> GET /api/v1/jobs/{jobId}/items/{itemId}/download?type=processed|preview|report
 ```
 
+In local Docker Compose, generated MinIO presigned URLs use the NGINX single entry point:
+
+```text
+http://localhost/image-preprocess-local/{objectKey}
+```
+
+NGINX proxies that bucket path to `minio:9000`. This keeps the upload request on the same browser origin as the
+frontend and removes local CORS/port issues from the manual upload test path.
+
 ## JobItem Artifact Download
 
 The Worker stores result object keys on each `JobItem` after preprocessing succeeds:
@@ -109,3 +118,9 @@ visible immediately after a Docker rebuild.
 - `/assets/*` uses `Cache-Control: no-cache, must-revalidate`.
 - This is a local verification policy. A production deployment can later use immutable hashed assets after the release
   pipeline guarantees content hashes change for every changed bundle.
+
+## Frontend Failure Diagnostics
+
+The upload console wraps each workflow step with a step label before surfacing an error. Object Storage upload failures
+also include the page origin and target origin so local CORS/proxy issues can be diagnosed from the screen without
+opening server logs.

--- a/docs/operation/storage-operation.md
+++ b/docs/operation/storage-operation.md
@@ -53,13 +53,26 @@ The local backend uses the same MinIO bucket as the Worker:
 - `MinioObjectStorageAdapter`
 - `StorageProperties`
 
-The adapter signs upload/download URLs with `storage.public-endpoint` so browser uploads can use `localhost`, while
-object existence checks use `storage.endpoint` so backend-api can reach MinIO inside Docker.
+The adapter signs upload/download URLs with `storage.public-endpoint` so browser uploads can use the public local entry
+point, while object existence checks use `storage.endpoint` so backend-api can reach MinIO inside Docker.
+
+In Docker Compose local mode, `MINIO_PUBLIC_ENDPOINT` is set to `http://localhost` and NGINX proxies the local bucket
+path to MinIO:
+
+```text
+Browser
+  -> http://localhost/image-preprocess-local/{objectKey}
+  -> NGINX
+  -> minio:9000
+```
+
+This keeps browser uploads on the same origin as the frontend and avoids local CORS or blocked-port failures during
+manual testing. MinIO is still exposed on `http://localhost:9000` for console/API debugging.
 
 For local browser uploads, MinIO must also allow the frontend origin:
 
 ```text
-MINIO_API_CORS_ALLOW_ORIGIN=http://localhost,http://localhost:5173
+MINIO_API_CORS_ALLOW_ORIGIN=http://localhost,http://localhost:5173,http://127.0.0.1,http://127.0.0.1:5173
 ```
 
 The local smoke flow verifies presigned PUT CORS with an `OPTIONS` preflight before uploading the image body.

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -5,13 +5,19 @@ server {
     root /usr/share/nginx/html;
     index index.html;
 
+    location = /index.html {
+        add_header Cache-Control "no-store, no-cache, must-revalidate" always;
+        try_files /index.html =404;
+    }
+
     location /assets/ {
         try_files $uri =404;
-        expires 1h;
-        add_header Cache-Control "public" always;
+        expires off;
+        add_header Cache-Control "no-cache, must-revalidate" always;
     }
 
     location / {
+        add_header Cache-Control "no-store, no-cache, must-revalidate" always;
         try_files $uri $uri/ /index.html;
     }
 }

--- a/frontend/src/app/App.tsx
+++ b/frontend/src/app/App.tsx
@@ -1,5 +1,17 @@
+import { useEffect, useState } from 'react';
 import { AppProviders } from './providers';
 import { resolveRoute, routes } from './routes';
+import { apiClient } from '../shared/api/apiClient';
+import { clearAccessToken, readStoredAccessToken } from '../shared/auth/accessTokenStore';
+
+type CurrentUser = {
+  id: number;
+  email: string;
+  name: string;
+  profileImageUrl?: string | null;
+  role: string;
+  providers: string[];
+};
 
 export function App() {
   const route = resolveRoute(window.location.pathname);
@@ -24,6 +36,7 @@ export function App() {
                 </a>
               ))}
           </nav>
+          <SidebarAccount />
         </aside>
         <main className="content">
           <div className="topbar">
@@ -38,5 +51,89 @@ export function App() {
         </main>
       </div>
     </AppProviders>
+  );
+}
+
+function SidebarAccount() {
+  const [currentUser, setCurrentUser] = useState<CurrentUser | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [logoutPending, setLogoutPending] = useState(false);
+
+  useEffect(() => {
+    let mounted = true;
+    apiClient
+      .get<CurrentUser>('/v1/auth/me', readStoredAccessToken())
+      .then((response) => {
+        if (mounted) {
+          setCurrentUser(response.result);
+        }
+      })
+      .catch(() => {
+        if (mounted) {
+          setCurrentUser(null);
+        }
+      })
+      .finally(() => {
+        if (mounted) {
+          setLoading(false);
+        }
+      });
+
+    return () => {
+      mounted = false;
+    };
+  }, []);
+
+  const logout = async () => {
+    setLogoutPending(true);
+    try {
+      await apiClient.post('/v1/auth/logout', {}, readStoredAccessToken());
+    } catch {
+      // The local token must still be cleared even if the refresh cookie already expired.
+    } finally {
+      clearAccessToken();
+      window.location.href = '/';
+    }
+  };
+
+  if (loading) {
+    return (
+      <section className="sidebar-account" aria-label="Account">
+        <span className="account-state">Checking session</span>
+      </section>
+    );
+  }
+
+  if (!currentUser) {
+    return (
+      <section className="sidebar-account" aria-label="Account">
+        <span className="account-state">Not signed in</span>
+        <a className="account-login" href="/oauth2/authorization/google">
+          Continue with Google
+        </a>
+      </section>
+    );
+  }
+
+  const displayName = currentUser.name || currentUser.email;
+  const initials = displayName.slice(0, 2).toUpperCase();
+
+  return (
+    <section className="sidebar-account" aria-label="Account">
+      <div className="account-card">
+        {currentUser.profileImageUrl ? (
+          <img className="account-avatar" src={currentUser.profileImageUrl} alt="" referrerPolicy="no-referrer" />
+        ) : (
+          <span className="account-avatar">{initials}</span>
+        )}
+        <span className="account-copy">
+          <strong>{displayName}</strong>
+          <small>{currentUser.email}</small>
+        </span>
+      </div>
+      <button className="text-action" type="button" onClick={logout} disabled={logoutPending}>
+        {logoutPending ? 'Signing out...' : 'Sign out'}
+      </button>
+    </section>
   );
 }

--- a/frontend/src/app/App.tsx
+++ b/frontend/src/app/App.tsx
@@ -11,8 +11,8 @@ export function App() {
           <a className="brand" href="/">
             <span className="brand-mark">DP</span>
             <span>
-              <strong>Doc Pipeline</strong>
-              <small>OCR preprocessing</small>
+              <strong>DocPrep Cloud</strong>
+              <small>document intelligence ops</small>
             </span>
           </a>
           <nav className="nav-list">
@@ -26,6 +26,10 @@ export function App() {
           </nav>
         </aside>
         <main className="content">
+          <div className="topbar">
+            <span>Local MVP</span>
+            <strong>Queue-backed preprocessing workspace</strong>
+          </div>
           <header className="page-header">
             <p className="eyebrow">Large-scale document image preprocessing</p>
             <h1>{route.label}</h1>

--- a/frontend/src/app/routes.tsx
+++ b/frontend/src/app/routes.tsx
@@ -18,7 +18,7 @@ export type AppRoute = {
 
 export const routes: AppRoute[] = [
   { path: '/', label: 'Dashboard', element: <DashboardPage /> },
-  { path: '/login', label: 'Login', element: <LoginPage /> },
+  { path: '/login', label: 'Login', element: <LoginPage />, showInNav: false },
   { path: '/oauth2/success', label: 'OAuth Success', element: <OAuthSuccessPage />, showInNav: false },
   { path: '/projects', label: 'Projects', element: <ProjectListPage /> },
   { path: '/projects/:projectId', label: 'Project Detail', element: <ProjectDetailPage /> },

--- a/frontend/src/features/auth/GoogleLoginButton.tsx
+++ b/frontend/src/features/auth/GoogleLoginButton.tsx
@@ -1,7 +1,7 @@
 export function GoogleLoginButton() {
   return (
     <a className="primary-action" href="/oauth2/authorization/google">
-      Continue with Google
+      Continue securely with Google
     </a>
   );
 }

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -4,8 +4,8 @@ import { PageSection } from '../shared/components/PageSection';
 export function LoginPage() {
   return (
     <PageSection
-      title="Google sign-in"
-      description="Authenticate through the backend OAuth endpoint. Only Google login is exposed."
+      title="Secure workspace access"
+      description="Sign in through Google. The refresh token is kept in an HttpOnly cookie and the access token is no longer shown in the URL or UI."
     >
       <GoogleLoginButton />
     </PageSection>

--- a/frontend/src/pages/OAuthSuccessPage.tsx
+++ b/frontend/src/pages/OAuthSuccessPage.tsx
@@ -1,20 +1,50 @@
+import { useEffect, useState } from 'react';
+import { apiClient } from '../shared/api/apiClient';
+import { storeAccessToken } from '../shared/auth/accessTokenStore';
 import { PageSection } from '../shared/components/PageSection';
 import { useAccessToken } from '../shared/hooks/useAccessToken';
 
+type TokenRefreshResponse = {
+  accessToken: string;
+  accessTokenExpiresAt: string;
+};
+
 export function OAuthSuccessPage() {
-  const { accessToken } = useAccessToken();
+  const { accessToken, setAccessToken } = useAccessToken();
+  const [status, setStatus] = useState(accessToken ? 'Session secured.' : 'Securing session...');
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (accessToken) {
+      return;
+    }
+    apiClient.post<TokenRefreshResponse>('/v1/auth/refresh', {})
+      .then((response) => {
+        storeAccessToken(response.result.accessToken);
+        setAccessToken(response.result.accessToken);
+        setStatus('Session secured.');
+      })
+      .catch((exception) => {
+        setError(exception instanceof Error ? exception.message : 'Failed to secure the OAuth session.');
+        setStatus('Session setup failed.');
+      });
+  }, [accessToken, setAccessToken]);
 
   return (
     <PageSection
-      title="OAuth callback"
-      description="Placeholder for accepting the short-lived access token and loading the current user profile."
+      title="Session handoff"
+      description="The refresh cookie is used to mint a short-lived access token without exposing it in the address bar."
     >
-      <div className="status-card">
-        <strong>Access token</strong>
-        <span>{accessToken ? 'saved to this browser' : 'missing'}</span>
+      <div className={`status-card ${error ? 'error' : ''}`}>
+        <strong>{status}</strong>
+        <span>
+          {error
+            ? error
+            : 'The token value is hidden from the UI and removed from the URL immediately if an older redirect includes it.'}
+        </span>
       </div>
       <a className="primary-action" href="/upload">
-        Start local smoke test
+        Open batch upload
       </a>
     </PageSection>
   );

--- a/frontend/src/pages/UploadPage.tsx
+++ b/frontend/src/pages/UploadPage.tsx
@@ -146,33 +146,36 @@ export function UploadPage() {
       const project = await ensureProject();
       appendLog(`Project ready: ${project.name} (#${project.id})`);
 
-      const existingImageIds = await loadExistingImageIds(project.id);
-      const hashedFiles = await hashSelectedFiles();
+      const existingImageIds = await runStep('Load existing project images', () => loadExistingImageIds(project.id));
+      const hashedFiles = await runStep('Calculate SHA-256 checksums', () => hashSelectedFiles());
       appendLog(`SHA-256 calculated for ${hashedFiles.length} files.`);
 
-      const session = await createUploadSession(project, selectedFiles);
+      const session = await runStep('Create upload session', () => createUploadSession(project, selectedFiles));
       appendLog(`Upload session created: #${session.id}`);
 
-      const uploadTargets = await createPresignedTargets(session, hashedFiles);
+      const uploadTargets = await runStep('Issue presigned upload URLs', () => createPresignedTargets(session, hashedFiles));
       appendLog(`Presigned upload URLs issued: ${uploadTargets.length}`);
 
-      await uploadFilesToObjectStorage(uploadTargets);
+      await runStep('Upload originals to object storage', () => uploadFilesToObjectStorage(uploadTargets));
       appendLog('Original images uploaded to MinIO.');
 
-      await completeUpload(session, uploadTargets.map((target) => target.uploadFileId));
+      await runStep('Complete upload session', () => completeUpload(session, uploadTargets.map((target) => target.uploadFileId)));
       appendLog('Upload session completed.');
 
-      const images = await findCreatedImages(project.id, selectedFiles, existingImageIds);
+      const images = await runStep(
+        'Resolve uploaded image metadata',
+        () => findCreatedImages(project.id, selectedFiles, existingImageIds)
+      );
       appendLog(`Image metadata created: ${images.length}`);
 
-      const job = await createJob(project, images);
+      const job = await runStep('Create preprocessing job', () => createJob(project, images));
       appendLog(`Preprocess job queued: #${job.jobId} (${job.totalImages} images)`);
 
       const smokeResult: SmokeResult = { project, images, job };
       setResult(smokeResult);
-      await pollJob(job.jobId, smokeResult);
+      await runStep('Poll preprocessing job', () => pollJob(job.jobId, smokeResult));
     } catch (exception) {
-      setError(exception instanceof Error ? exception.message : 'Batch preprocess flow failed.');
+      setError(describeError(exception, 'Batch preprocess flow failed.'));
     } finally {
       setBusy(false);
     }
@@ -261,11 +264,7 @@ export function UploadPage() {
     await Promise.all(
       targets.map(async (target) => {
         updateFileRow(target.entry.key, { phase: 'uploading', detail: 'Uploading original' });
-        const response = await fetch(target.uploadUrl, {
-          method: 'PUT',
-          headers: target.requiredHeaders,
-          body: target.entry.file
-        });
+        const response = await uploadFile(target);
         if (!response.ok) {
           updateFileRow(target.entry.key, { phase: 'failed', detail: `HTTP ${response.status}` });
           throw new Error(`MinIO upload failed for ${target.entry.file.name} with HTTP ${response.status}.`);
@@ -396,6 +395,26 @@ export function UploadPage() {
 
   function appendLog(message: string) {
     setLogs((previous) => [...previous, `${new Date().toLocaleTimeString()} ${message}`]);
+  }
+
+  async function uploadFile(
+    target: PresignedUploadUrlResponse['uploadTargets'][number] & { entry: SelectedUploadFile }
+  ) {
+    try {
+      return await fetch(target.uploadUrl, {
+        method: 'PUT',
+        headers: target.requiredHeaders,
+        body: target.entry.file
+      });
+    } catch (exception) {
+      updateFileRow(target.entry.key, { phase: 'failed', detail: 'Network/CORS failure' });
+      const targetOrigin = safeOrigin(target.uploadUrl);
+      throw new Error(
+        `Object storage upload request failed for ${target.entry.file.name}. `
+        + `pageOrigin=${window.location.origin}, targetOrigin=${targetOrigin}. `
+        + describeError(exception, 'Browser fetch failed.')
+      );
+    }
   }
 
   return (
@@ -594,6 +613,29 @@ export function UploadPage() {
       )}
     </div>
   );
+}
+
+async function runStep<T>(stepName: string, action: () => Promise<T>): Promise<T> {
+  try {
+    return await action();
+  } catch (exception) {
+    throw new Error(`${stepName} failed. ${describeError(exception, 'Unknown error.')}`);
+  }
+}
+
+function describeError(exception: unknown, fallback: string) {
+  if (exception instanceof Error && exception.message) {
+    return exception.message;
+  }
+  return fallback;
+}
+
+function safeOrigin(url: string) {
+  try {
+    return new URL(url).origin;
+  } catch {
+    return 'invalid-url';
+  }
 }
 
 function MetricCard({ label, value, detail }: { label: string; value: string; detail: string }) {

--- a/frontend/src/pages/UploadPage.tsx
+++ b/frontend/src/pages/UploadPage.tsx
@@ -425,7 +425,7 @@ export function UploadPage() {
           <h2>Prepare scanned documents for OCR at queue scale.</h2>
           <p>
             Upload multiple scans, let the API create one JobItem per image, and watch the Worker produce processed
-            images, previews, reports, and optional debug artifacts.
+            images that can be downloaded as the final output.
           </p>
         </div>
         <div className="session-card">
@@ -439,7 +439,7 @@ export function UploadPage() {
         <div className="status-card warning">
           <strong>Google session required</strong>
           <span>Sign in first. The OAuth callback now refreshes the access token without exposing it in the URL.</span>
-          <a className="primary-action" href="/login">Go to login</a>
+          <a className="primary-action" href="/oauth2/authorization/google">Continue with Google</a>
         </div>
       )}
 
@@ -566,7 +566,7 @@ export function UploadPage() {
         <section className="artifact-board">
           <div>
             <span className="status-pill accent">Results</span>
-            <h2>Worker artifacts</h2>
+            <h2>Processed images</h2>
           </div>
           <div className="artifact-grid">
             {result.items.map((item) => (
@@ -578,8 +578,6 @@ export function UploadPage() {
                 <small>Image #{item.imageId}</small>
                 {item.errorMessage && <span className="error-text">{item.errorCode}: {item.errorMessage}</span>}
                 {item.processedObjectKey && <code>{item.processedObjectKey}</code>}
-                {item.previewObjectKey && <code>{item.previewObjectKey}</code>}
-                {item.reportObjectKey && <code>{item.reportObjectKey}</code>}
                 <div className="download-actions">
                   <button
                     type="button"
@@ -587,23 +585,7 @@ export function UploadPage() {
                     disabled={!item.processedObjectKey}
                     onClick={() => downloadArtifact(item, 'processed')}
                   >
-                    Processed
-                  </button>
-                  <button
-                    type="button"
-                    className="secondary-action"
-                    disabled={!item.previewObjectKey}
-                    onClick={() => downloadArtifact(item, 'preview')}
-                  >
-                    Preview
-                  </button>
-                  <button
-                    type="button"
-                    className="secondary-action"
-                    disabled={!item.reportObjectKey}
-                    onClick={() => downloadArtifact(item, 'report')}
-                  >
-                    Report
+                    Download processed image
                   </button>
                 </div>
               </div>

--- a/frontend/src/pages/UploadPage.tsx
+++ b/frontend/src/pages/UploadPage.tsx
@@ -1,4 +1,4 @@
-import { FormEvent, useEffect, useState } from 'react';
+import { FormEvent, useEffect, useMemo, useState } from 'react';
 import { apiClient } from '../shared/api/apiClient';
 import { readStoredAccessToken } from '../shared/auth/accessTokenStore';
 import { PageSection } from '../shared/components/PageSection';
@@ -60,25 +60,56 @@ type JobItemResponse = {
   errorMessage?: string;
 };
 
+type JobItemDownloadUrlResponse = {
+  jobId: number;
+  itemId: number;
+  type: 'processed' | 'preview' | 'report';
+  objectKey: string;
+  downloadUrl: string;
+  expiresAt: string;
+};
+
+type SelectedUploadFile = {
+  key: string;
+  file: File;
+};
+
+type FilePhase = 'selected' | 'hashing' | 'ready' | 'uploading' | 'uploaded' | 'completed' | 'failed';
+
+type FileUploadRow = {
+  key: string;
+  name: string;
+  size: number;
+  phase: FilePhase;
+  detail?: string;
+};
+
 type SmokeResult = {
   project?: ProjectResponse;
-  image?: ImageListResponse;
+  images?: ImageListResponse[];
   job?: JobCreateResponse;
   summary?: JobSummaryResponse;
   items?: JobItemResponse[];
 };
 
 export function UploadPage() {
-  const [accessToken, setAccessToken] = useState(() => readStoredAccessToken() ?? '');
+  const [accessToken] = useState(() => readStoredAccessToken() ?? '');
   const [projects, setProjects] = useState<ProjectResponse[]>([]);
   const [projectId, setProjectId] = useState('');
-  const [projectName, setProjectName] = useState(() => `Local smoke ${new Date().toLocaleString()}`);
-  const [file, setFile] = useState<File | null>(null);
+  const [projectName, setProjectName] = useState(() => `Batch ingest ${new Date().toLocaleString()}`);
+  const [selectedFiles, setSelectedFiles] = useState<SelectedUploadFile[]>([]);
+  const [fileRows, setFileRows] = useState<FileUploadRow[]>([]);
   const [debug, setDebug] = useState(true);
   const [busy, setBusy] = useState(false);
   const [logs, setLogs] = useState<string[]>([]);
   const [result, setResult] = useState<SmokeResult>({});
   const [error, setError] = useState<string | null>(null);
+
+  const totalSize = useMemo(
+    () => selectedFiles.reduce((sum, entry) => sum + entry.file.size, 0),
+    [selectedFiles]
+  );
+  const completedItems = result.summary ? result.summary.succeeded + result.summary.failed : 0;
 
   useEffect(() => {
     if (!accessToken) {
@@ -98,11 +129,11 @@ export function UploadPage() {
   async function handleSubmit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
     if (!accessToken) {
-      setError('Google login is required before running the smoke test.');
+      setError('Google login is required before running a batch preprocess job.');
       return;
     }
-    if (!file) {
-      setError('Select one image file first.');
+    if (selectedFiles.length === 0) {
+      setError('Select at least one document image.');
       return;
     }
 
@@ -115,32 +146,33 @@ export function UploadPage() {
       const project = await ensureProject();
       appendLog(`Project ready: ${project.name} (#${project.id})`);
 
-      const checksumSha256 = await sha256(file);
-      appendLog(`SHA-256 calculated: ${checksumSha256.slice(0, 12)}...`);
+      const existingImageIds = await loadExistingImageIds(project.id);
+      const hashedFiles = await hashSelectedFiles();
+      appendLog(`SHA-256 calculated for ${hashedFiles.length} files.`);
 
-      const session = await createUploadSession(project, file);
+      const session = await createUploadSession(project, selectedFiles);
       appendLog(`Upload session created: #${session.id}`);
 
-      const uploadTarget = await createPresignedTarget(session, file, checksumSha256);
-      appendLog('Presigned upload URL issued.');
+      const uploadTargets = await createPresignedTargets(session, hashedFiles);
+      appendLog(`Presigned upload URLs issued: ${uploadTargets.length}`);
 
-      await uploadToObjectStorage(uploadTarget, file);
-      appendLog('Original image uploaded to MinIO.');
+      await uploadFilesToObjectStorage(uploadTargets);
+      appendLog('Original images uploaded to MinIO.');
 
-      await completeUpload(session, uploadTarget.uploadFileId);
+      await completeUpload(session, uploadTargets.map((target) => target.uploadFileId));
       appendLog('Upload session completed.');
 
-      const image = await findLatestImage(project.id, file.name);
-      appendLog(`Image metadata created: #${image.id}`);
+      const images = await findCreatedImages(project.id, selectedFiles, existingImageIds);
+      appendLog(`Image metadata created: ${images.length}`);
 
-      const job = await createJob(project, image);
-      appendLog(`Preprocess job queued: #${job.jobId}`);
+      const job = await createJob(project, images);
+      appendLog(`Preprocess job queued: #${job.jobId} (${job.totalImages} images)`);
 
-      const smokeResult: SmokeResult = { project, image, job };
+      const smokeResult: SmokeResult = { project, images, job };
       setResult(smokeResult);
       await pollJob(job.jobId, smokeResult);
     } catch (exception) {
-      setError(exception instanceof Error ? exception.message : 'Smoke test failed.');
+      setError(exception instanceof Error ? exception.message : 'Batch preprocess flow failed.');
     } finally {
       setBusy(false);
     }
@@ -157,7 +189,7 @@ export function UploadPage() {
       '/v1/projects',
       {
         name: projectName,
-        description: 'Created by the local frontend smoke flow.',
+        description: 'Created by the local batch upload flow.',
         defaultPreset: 'A4_SCAN_300DPI'
       },
       accessToken
@@ -167,82 +199,116 @@ export function UploadPage() {
     return response.result;
   }
 
-  async function createUploadSession(project: ProjectResponse, selectedFile: File) {
+  async function loadExistingImageIds(projectIdValue: number) {
+    const response = await apiClient.get<PageResponse<ImageListResponse>>(
+      `/v1/projects/${projectIdValue}/images?size=500`,
+      accessToken
+    );
+    return new Set(response.result.content.map((image) => image.id));
+  }
+
+  async function hashSelectedFiles() {
+    return Promise.all(
+      selectedFiles.map(async (entry) => {
+        updateFileRow(entry.key, { phase: 'hashing', detail: 'Calculating checksum' });
+        const checksumSha256 = await sha256(entry.file);
+        updateFileRow(entry.key, { phase: 'ready', detail: checksumSha256.slice(0, 12) });
+        return { ...entry, checksumSha256 };
+      })
+    );
+  }
+
+  async function createUploadSession(project: ProjectResponse, entries: SelectedUploadFile[]) {
     const response = await apiClient.post<UploadSessionResponse>(
       `/v1/projects/${project.id}/upload-sessions`,
       {
-        expectedFileCount: 1,
-        expectedTotalSizeBytes: selectedFile.size
+        expectedFileCount: entries.length,
+        expectedTotalSizeBytes: entries.reduce((sum, entry) => sum + entry.file.size, 0)
       },
       accessToken
     );
     return response.result;
   }
 
-  async function createPresignedTarget(
+  async function createPresignedTargets(
     session: UploadSessionResponse,
-    selectedFile: File,
-    checksumSha256: string
+    entries: Array<SelectedUploadFile & { checksumSha256: string }>
   ) {
     const response = await apiClient.post<PresignedUploadUrlResponse>(
       `/v1/upload-sessions/${session.id}/files/presigned-url`,
       {
-        files: [
-          {
-            fileName: selectedFile.name,
-            contentType: selectedFile.type || 'image/png',
-            sizeBytes: selectedFile.size,
-            checksumSha256
-          }
-        ]
+        files: entries.map((entry) => ({
+          fileName: entry.file.name,
+          contentType: entry.file.type || 'image/png',
+          sizeBytes: entry.file.size,
+          checksumSha256: entry.checksumSha256
+        }))
       },
       accessToken
     );
-    return response.result.uploadTargets[0];
-  }
-
-  async function uploadToObjectStorage(
-    target: PresignedUploadUrlResponse['uploadTargets'][number],
-    selectedFile: File
-  ) {
-    const response = await fetch(target.uploadUrl, {
-      method: 'PUT',
-      headers: target.requiredHeaders,
-      body: selectedFile
-    });
-    if (!response.ok) {
-      throw new Error(`MinIO upload failed with HTTP ${response.status}.`);
+    if (response.result.uploadTargets.length !== entries.length) {
+      throw new Error('Presigned upload target count does not match selected file count.');
     }
+    return response.result.uploadTargets.map((target, index) => ({
+      ...target,
+      entry: entries[index]
+    }));
   }
 
-  async function completeUpload(session: UploadSessionResponse, uploadFileId: number) {
+  async function uploadFilesToObjectStorage(
+    targets: Array<PresignedUploadUrlResponse['uploadTargets'][number] & { entry: SelectedUploadFile }>
+  ) {
+    await Promise.all(
+      targets.map(async (target) => {
+        updateFileRow(target.entry.key, { phase: 'uploading', detail: 'Uploading original' });
+        const response = await fetch(target.uploadUrl, {
+          method: 'PUT',
+          headers: target.requiredHeaders,
+          body: target.entry.file
+        });
+        if (!response.ok) {
+          updateFileRow(target.entry.key, { phase: 'failed', detail: `HTTP ${response.status}` });
+          throw new Error(`MinIO upload failed for ${target.entry.file.name} with HTTP ${response.status}.`);
+        }
+        updateFileRow(target.entry.key, { phase: 'uploaded', detail: 'Stored in MinIO' });
+      })
+    );
+  }
+
+  async function completeUpload(session: UploadSessionResponse, uploadFileIds: number[]) {
     await apiClient.post(
       `/v1/upload-sessions/${session.id}/complete`,
-      { uploadFileIds: [uploadFileId] },
+      { uploadFileIds },
       accessToken
     );
+    setFileRows((previous) => previous.map((row) => ({ ...row, phase: 'completed', detail: 'Metadata ready' })));
   }
 
-  async function findLatestImage(projectIdValue: number, fileName: string) {
+  async function findCreatedImages(
+    projectIdValue: number,
+    entries: SelectedUploadFile[],
+    existingImageIds: Set<number>
+  ) {
     const response = await apiClient.get<PageResponse<ImageListResponse>>(
-      `/v1/projects/${projectIdValue}/images?size=100`,
+      `/v1/projects/${projectIdValue}/images?size=500`,
       accessToken
     );
-    const image = response.result.content
-      .filter((candidate) => candidate.originalFileName === fileName)
-      .sort((left, right) => right.id - left.id)[0];
-    if (!image) {
-      throw new Error('Uploaded image metadata was not found.');
+    const selectedNames = new Set(entries.map((entry) => entry.file.name));
+    const images = response.result.content
+      .filter((candidate) => !existingImageIds.has(candidate.id) && selectedNames.has(candidate.originalFileName))
+      .sort((left, right) => left.id - right.id);
+    if (images.length < entries.length) {
+      throw new Error(`Only ${images.length}/${entries.length} uploaded image metadata rows were found.`);
     }
-    return image;
+    return images.slice(-entries.length);
   }
 
-  async function createJob(project: ProjectResponse, image: ImageListResponse) {
+  async function createJob(project: ProjectResponse, images: ImageListResponse[]) {
     const response = await apiClient.post<JobCreateResponse>(
       '/v1/jobs',
       {
         projectId: project.id,
-        imageIds: [image.id],
+        imageIds: images.map((image) => image.id),
         preset: project.defaultPreset || 'A4_SCAN_300DPI',
         presetParameters: { targetDpi: '300' },
         debug,
@@ -260,11 +326,11 @@ export function UploadPage() {
   }
 
   async function pollJob(jobId: number, smokeResult: SmokeResult) {
-    for (let attempt = 0; attempt < 30; attempt++) {
+    for (let attempt = 0; attempt < 60; attempt++) {
       await delay(1500);
       const [summaryResponse, itemsResponse] = await Promise.all([
         apiClient.get<JobSummaryResponse>(`/v1/jobs/${jobId}/summary`, accessToken),
-        apiClient.get<PageResponse<JobItemResponse>>(`/v1/jobs/${jobId}/items?size=20`, accessToken)
+        apiClient.get<PageResponse<JobItemResponse>>(`/v1/jobs/${jobId}/items?size=200`, accessToken)
       ]);
       const next = {
         ...smokeResult,
@@ -272,7 +338,10 @@ export function UploadPage() {
         items: itemsResponse.result.content
       };
       setResult(next);
-      appendLog(`Job progress: ${summaryResponse.result.progressPercent.toFixed(1)}%`);
+      appendLog(
+        `Job progress: ${summaryResponse.result.progressPercent.toFixed(1)}% `
+        + `(${summaryResponse.result.succeeded} succeeded / ${summaryResponse.result.failed} failed)`
+      );
       if (summaryResponse.result.succeeded + summaryResponse.result.failed >= summaryResponse.result.total) {
         return;
       }
@@ -280,105 +349,260 @@ export function UploadPage() {
     appendLog('Polling timed out. Refresh the job summary after the Worker finishes.');
   }
 
+  async function downloadArtifact(item: JobItemResponse, type: JobItemDownloadUrlResponse['type']) {
+    if (!result.job) {
+      setError('Job result is not ready yet.');
+      return;
+    }
+    try {
+      const response = await apiClient.get<JobItemDownloadUrlResponse>(
+        `/v1/jobs/${result.job.jobId}/items/${item.id}/download?type=${type}`,
+        accessToken
+      );
+      const anchor = document.createElement('a');
+      anchor.href = response.result.downloadUrl;
+      anchor.target = '_blank';
+      anchor.rel = 'noopener noreferrer';
+      anchor.download = downloadFileName(response.result);
+      document.body.appendChild(anchor);
+      anchor.click();
+      anchor.remove();
+      appendLog(`Download URL opened: ${type} for item #${item.id}`);
+    } catch (exception) {
+      setError(exception instanceof Error ? exception.message : `Failed to download ${type}.`);
+    }
+  }
+
+  function handleFileSelection(files: FileList | null) {
+    const nextFiles = Array.from(files ?? []).map((file, index) => ({
+      key: `${file.name}-${file.size}-${file.lastModified}-${index}`,
+      file
+    }));
+    setSelectedFiles(nextFiles);
+    setFileRows(nextFiles.map((entry) => ({
+      key: entry.key,
+      name: entry.file.name,
+      size: entry.file.size,
+      phase: 'selected',
+      detail: 'Waiting'
+    })));
+    setResult({});
+    setError(null);
+  }
+
+  function updateFileRow(key: string, patch: Partial<FileUploadRow>) {
+    setFileRows((previous) => previous.map((row) => (row.key === key ? { ...row, ...patch } : row)));
+  }
+
   function appendLog(message: string) {
     setLogs((previous) => [...previous, `${new Date().toLocaleTimeString()} ${message}`]);
   }
 
   return (
-    <PageSection
-      title="Local image preprocess smoke"
-      description="Upload one image through the frontend, create a preprocessing job, and poll the Worker result."
-    >
+    <div className="upload-console">
+      <section className="console-hero">
+        <div>
+          <span className="status-pill accent">Batch pipeline</span>
+          <h2>Prepare scanned documents for OCR at queue scale.</h2>
+          <p>
+            Upload multiple scans, let the API create one JobItem per image, and watch the Worker produce processed
+            images, previews, reports, and optional debug artifacts.
+          </p>
+        </div>
+        <div className="session-card">
+          <span className={`status-dot ${accessToken ? 'online' : 'offline'}`} />
+          <strong>{accessToken ? 'Authenticated' : 'Login required'}</strong>
+          <small>Access token value is hidden. Refresh token stays in an HttpOnly cookie.</small>
+        </div>
+      </section>
+
       {!accessToken && (
         <div className="status-card warning">
-          <strong>Login required</strong>
-          <span>Use Google login first. The OAuth success page stores the access token in this browser.</span>
+          <strong>Google session required</strong>
+          <span>Sign in first. The OAuth callback now refreshes the access token without exposing it in the URL.</span>
           <a className="primary-action" href="/login">Go to login</a>
         </div>
       )}
 
-      <form className="smoke-form" onSubmit={handleSubmit}>
-        <label>
-          Access token
-          <input value={accessToken} onChange={(event) => setAccessToken(event.target.value)} />
-        </label>
+      <section className="metric-strip">
+        <MetricCard label="Selected" value={String(selectedFiles.length)} detail="images" />
+        <MetricCard label="Batch size" value={formatBytes(totalSize)} detail="original input" />
+        <MetricCard
+          label="Job progress"
+          value={`${result.summary?.progressPercent.toFixed(0) ?? '0'}%`}
+          detail={result.summary ? `${completedItems}/${result.summary.total} done` : 'not started'}
+        />
+        <MetricCard label="Artifacts" value={String(result.items?.filter((item) => item.processedObjectKey).length ?? 0)} detail="ready" />
+      </section>
 
-        <label>
-          Existing project
-          <select value={projectId} onChange={(event) => setProjectId(event.target.value)}>
-            <option value="">Create a new project</option>
-            {projects.map((project) => (
-              <option key={project.id} value={project.id}>
-                #{project.id} {project.name}
-              </option>
-            ))}
-          </select>
-        </label>
+      <form className="upload-layout" onSubmit={handleSubmit}>
+        <div className="control-panel">
+          <PageSection
+            title="1. Scope"
+            description="Choose an existing project or create a fresh batch workspace."
+          >
+            <label className="field">
+              Existing project
+              <select value={projectId} onChange={(event) => setProjectId(event.target.value)}>
+                <option value="">Create a new project</option>
+                {projects.map((project) => (
+                  <option key={project.id} value={project.id}>
+                    #{project.id} {project.name}
+                  </option>
+                ))}
+              </select>
+            </label>
 
-        {!projectId && (
-          <label>
-            New project name
-            <input value={projectName} onChange={(event) => setProjectName(event.target.value)} />
-          </label>
-        )}
+            {!projectId && (
+              <label className="field">
+                New project name
+                <input value={projectName} onChange={(event) => setProjectName(event.target.value)} />
+              </label>
+            )}
 
-        <label>
-          Document image
-          <input
-            type="file"
-            accept="image/png,image/jpeg,image/jpg,image/webp,image/bmp,image/tiff"
-            onChange={(event) => setFile(event.target.files?.[0] ?? null)}
-          />
-        </label>
+            <label className="check-row">
+              <input type="checkbox" checked={debug} onChange={(event) => setDebug(event.target.checked)} />
+              Save per-step debug artifacts
+            </label>
+          </PageSection>
 
-        <label className="check-row">
-          <input type="checkbox" checked={debug} onChange={(event) => setDebug(event.target.checked)} />
-          Save per-step debug artifacts
-        </label>
+          <PageSection
+            title="2. Files"
+            description="Select multiple document images. Each image becomes a separate queue message."
+          >
+            <label className="file-dropzone">
+              <span>Drop zone</span>
+              <strong>{selectedFiles.length > 0 ? `${selectedFiles.length} files ready` : 'Choose document images'}</strong>
+              <small>PNG, JPEG, WEBP, BMP, or TIFF. Duplicate checksums are rejected per project.</small>
+              <input
+                type="file"
+                multiple
+                accept="image/png,image/jpeg,image/jpg,image/webp,image/bmp,image/tiff"
+                onChange={(event) => handleFileSelection(event.target.files)}
+              />
+            </label>
 
-        <button className="primary-action" type="submit" disabled={busy}>
-          {busy ? 'Running smoke flow...' : 'Upload and preprocess'}
-        </button>
+            <button className="primary-action" type="submit" disabled={busy || !accessToken}>
+              {busy ? 'Running batch...' : 'Upload batch and preprocess'}
+            </button>
+          </PageSection>
+        </div>
+
+        <div className="batch-panel">
+          <PageSection
+            title="3. Batch monitor"
+            description="Track upload preparation, Worker progress, and downloadable artifacts."
+          >
+            {error && (
+              <div className="status-card error">
+                <strong>Batch flow failed</strong>
+                <span>{error}</span>
+              </div>
+            )}
+
+            {fileRows.length > 0 ? (
+              <div className="file-list">
+                {fileRows.map((row) => (
+                  <div className="file-row" key={row.key}>
+                    <div>
+                      <strong>{row.name}</strong>
+                      <small>{formatBytes(row.size)}</small>
+                    </div>
+                    <span className={`status-pill ${row.phase}`}>{row.phase}</span>
+                    <small>{row.detail}</small>
+                  </div>
+                ))}
+              </div>
+            ) : (
+              <div className="empty-state">
+                <strong>No files selected</strong>
+                <span>Select a small batch first, then scale up after the flow is verified.</span>
+              </div>
+            )}
+
+            {result.summary && (
+              <div className="progress-card">
+                <div>
+                  <strong>Job #{result.summary.jobId}</strong>
+                  <span>{result.summary.succeeded} succeeded, {result.summary.failed} failed, {result.summary.processing} processing</span>
+                </div>
+                <div className="progress-track">
+                  <span style={{ width: `${Math.min(result.summary.progressPercent, 100)}%` }} />
+                </div>
+              </div>
+            )}
+
+            {logs.length > 0 && (
+              <div className="log-panel">
+                {logs.map((log) => (
+                  <span key={log}>{log}</span>
+                ))}
+              </div>
+            )}
+          </PageSection>
+        </div>
       </form>
 
-      {error && (
-        <div className="status-card error">
-          <strong>Smoke flow failed</strong>
-          <span>{error}</span>
-        </div>
-      )}
-
-      {logs.length > 0 && (
-        <div className="log-panel">
-          {logs.map((log) => (
-            <span key={log}>{log}</span>
-          ))}
-        </div>
-      )}
-
-      {result.job && (
-        <div className="status-grid">
-          <div className="status-card">
-            <strong>Job #{result.job.jobId}</strong>
-            <span>{result.summary?.progressPercent.toFixed(1) ?? '0.0'}% complete</span>
+      {result.items && result.items.length > 0 && (
+        <section className="artifact-board">
+          <div>
+            <span className="status-pill accent">Results</span>
+            <h2>Worker artifacts</h2>
           </div>
-          <div className="status-card">
-            <strong>Image</strong>
-            <span>#{result.image?.id} {result.image?.originalFileName}</span>
+          <div className="artifact-grid">
+            {result.items.map((item) => (
+              <div className="artifact-card" key={item.id}>
+                <div className="artifact-title">
+                  <strong>Item #{item.id}</strong>
+                  <span className={`status-pill ${item.status.toLowerCase()}`}>{item.status}</span>
+                </div>
+                <small>Image #{item.imageId}</small>
+                {item.errorMessage && <span className="error-text">{item.errorCode}: {item.errorMessage}</span>}
+                {item.processedObjectKey && <code>{item.processedObjectKey}</code>}
+                {item.previewObjectKey && <code>{item.previewObjectKey}</code>}
+                {item.reportObjectKey && <code>{item.reportObjectKey}</code>}
+                <div className="download-actions">
+                  <button
+                    type="button"
+                    className="secondary-action"
+                    disabled={!item.processedObjectKey}
+                    onClick={() => downloadArtifact(item, 'processed')}
+                  >
+                    Processed
+                  </button>
+                  <button
+                    type="button"
+                    className="secondary-action"
+                    disabled={!item.previewObjectKey}
+                    onClick={() => downloadArtifact(item, 'preview')}
+                  >
+                    Preview
+                  </button>
+                  <button
+                    type="button"
+                    className="secondary-action"
+                    disabled={!item.reportObjectKey}
+                    onClick={() => downloadArtifact(item, 'report')}
+                  >
+                    Report
+                  </button>
+                </div>
+              </div>
+            ))}
           </div>
-        </div>
+        </section>
       )}
+    </div>
+  );
+}
 
-      {result.items?.map((item) => (
-        <div className="artifact-card" key={item.id}>
-          <strong>Item #{item.id}: {item.status}</strong>
-          {item.errorMessage && <span className="error-text">{item.errorCode}: {item.errorMessage}</span>}
-          {item.processedObjectKey && <code>{item.processedObjectKey}</code>}
-          {item.previewObjectKey && <code>{item.previewObjectKey}</code>}
-          {item.reportObjectKey && <code>{item.reportObjectKey}</code>}
-        </div>
-      ))}
-    </PageSection>
+function MetricCard({ label, value, detail }: { label: string; value: string; detail: string }) {
+  return (
+    <div className="metric-card">
+      <span>{label}</span>
+      <strong>{value}</strong>
+      <small>{detail}</small>
+    </div>
   );
 }
 
@@ -391,4 +615,18 @@ async function sha256(file: File) {
 
 function delay(milliseconds: number) {
   return new Promise((resolve) => window.setTimeout(resolve, milliseconds));
+}
+
+function downloadFileName(target: JobItemDownloadUrlResponse) {
+  const extension = target.type === 'report' ? 'json' : 'png';
+  return `job-${target.jobId}-item-${target.itemId}-${target.type}.${extension}`;
+}
+
+function formatBytes(bytes: number) {
+  if (bytes === 0) {
+    return '0 B';
+  }
+  const units = ['B', 'KB', 'MB', 'GB'];
+  const index = Math.min(Math.floor(Math.log(bytes) / Math.log(1024)), units.length - 1);
+  return `${(bytes / 1024 ** index).toFixed(index === 0 ? 0 : 1)} ${units[index]}`;
 }

--- a/frontend/src/shared/api/apiClient.ts
+++ b/frontend/src/shared/api/apiClient.ts
@@ -30,6 +30,12 @@ export class ApiClient {
   }
 
   private async parse<T>(response: Response): Promise<ApiResponse<T>> {
+    const contentType = response.headers.get('content-type') ?? '';
+    if (!contentType.includes('application/json')) {
+      const text = await response.text();
+      const preview = text.replace(/\s+/g, ' ').slice(0, 120);
+      throw new Error(`API returned non-JSON response with HTTP ${response.status}: ${preview}`);
+    }
     const payload = (await response.json()) as ApiResponse<T>;
     if (!response.ok || !payload.isSuccess) {
       throw new Error(payload.message || `API request failed with ${response.status}`);

--- a/frontend/src/shared/api/apiClient.ts
+++ b/frontend/src/shared/api/apiClient.ts
@@ -1,3 +1,5 @@
+import { clearAccessToken, readStoredAccessToken, storeAccessToken } from '../auth/accessTokenStore';
+
 export type ApiResponse<T> = {
   isSuccess: boolean;
   code: string;
@@ -5,28 +7,69 @@ export type ApiResponse<T> = {
   result: T;
 };
 
+type TokenRefreshResponse = {
+  accessToken: string;
+  accessTokenExpiresAt: string;
+};
+
 export class ApiClient {
   constructor(private readonly baseUrl = '/api') {}
 
   async get<T>(path: string, accessToken?: string): Promise<ApiResponse<T>> {
-    const response = await fetch(`${this.baseUrl}${path}`, {
-      headers: this.headers(accessToken),
-      credentials: 'include'
-    });
-    return this.parse<T>(response);
+    return this.request<T>('GET', path, undefined, accessToken);
   }
 
   async post<T>(path: string, body: unknown, accessToken?: string): Promise<ApiResponse<T>> {
-    const response = await fetch(`${this.baseUrl}${path}`, {
-      method: 'POST',
-      headers: {
-        ...this.headers(accessToken),
-        'Content-Type': 'application/json'
-      },
-      credentials: 'include',
-      body: JSON.stringify(body)
-    });
+    return this.request<T>('POST', path, body, accessToken);
+  }
+
+  private async request<T>(
+    method: 'GET' | 'POST',
+    path: string,
+    body?: unknown,
+    accessToken?: string
+  ): Promise<ApiResponse<T>> {
+    const response = await this.fetchJson(method, path, body, accessToken);
+    if (response.status === 401 && this.canRefresh(path)) {
+      const refreshedAccessToken = await this.refreshAccessToken();
+      const retryResponse = await this.fetchJson(method, path, body, refreshedAccessToken);
+      return this.parse<T>(retryResponse);
+    }
     return this.parse<T>(response);
+  }
+
+  private async fetchJson(method: 'GET' | 'POST', path: string, body?: unknown, accessToken?: string) {
+    const headers: Record<string, string> = {
+      ...this.headers(accessToken)
+    };
+    const init: RequestInit = {
+      method,
+      headers,
+      credentials: 'include',
+      redirect: 'manual'
+    };
+    if (method === 'POST') {
+      headers['Content-Type'] = 'application/json';
+      init.body = JSON.stringify(body ?? {});
+    }
+    return fetch(`${this.baseUrl}${path}`, init);
+  }
+
+  private async refreshAccessToken() {
+    const response = await fetch(`${this.baseUrl}/v1/auth/refresh`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      credentials: 'include',
+      redirect: 'manual',
+      body: '{}'
+    });
+    const payload = await this.parse<TokenRefreshResponse>(response);
+    storeAccessToken(payload.result.accessToken);
+    return payload.result.accessToken;
+  }
+
+  private canRefresh(path: string) {
+    return path !== '/v1/auth/refresh' && path !== '/v1/auth/logout';
   }
 
   private async parse<T>(response: Response): Promise<ApiResponse<T>> {
@@ -38,13 +81,17 @@ export class ApiClient {
     }
     const payload = (await response.json()) as ApiResponse<T>;
     if (!response.ok || !payload.isSuccess) {
+      if (response.status === 401) {
+        clearAccessToken();
+      }
       throw new Error(payload.message || `API request failed with ${response.status}`);
     }
     return payload;
   }
 
-  private headers(accessToken?: string): HeadersInit {
-    return accessToken ? { Authorization: `Bearer ${accessToken}` } : {};
+  private headers(accessToken?: string): Record<string, string> {
+    const token = readStoredAccessToken() ?? accessToken;
+    return token ? { Authorization: `Bearer ${token}` } : {};
   }
 }
 

--- a/frontend/src/shared/api/apiClient.ts
+++ b/frontend/src/shared/api/apiClient.ts
@@ -90,7 +90,7 @@ export class ApiClient {
   }
 
   private headers(accessToken?: string): Record<string, string> {
-    const token = readStoredAccessToken() ?? accessToken;
+    const token = accessToken ?? readStoredAccessToken();
     return token ? { Authorization: `Bearer ${token}` } : {};
   }
 }

--- a/frontend/src/shared/hooks/useAccessToken.ts
+++ b/frontend/src/shared/hooks/useAccessToken.ts
@@ -7,6 +7,11 @@ export function useAccessToken() {
     const token = params.get('accessToken') ?? undefined;
     if (token) {
       storeAccessToken(token);
+      params.delete('accessToken');
+      params.delete('accessTokenExpiresAt');
+      const nextSearch = params.toString();
+      const nextUrl = `${window.location.pathname}${nextSearch ? `?${nextSearch}` : ''}${window.location.hash}`;
+      window.history.replaceState({}, document.title, nextUrl);
       return token;
     }
     return readStoredAccessToken();

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -1,35 +1,62 @@
 :root {
-  color: #182018;
-  background: #f2eadc;
-  --ink: #182018;
-  --muted: #687063;
-  --paper: #fffaf0;
-  --line: #d9cab0;
-  --moss: #315c45;
-  --clay: #b9623c;
+  color: #17201c;
+  background: #eef1e8;
+  --ink: #17201c;
+  --muted: #6e766f;
+  --subtle: #8b948b;
+  --paper: #fbfaf3;
+  --surface: rgba(255, 255, 248, 0.82);
+  --surface-strong: #ffffff;
+  --line: #d7dece;
+  --line-strong: #bec8b8;
+  --pine: #12382d;
+  --pine-2: #1f5a47;
+  --ember: #d86d3d;
+  --gold: #d6b45f;
+  --blue: #486dff;
+  --danger: #ba3f35;
+  --shadow: 0 1.5rem 4.5rem rgba(18, 56, 45, 0.14);
 }
 
 body {
+  font-family: "Space Grotesk", "Aptos", "Segoe UI", sans-serif;
   background:
-    radial-gradient(circle at top left, rgba(185, 98, 60, 0.18), transparent 28rem),
-    linear-gradient(135deg, #f7efdF 0%, #e9dfc9 100%);
+    radial-gradient(circle at 15% 12%, rgba(216, 109, 61, 0.22), transparent 24rem),
+    radial-gradient(circle at 80% 8%, rgba(72, 109, 255, 0.12), transparent 22rem),
+    linear-gradient(135deg, #f7f2e6 0%, #e5eadf 50%, #dfe6dc 100%);
+}
+
+button,
+input,
+select {
+  font: inherit;
+}
+
+button {
+  border: 0;
 }
 
 .shell {
   display: grid;
-  grid-template-columns: 18rem 1fr;
+  grid-template-columns: 18rem minmax(0, 1fr);
   min-height: 100vh;
 }
 
 .sidebar {
-  border-right: 1px solid var(--line);
-  background: rgba(255, 250, 240, 0.84);
-  padding: 2rem;
+  position: sticky;
+  top: 0;
+  height: 100vh;
+  border-right: 1px solid rgba(18, 56, 45, 0.12);
+  background:
+    linear-gradient(180deg, rgba(18, 56, 45, 0.96), rgba(18, 56, 45, 0.88)),
+    radial-gradient(circle at top left, rgba(255, 255, 255, 0.16), transparent 18rem);
+  color: #f7f3e7;
+  padding: 1.5rem;
 }
 
 .brand {
   display: flex;
-  gap: 0.85rem;
+  gap: 0.9rem;
   align-items: center;
   margin-bottom: 2rem;
 }
@@ -39,167 +66,510 @@ body {
   width: 3rem;
   height: 3rem;
   place-items: center;
+  border: 1px solid rgba(255, 255, 255, 0.28);
   border-radius: 1rem;
-  background: var(--moss);
-  color: #fffaf0;
-  font-weight: 700;
+  background: rgba(255, 255, 255, 0.12);
+  color: #fff8df;
+  font-weight: 800;
 }
 
-.brand small,
-.eyebrow,
-.page-section p,
-.status-card span {
-  color: var(--muted);
+.brand strong,
+.brand small {
+  display: block;
+}
+
+.brand small {
+  color: rgba(247, 243, 231, 0.68);
+  font-size: 0.78rem;
 }
 
 .nav-list {
   display: grid;
-  gap: 0.4rem;
+  gap: 0.35rem;
 }
 
 .nav-list a {
-  border-radius: 999px;
-  padding: 0.7rem 0.9rem;
+  border: 1px solid transparent;
+  border-radius: 0.95rem;
+  color: rgba(247, 243, 231, 0.72);
+  padding: 0.82rem 0.95rem;
+  transition: 150ms ease;
 }
 
 .nav-list a.active,
 .nav-list a:hover {
-  background: var(--ink);
-  color: var(--paper);
+  border-color: rgba(255, 255, 255, 0.18);
+  background: rgba(255, 255, 255, 0.12);
+  color: #fff8df;
 }
 
 .content {
-  padding: 3rem;
+  min-width: 0;
+  padding: 2rem clamp(1.25rem, 4vw, 4rem) 4rem;
+}
+
+.topbar {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  align-items: center;
+  max-width: 76rem;
+  margin-bottom: 2rem;
+  border: 1px solid rgba(18, 56, 45, 0.12);
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.52);
+  padding: 0.7rem 1rem;
+  backdrop-filter: blur(18px);
+}
+
+.topbar span {
+  color: var(--muted);
 }
 
 .page-header {
-  max-width: 52rem;
+  max-width: 70rem;
   margin-bottom: 2rem;
+}
+
+.eyebrow {
+  margin: 0;
+  color: var(--pine-2);
+  font-size: 0.82rem;
+  font-weight: 800;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
 }
 
 .page-header h1 {
   margin: 0.25rem 0 0;
-  font-size: clamp(2.25rem, 6vw, 5.5rem);
-  line-height: 0.95;
+  max-width: 58rem;
+  color: var(--ink);
+  font-size: clamp(2.6rem, 7vw, 6.8rem);
+  letter-spacing: -0.08em;
+  line-height: 0.88;
 }
 
 .page-section {
   display: grid;
-  gap: 1.5rem;
-  max-width: 54rem;
-  border: 1px solid var(--line);
-  border-radius: 1.5rem;
-  background: rgba(255, 250, 240, 0.76);
-  padding: 2rem;
-  box-shadow: 0 1.5rem 4rem rgba(49, 92, 69, 0.12);
+  gap: 1.35rem;
+  border: 1px solid rgba(18, 56, 45, 0.12);
+  border-radius: 1.35rem;
+  background: var(--surface);
+  padding: clamp(1.2rem, 2vw, 1.65rem);
+  box-shadow: 0 1rem 2.5rem rgba(18, 56, 45, 0.07);
 }
 
 .page-section h2 {
-  margin: 0 0 0.5rem;
-  font-size: 1.5rem;
+  margin: 0 0 0.35rem;
+  color: var(--ink);
+  font-size: 1.15rem;
+  letter-spacing: -0.02em;
+}
+
+.page-section p,
+.status-card span,
+.status-card small,
+.metric-card small,
+.file-row small,
+.empty-state span,
+.progress-card span,
+.session-card small {
+  color: var(--muted);
 }
 
 .page-section p {
   margin: 0;
-  line-height: 1.7;
+  line-height: 1.65;
+}
+
+.primary-action,
+.secondary-action {
+  display: inline-flex;
+  width: fit-content;
+  align-items: center;
+  justify-content: center;
+  border-radius: 999px;
+  font-weight: 800;
+  cursor: pointer;
 }
 
 .primary-action {
-  width: fit-content;
-  border-radius: 999px;
-  background: var(--clay);
-  color: #fffaf0;
-  padding: 0.9rem 1.2rem;
-  font-weight: 700;
+  background: linear-gradient(135deg, var(--pine), var(--pine-2));
+  color: #fff8df;
+  padding: 0.88rem 1.15rem;
+  box-shadow: 0 0.8rem 1.8rem rgba(18, 56, 45, 0.2);
 }
 
-.status-card {
+.primary-action:disabled {
+  cursor: not-allowed;
+  opacity: 0.52;
+}
+
+.secondary-action {
+  border: 1px solid rgba(18, 56, 45, 0.16);
+  background: #fffef8;
+  color: var(--ink);
+  padding: 0.66rem 0.9rem;
+}
+
+.secondary-action:disabled {
+  cursor: not-allowed;
+  opacity: 0.42;
+}
+
+.upload-console {
   display: grid;
-  gap: 0.35rem;
-  border-left: 4px solid var(--moss);
-  padding: 1rem;
-  background: #f6ecd8;
+  max-width: 76rem;
+  gap: 1.3rem;
 }
 
-.status-card.warning {
-  border-left-color: #c58b25;
-}
-
-.status-card.error {
-  border-left-color: #a33d2f;
-}
-
-.smoke-form {
+.console-hero {
   display: grid;
+  grid-template-columns: minmax(0, 1fr) 18rem;
   gap: 1rem;
+  align-items: stretch;
+  border: 1px solid rgba(18, 56, 45, 0.14);
+  border-radius: 1.6rem;
+  background:
+    radial-gradient(circle at 80% 20%, rgba(216, 109, 61, 0.2), transparent 18rem),
+    linear-gradient(135deg, rgba(255, 255, 255, 0.9), rgba(247, 242, 230, 0.74));
+  padding: clamp(1.25rem, 3vw, 2.4rem);
+  box-shadow: var(--shadow);
 }
 
-.smoke-form label {
+.console-hero h2 {
+  max-width: 48rem;
+  margin: 0.75rem 0;
+  font-size: clamp(2rem, 4vw, 4rem);
+  letter-spacing: -0.06em;
+  line-height: 0.95;
+}
+
+.console-hero p {
+  max-width: 48rem;
+  margin: 0;
+  color: var(--muted);
+  line-height: 1.7;
+}
+
+.session-card,
+.metric-card,
+.status-card,
+.empty-state,
+.progress-card {
+  display: grid;
+  gap: 0.45rem;
+  border: 1px solid rgba(18, 56, 45, 0.12);
+  border-radius: 1.15rem;
+  background: rgba(255, 255, 255, 0.68);
+  padding: 1rem;
+}
+
+.session-card {
+  align-content: center;
+}
+
+.status-dot {
+  width: 0.7rem;
+  height: 0.7rem;
+  border-radius: 999px;
+  background: var(--danger);
+}
+
+.status-dot.online {
+  background: #2f9d68;
+  box-shadow: 0 0 0 0.35rem rgba(47, 157, 104, 0.14);
+}
+
+.status-dot.offline {
+  box-shadow: 0 0 0 0.35rem rgba(186, 63, 53, 0.12);
+}
+
+.metric-strip {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 0.9rem;
+}
+
+.metric-card span {
+  color: var(--subtle);
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.metric-card strong {
+  font-size: 1.75rem;
+  letter-spacing: -0.04em;
+}
+
+.upload-layout {
+  display: grid;
+  grid-template-columns: minmax(18rem, 0.82fr) minmax(24rem, 1.18fr);
+  gap: 1.1rem;
+  align-items: start;
+}
+
+.control-panel,
+.batch-panel {
+  display: grid;
+  gap: 1.1rem;
+}
+
+.field {
   display: grid;
   gap: 0.45rem;
   color: var(--muted);
-  font-weight: 700;
+  font-weight: 800;
 }
 
-.smoke-form input,
-.smoke-form select {
+.field input,
+.field select,
+.file-dropzone {
   border: 1px solid var(--line);
-  border-radius: 0.85rem;
-  background: #fffdf7;
+  border-radius: 1rem;
+  background: #fffef8;
   color: var(--ink);
-  padding: 0.85rem 1rem;
+  padding: 0.9rem 1rem;
+}
+
+.field input:focus,
+.field select:focus {
+  outline: 3px solid rgba(31, 90, 71, 0.14);
 }
 
 .check-row {
-  display: flex !important;
-  grid-template-columns: auto 1fr;
+  display: flex;
+  gap: 0.65rem;
   align-items: center;
+  color: var(--muted);
+  font-weight: 800;
 }
 
 .check-row input {
   width: 1rem;
 }
 
-.log-panel,
-.artifact-card {
+.file-dropzone {
+  position: relative;
   display: grid;
-  gap: 0.45rem;
-  border: 1px dashed var(--line);
+  gap: 0.25rem;
+  min-height: 9rem;
+  align-content: center;
+  border-style: dashed;
+  cursor: pointer;
+  transition: 150ms ease;
+}
+
+.file-dropzone:hover {
+  border-color: var(--pine-2);
+  background: #fffaf0;
+}
+
+.file-dropzone span {
+  color: var(--pine-2);
+  font-weight: 900;
+}
+
+.file-dropzone input {
+  position: absolute;
+  inset: 0;
+  cursor: pointer;
+  opacity: 0;
+}
+
+.file-list,
+.log-panel,
+.artifact-grid {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.file-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto minmax(5rem, auto);
+  gap: 0.75rem;
+  align-items: center;
+  border: 1px solid rgba(18, 56, 45, 0.1);
   border-radius: 1rem;
-  background: rgba(255, 253, 247, 0.82);
+  background: rgba(255, 254, 248, 0.8);
+  padding: 0.82rem;
+}
+
+.file-row strong,
+.file-row small {
+  display: block;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.status-pill {
+  display: inline-flex;
+  width: fit-content;
+  align-items: center;
+  border: 1px solid rgba(18, 56, 45, 0.12);
+  border-radius: 999px;
+  background: rgba(18, 56, 45, 0.06);
+  color: var(--pine);
+  padding: 0.28rem 0.62rem;
+  font-size: 0.72rem;
+  font-weight: 900;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.status-pill.accent,
+.status-pill.succeeded,
+.status-pill.completed,
+.status-pill.uploaded,
+.status-pill.ready {
+  border-color: rgba(47, 157, 104, 0.18);
+  background: rgba(47, 157, 104, 0.1);
+  color: #1d6a48;
+}
+
+.status-pill.failed,
+.status-pill.error {
+  border-color: rgba(186, 63, 53, 0.2);
+  background: rgba(186, 63, 53, 0.1);
+  color: var(--danger);
+}
+
+.status-pill.processing,
+.status-pill.uploading,
+.status-pill.hashing {
+  border-color: rgba(72, 109, 255, 0.18);
+  background: rgba(72, 109, 255, 0.1);
+  color: var(--blue);
+}
+
+.status-card.warning {
+  border-color: rgba(214, 180, 95, 0.4);
+  background: rgba(214, 180, 95, 0.12);
+}
+
+.status-card.error {
+  border-color: rgba(186, 63, 53, 0.28);
+  background: rgba(186, 63, 53, 0.1);
+}
+
+.progress-card {
+  background: rgba(18, 56, 45, 0.06);
+}
+
+.progress-track {
+  height: 0.7rem;
+  overflow: hidden;
+  border-radius: 999px;
+  background: rgba(18, 56, 45, 0.12);
+}
+
+.progress-track span {
+  display: block;
+  height: 100%;
+  border-radius: inherit;
+  background: linear-gradient(90deg, var(--pine-2), var(--ember));
+}
+
+.log-panel {
+  max-height: 13rem;
+  overflow: auto;
+  border: 1px dashed var(--line-strong);
+  border-radius: 1rem;
+  background: rgba(18, 56, 45, 0.04);
   padding: 1rem;
 }
 
-.log-panel span,
-.artifact-card code {
-  overflow-wrap: anywhere;
+.log-panel span {
+  color: var(--muted);
+  font-family: "JetBrains Mono", "Consolas", monospace;
+  font-size: 0.78rem;
 }
 
-.status-grid {
+.artifact-board {
   display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
   gap: 1rem;
+  border: 1px solid rgba(18, 56, 45, 0.12);
+  border-radius: 1.6rem;
+  background: rgba(255, 255, 248, 0.6);
+  padding: clamp(1.2rem, 2vw, 1.6rem);
+}
+
+.artifact-board h2 {
+  margin: 0.45rem 0 0;
+  font-size: 1.8rem;
+  letter-spacing: -0.04em;
+}
+
+.artifact-grid {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.artifact-card {
+  display: grid;
+  gap: 0.55rem;
+  border: 1px solid rgba(18, 56, 45, 0.12);
+  border-radius: 1.1rem;
+  background: rgba(255, 254, 248, 0.9);
+  padding: 1rem;
+}
+
+.artifact-title,
+.download-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.65rem;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.artifact-card code {
+  overflow-wrap: anywhere;
+  border-radius: 0.75rem;
+  background: rgba(18, 56, 45, 0.06);
+  color: var(--pine);
+  padding: 0.55rem;
+  font-family: "JetBrains Mono", "Consolas", monospace;
+  font-size: 0.78rem;
 }
 
 .error-text {
-  color: #a33d2f;
+  color: var(--danger);
 }
 
-@media (max-width: 780px) {
-  .shell {
+@media (max-width: 980px) {
+  .shell,
+  .upload-layout,
+  .console-hero {
     grid-template-columns: 1fr;
   }
 
   .sidebar {
-    border-right: 0;
-    border-bottom: 1px solid var(--line);
+    position: static;
+    height: auto;
   }
 
+  .metric-strip,
+  .artifact-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 640px) {
   .content {
-    padding: 2rem 1.25rem;
+    padding: 1.25rem 1rem 3rem;
   }
 
-  .status-grid {
+  .topbar,
+  .file-row {
+    align-items: stretch;
+    grid-template-columns: 1fr;
+  }
+
+  .metric-strip,
+  .artifact-grid {
     grid-template-columns: 1fr;
   }
 }

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -45,6 +45,8 @@ button {
 .sidebar {
   position: sticky;
   top: 0;
+  display: flex;
+  flex-direction: column;
   height: 100vh;
   border-right: 1px solid rgba(18, 56, 45, 0.12);
   background:
@@ -101,6 +103,98 @@ button {
   border-color: rgba(255, 255, 255, 0.18);
   background: rgba(255, 255, 255, 0.12);
   color: #fff8df;
+}
+
+.sidebar-account {
+  display: grid;
+  gap: 0.75rem;
+  margin-top: auto;
+  border-top: 1px solid rgba(255, 255, 255, 0.14);
+  padding-top: 1rem;
+}
+
+.account-state {
+  color: rgba(247, 243, 231, 0.68);
+  font-size: 0.82rem;
+  font-weight: 800;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.account-login,
+.text-action {
+  display: inline-flex;
+  width: fit-content;
+  align-items: center;
+  justify-content: center;
+  border-radius: 999px;
+  font-size: 0.9rem;
+  font-weight: 900;
+}
+
+.account-login {
+  background: #fff8df;
+  color: var(--pine);
+  padding: 0.72rem 0.88rem;
+  box-shadow: 0 0.8rem 1.5rem rgba(0, 0, 0, 0.12);
+}
+
+.account-card {
+  display: grid;
+  grid-template-columns: 2.45rem minmax(0, 1fr);
+  gap: 0.75rem;
+  align-items: center;
+}
+
+.account-avatar {
+  display: grid;
+  width: 2.45rem;
+  height: 2.45rem;
+  place-items: center;
+  border: 1px solid rgba(255, 255, 255, 0.24);
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.16);
+  color: #fff8df;
+  font-size: 0.78rem;
+  font-weight: 900;
+  object-fit: cover;
+}
+
+.account-copy {
+  display: grid;
+  min-width: 0;
+}
+
+.account-copy strong,
+.account-copy small {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.account-copy strong {
+  color: #fff8df;
+  font-size: 0.92rem;
+}
+
+.account-copy small {
+  color: rgba(247, 243, 231, 0.64);
+  font-size: 0.76rem;
+}
+
+.text-action {
+  background: transparent;
+  color: rgba(247, 243, 231, 0.7);
+  padding: 0;
+}
+
+.text-action:hover:not(:disabled) {
+  color: #fff8df;
+}
+
+.text-action:disabled {
+  cursor: not-allowed;
+  opacity: 0.52;
 }
 
 .content {
@@ -549,6 +643,10 @@ button {
   .sidebar {
     position: static;
     height: auto;
+  }
+
+  .sidebar-account {
+    margin-top: 1rem;
   }
 
   .metric-strip,

--- a/infra/docker-compose/.env.example
+++ b/infra/docker-compose/.env.example
@@ -15,9 +15,9 @@ MINIO_ROOT_PASSWORD=minioadmin
 MINIO_BUCKET=image-preprocess-local
 MINIO_API_PORT=9000
 MINIO_CONSOLE_PORT=9001
-MINIO_PUBLIC_ENDPOINT=http://localhost:9000
+MINIO_PUBLIC_ENDPOINT=http://localhost
 MINIO_REGION=us-east-1
-MINIO_API_CORS_ALLOW_ORIGIN=http://localhost,http://localhost:5173
+MINIO_API_CORS_ALLOW_ORIGIN=http://localhost,http://localhost:5173,http://127.0.0.1,http://127.0.0.1:5173
 
 NGINX_HTTP_PORT=80
 BACKEND_API_PORT=8080

--- a/infra/docker-compose/docker-compose.local.yml
+++ b/infra/docker-compose/docker-compose.local.yml
@@ -75,7 +75,7 @@ services:
     environment:
       MINIO_ROOT_USER: ${MINIO_ROOT_USER:-minioadmin}
       MINIO_ROOT_PASSWORD: ${MINIO_ROOT_PASSWORD:-minioadmin}
-      MINIO_API_CORS_ALLOW_ORIGIN: ${MINIO_API_CORS_ALLOW_ORIGIN:-http://localhost,http://localhost:5173}
+      MINIO_API_CORS_ALLOW_ORIGIN: ${MINIO_API_CORS_ALLOW_ORIGIN:-http://localhost,http://localhost:5173,http://127.0.0.1,http://127.0.0.1:5173}
     ports:
       - "${MINIO_API_PORT:-9000}:9000"
       - "${MINIO_CONSOLE_PORT:-9001}:9001"
@@ -135,7 +135,7 @@ services:
       WORKER_INTERNAL_TOKEN: ${WORKER_INTERNAL_TOKEN:-local-worker-token}
       SERVER_FORWARD_HEADERS_STRATEGY: framework
       MINIO_ENDPOINT: http://minio:9000
-      MINIO_PUBLIC_ENDPOINT: ${MINIO_PUBLIC_ENDPOINT:-http://localhost:9000}
+      MINIO_PUBLIC_ENDPOINT: ${MINIO_PUBLIC_ENDPOINT:-http://localhost}
       MINIO_ACCESS_KEY: ${MINIO_ROOT_USER:-minioadmin}
       MINIO_SECRET_KEY: ${MINIO_ROOT_PASSWORD:-minioadmin}
       MINIO_BUCKET: ${MINIO_BUCKET:-image-preprocess-local}

--- a/infra/nginx/conf.d/api.conf
+++ b/infra/nginx/conf.d/api.conf
@@ -3,6 +3,11 @@ location /api/ {
     proxy_pass http://backend_api;
 }
 
+location = /oauth2/success {
+    include /etc/nginx/snippets/proxy.conf;
+    proxy_pass http://frontend_app;
+}
+
 location /oauth2/ {
     include /etc/nginx/snippets/proxy.conf;
     proxy_pass http://backend_api;

--- a/infra/nginx/conf.d/app.conf
+++ b/infra/nginx/conf.d/app.conf
@@ -8,6 +8,11 @@ upstream frontend_app {
     keepalive 16;
 }
 
+upstream minio_api {
+    server minio:9000;
+    keepalive 16;
+}
+
 server {
     listen 80;
     server_name _;
@@ -24,6 +29,14 @@ server {
         access_log off;
         default_type text/plain;
         return 200 "ok\n";
+    }
+
+    location /image-preprocess-local/ {
+        client_max_body_size 2g;
+        proxy_request_buffering off;
+        proxy_buffering off;
+        proxy_pass http://minio_api;
+        include /etc/nginx/snippets/proxy.conf;
     }
 
     location /assets/ {


### PR DESCRIPTION
## #️⃣ 기능 설명

로컬 MVP 업로드 화면을 다중 이미지 배치 업로드/전처리 콘솔로 확장하고, OAuth success 흐름에서 access token이 URL과 UI에 노출되지 않도록 수정했습니다.

Closes #85

## 🛠️ 작업 상세 내용

- [x] `/upload`에서 여러 이미지 파일 선택, checksum 계산, presigned URL 일괄 발급, MinIO 병렬 업로드, upload complete 처리
- [x] 여러 imageId를 하나의 Job으로 생성하고 item별 진행률/결과 artifact 표시
- [x] processed, preview, report item별 다운로드 버튼 제공
- [x] OAuth 성공 redirect에서 `accessToken` query 제거, refresh cookie 기반 `/api/v1/auth/refresh`로 access token 확보
- [x] access token 입력 필드 제거 및 URL query token 즉시 제거 fallback 추가
- [x] SaaS형 batch operations console 스타일로 전반 UI 개편
- [x] 인증/Swagger/feature spec 문서 갱신

## 📁 변경 파일 요약

- `backend-api/src/main/java/.../OAuth2LoginSuccessHandler.java`
- `frontend/src/pages/UploadPage.tsx`
- `frontend/src/pages/OAuthSuccessPage.tsx`
- `frontend/src/shared/api/apiClient.ts`
- `frontend/src/shared/hooks/useAccessToken.ts`
- `frontend/src/styles/global.css`
- `docs/api/auth-token-flow.md`
- `docs/api/swagger-openapi.md`
- `docs/feature-specs/issue-85-batch-upload-secure-saas-ux.md`

## ✅ 검증 내용

- [x] `frontend`: `npm run build` 통과
- [x] `backend-api`: Docker Gradle `gradle test --no-daemon` 통과
- [x] `git diff --check` 통과
- [x] access token URL/query 노출 문구 검색 확인

## 🔎 리뷰어가 확인해야 할 부분

- OAuth success가 이제 access token을 URL로 넘기지 않고 refresh cookie 기반으로 동작하는지
- 다중 파일 선택 후 upload session, presigned URL, complete, job 생성 흐름이 기존 backend API 계약과 맞는지
- 새 Upload UI가 실제 로컬 Docker smoke flow에서 여러 이미지 처리에 적합한지

## 📸 스크린샷

로컬 브라우저에서 `/upload` batch console 확인 필요.

## 💬 기타 공유사항 to 리뷰어

- 기존 backend API가 이미 다중 files와 다중 imageIds를 받을 수 있어, 이번 작업은 대부분 frontend flow 확장입니다.
- Worker는 계속 OCR 텍스트 추출이 아니라 OCR 전처리만 수행합니다.
