### PR TITLE
✨ [Feat] ZIP 업로드와 처리 결과 ZIP 다운로드 지원

### DIFF
--- a/backend-api/src/main/java/com/moonju/preprocess/api/domain/job/controller/JobController.java
+++ b/backend-api/src/main/java/com/moonju/preprocess/api/domain/job/controller/JobController.java
@@ -9,10 +9,12 @@ import com.moonju.preprocess.api.domain.job.dto.JobItemResponse;
 import com.moonju.preprocess.api.domain.job.dto.JobResponse;
 import com.moonju.preprocess.api.domain.job.dto.JobRetryResponse;
 import com.moonju.preprocess.api.domain.job.dto.JobSummaryResponse;
+import com.moonju.preprocess.api.domain.job.dto.JobZipDownloadResponse;
 import com.moonju.preprocess.api.domain.job.service.JobCancelService;
 import com.moonju.preprocess.api.domain.job.service.JobCommandService;
 import com.moonju.preprocess.api.domain.job.service.JobQueryService;
 import com.moonju.preprocess.api.domain.job.service.JobRetryService;
+import com.moonju.preprocess.api.domain.job.service.JobZipDownloadService;
 import com.moonju.preprocess.api.global.error.ErrorCode;
 import com.moonju.preprocess.api.global.response.ApiResponse;
 import com.moonju.preprocess.api.global.response.PageResponse;
@@ -36,17 +38,20 @@ public class JobController {
     private final JobQueryService jobQueryService;
     private final JobCancelService jobCancelService;
     private final JobRetryService jobRetryService;
+    private final JobZipDownloadService jobZipDownloadService;
 
     public JobController(
         JobCommandService jobCommandService,
         JobQueryService jobQueryService,
         JobCancelService jobCancelService,
-        JobRetryService jobRetryService
+        JobRetryService jobRetryService,
+        JobZipDownloadService jobZipDownloadService
     ) {
         this.jobCommandService = jobCommandService;
         this.jobQueryService = jobQueryService;
         this.jobCancelService = jobCancelService;
         this.jobRetryService = jobRetryService;
+        this.jobZipDownloadService = jobZipDownloadService;
     }
 
     @PostMapping
@@ -115,7 +120,7 @@ public class JobController {
     }
 
     @GetMapping("/{jobId}/download.zip")
-    public ApiResponse<JobArtifactResponse> downloadZip(@CurrentUser Long currentUserId, @PathVariable Long jobId) {
-        return ApiResponse.success(jobQueryService.artifacts(currentUserId, jobId));
+    public ApiResponse<JobZipDownloadResponse> downloadZip(@CurrentUser Long currentUserId, @PathVariable Long jobId) {
+        return ApiResponse.success(jobZipDownloadService.createProcessedZip(currentUserId, jobId));
     }
 }

--- a/backend-api/src/main/java/com/moonju/preprocess/api/domain/job/dto/JobZipDownloadResponse.java
+++ b/backend-api/src/main/java/com/moonju/preprocess/api/domain/job/dto/JobZipDownloadResponse.java
@@ -1,0 +1,23 @@
+package com.moonju.preprocess.api.domain.job.dto;
+
+import com.moonju.preprocess.api.infra.storage.PresignedDownloadTarget;
+import java.time.Instant;
+
+public record JobZipDownloadResponse(
+    Long jobId,
+    int fileCount,
+    String objectKey,
+    String downloadUrl,
+    Instant expiresAt
+) {
+
+    public static JobZipDownloadResponse of(Long jobId, int fileCount, PresignedDownloadTarget target) {
+        return new JobZipDownloadResponse(
+            jobId,
+            fileCount,
+            target.objectKey(),
+            target.downloadUrl(),
+            target.expiresAt()
+        );
+    }
+}

--- a/backend-api/src/main/java/com/moonju/preprocess/api/domain/job/service/JobZipDownloadService.java
+++ b/backend-api/src/main/java/com/moonju/preprocess/api/domain/job/service/JobZipDownloadService.java
@@ -1,0 +1,111 @@
+package com.moonju.preprocess.api.domain.job.service;
+
+import com.moonju.preprocess.api.domain.job.dto.JobZipDownloadResponse;
+import com.moonju.preprocess.api.domain.job.entity.Job;
+import com.moonju.preprocess.api.domain.job.entity.JobItem;
+import com.moonju.preprocess.api.domain.job.entity.JobItemStatus;
+import com.moonju.preprocess.api.domain.job.exception.JobNotFoundException;
+import com.moonju.preprocess.api.domain.job.repository.JobItemRepository;
+import com.moonju.preprocess.api.domain.job.repository.JobRepository;
+import com.moonju.preprocess.api.domain.project.service.ProjectPermissionService;
+import com.moonju.preprocess.api.global.error.BusinessException;
+import com.moonju.preprocess.api.global.error.ErrorCode;
+import com.moonju.preprocess.api.infra.storage.ObjectStoragePort;
+import com.moonju.preprocess.api.infra.storage.PresignedDownloadCommand;
+import com.moonju.preprocess.api.infra.storage.PresignedDownloadTarget;
+import com.moonju.preprocess.api.infra.storage.PresignedDownloadUrlGenerator;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.time.Duration;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
+import org.springframework.stereotype.Service;
+
+@Service
+public class JobZipDownloadService {
+
+    private static final Duration DOWNLOAD_URL_EXPIRES_IN = Duration.ofMinutes(10);
+    private static final String ZIP_CONTENT_TYPE = "application/zip";
+
+    private final JobRepository jobRepository;
+    private final JobItemRepository jobItemRepository;
+    private final ProjectPermissionService projectPermissionService;
+    private final ObjectStoragePort objectStoragePort;
+    private final PresignedDownloadUrlGenerator presignedDownloadUrlGenerator;
+
+    public JobZipDownloadService(
+        JobRepository jobRepository,
+        JobItemRepository jobItemRepository,
+        ProjectPermissionService projectPermissionService,
+        ObjectStoragePort objectStoragePort,
+        PresignedDownloadUrlGenerator presignedDownloadUrlGenerator
+    ) {
+        this.jobRepository = jobRepository;
+        this.jobItemRepository = jobItemRepository;
+        this.projectPermissionService = projectPermissionService;
+        this.objectStoragePort = objectStoragePort;
+        this.presignedDownloadUrlGenerator = presignedDownloadUrlGenerator;
+    }
+
+    public JobZipDownloadResponse createProcessedZip(Long currentUserId, Long jobId) {
+        Job job = jobRepository.findById(jobId).orElseThrow(JobNotFoundException::new);
+        projectPermissionService.validateReadable(job.getProjectId(), currentUserId);
+
+        List<JobItem> readyItems = jobItemRepository
+            .findAllByJobIdAndStatusIn(job.getId(), Set.of(JobItemStatus.SUCCEEDED))
+            .stream()
+            .filter(item -> item.getProcessedObjectKey() != null && !item.getProcessedObjectKey().isBlank())
+            .toList();
+        if (readyItems.isEmpty()) {
+            throw new BusinessException(ErrorCode.COMMON_NOT_FOUND, "No processed images are ready for ZIP download.");
+        }
+
+        byte[] zipBytes = createZipBytes(readyItems);
+        String archiveObjectKey = archiveObjectKey(job);
+        objectStoragePort.uploadBytes(archiveObjectKey, zipBytes, ZIP_CONTENT_TYPE);
+        PresignedDownloadTarget target = presignedDownloadUrlGenerator.generateDownloadUrl(
+            new PresignedDownloadCommand(archiveObjectKey, DOWNLOAD_URL_EXPIRES_IN)
+        );
+        return JobZipDownloadResponse.of(job.getId(), readyItems.size(), target);
+    }
+
+    private byte[] createZipBytes(List<JobItem> items) {
+        try (ByteArrayOutputStream byteStream = new ByteArrayOutputStream();
+             ZipOutputStream zipStream = new ZipOutputStream(byteStream)) {
+            for (JobItem item : items) {
+                zipStream.putNextEntry(new ZipEntry(entryName(item)));
+                zipStream.write(objectStoragePort.downloadBytes(item.getProcessedObjectKey()));
+                zipStream.closeEntry();
+            }
+            zipStream.finish();
+            return byteStream.toByteArray();
+        } catch (IOException exception) {
+            throw new BusinessException(ErrorCode.COMMON_INTERNAL_SERVER_ERROR, "Failed to create processed ZIP.");
+        }
+    }
+
+    private String archiveObjectKey(Job job) {
+        return "archives/%d/%d/processed-results.zip".formatted(job.getProjectId(), job.getId());
+    }
+
+    private String entryName(JobItem item) {
+        return "image-%d-item-%d-processed%s".formatted(
+            item.getImageId(),
+            item.getId(),
+            extension(item.getProcessedObjectKey())
+        );
+    }
+
+    private String extension(String objectKey) {
+        int lastSlash = objectKey.lastIndexOf('/');
+        int lastDot = objectKey.lastIndexOf('.');
+        if (lastDot <= lastSlash || lastDot == objectKey.length() - 1) {
+            return ".png";
+        }
+        String extension = objectKey.substring(lastDot).toLowerCase(Locale.ROOT);
+        return extension.length() > 12 ? ".png" : extension;
+    }
+}

--- a/backend-api/src/main/java/com/moonju/preprocess/api/infra/storage/LocalObjectStorageAdapter.java
+++ b/backend-api/src/main/java/com/moonju/preprocess/api/infra/storage/LocalObjectStorageAdapter.java
@@ -1,9 +1,31 @@
 package com.moonju.preprocess.api.infra.storage;
 
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
 public class LocalObjectStorageAdapter implements ObjectStoragePort {
+
+    private final Map<String, byte[]> objects = new ConcurrentHashMap<>();
 
     @Override
     public boolean exists(String objectKey) {
-        return true;
+        return objects.containsKey(objectKey);
+    }
+
+    @Override
+    public byte[] downloadBytes(String objectKey) {
+        byte[] bytes = objects.get(objectKey);
+        if (bytes == null) {
+            throw new ObjectStorageAccessException(
+                "Local object not found: " + objectKey,
+                new IllegalArgumentException(objectKey)
+            );
+        }
+        return bytes;
+    }
+
+    @Override
+    public void uploadBytes(String objectKey, byte[] bytes, String contentType) {
+        objects.put(objectKey, bytes);
     }
 }

--- a/backend-api/src/main/java/com/moonju/preprocess/api/infra/storage/MinioObjectStorageAdapter.java
+++ b/backend-api/src/main/java/com/moonju/preprocess/api/infra/storage/MinioObjectStorageAdapter.java
@@ -1,10 +1,13 @@
 package com.moonju.preprocess.api.infra.storage;
 
 import io.minio.GetPresignedObjectUrlArgs;
+import io.minio.GetObjectArgs;
 import io.minio.Http.Method;
 import io.minio.MinioClient;
+import io.minio.PutObjectArgs;
 import io.minio.StatObjectArgs;
 import io.minio.errors.ErrorResponseException;
+import java.io.ByteArrayInputStream;
 import java.time.Instant;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
@@ -48,6 +51,32 @@ public class MinioObjectStorageAdapter
             throw new ObjectStorageAccessException("Object storage stat failed: " + objectKey, exception);
         } catch (Exception exception) {
             throw new ObjectStorageAccessException("Object storage stat failed: " + objectKey, exception);
+        }
+    }
+
+    @Override
+    public byte[] downloadBytes(String objectKey) {
+        try (var response = internalClient.getObject(GetObjectArgs.builder()
+            .bucket(properties.getBucket())
+            .object(objectKey)
+            .build())) {
+            return response.readAllBytes();
+        } catch (Exception exception) {
+            throw new ObjectStorageAccessException("Object storage download failed: " + objectKey, exception);
+        }
+    }
+
+    @Override
+    public void uploadBytes(String objectKey, byte[] bytes, String contentType) {
+        try (var input = new ByteArrayInputStream(bytes)) {
+            internalClient.putObject(PutObjectArgs.builder()
+                .bucket(properties.getBucket())
+                .object(objectKey)
+                .contentType(contentType)
+                .stream(input, (long) bytes.length, -1L)
+                .build());
+        } catch (Exception exception) {
+            throw new ObjectStorageAccessException("Object storage upload failed: " + objectKey, exception);
         }
     }
 

--- a/backend-api/src/main/java/com/moonju/preprocess/api/infra/storage/ObjectStoragePort.java
+++ b/backend-api/src/main/java/com/moonju/preprocess/api/infra/storage/ObjectStoragePort.java
@@ -3,4 +3,8 @@ package com.moonju.preprocess.api.infra.storage;
 public interface ObjectStoragePort {
 
     boolean exists(String objectKey);
+
+    byte[] downloadBytes(String objectKey);
+
+    void uploadBytes(String objectKey, byte[] bytes, String contentType);
 }

--- a/backend-api/src/test/java/com/moonju/preprocess/api/domain/job/controller/JobControllerTests.java
+++ b/backend-api/src/test/java/com/moonju/preprocess/api/domain/job/controller/JobControllerTests.java
@@ -13,6 +13,7 @@ import com.moonju.preprocess.api.domain.job.service.JobCancelService;
 import com.moonju.preprocess.api.domain.job.service.JobCommandService;
 import com.moonju.preprocess.api.domain.job.service.JobQueryService;
 import com.moonju.preprocess.api.domain.job.service.JobRetryService;
+import com.moonju.preprocess.api.domain.job.service.JobZipDownloadService;
 import com.moonju.preprocess.api.global.response.ApiResponse;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -36,6 +37,9 @@ class JobControllerTests {
 
     @Mock
     private JobRetryService jobRetryService;
+
+    @Mock
+    private JobZipDownloadService jobZipDownloadService;
 
     @Test
     void createsJobWithCommonCreatedResponse() {
@@ -79,6 +83,12 @@ class JobControllerTests {
     }
 
     private JobController controller() {
-        return new JobController(jobCommandService, jobQueryService, jobCancelService, jobRetryService);
+        return new JobController(
+            jobCommandService,
+            jobQueryService,
+            jobCancelService,
+            jobRetryService,
+            jobZipDownloadService
+        );
     }
 }

--- a/backend-api/src/test/java/com/moonju/preprocess/api/domain/job/service/JobZipDownloadServiceTests.java
+++ b/backend-api/src/test/java/com/moonju/preprocess/api/domain/job/service/JobZipDownloadServiceTests.java
@@ -1,0 +1,131 @@
+package com.moonju.preprocess.api.domain.job.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.moonju.preprocess.api.domain.job.dto.JobZipDownloadResponse;
+import com.moonju.preprocess.api.domain.job.entity.Job;
+import com.moonju.preprocess.api.domain.job.entity.JobItem;
+import com.moonju.preprocess.api.domain.job.entity.JobItemStatus;
+import com.moonju.preprocess.api.domain.job.entity.JobPriority;
+import com.moonju.preprocess.api.domain.job.repository.JobItemRepository;
+import com.moonju.preprocess.api.domain.job.repository.JobRepository;
+import com.moonju.preprocess.api.domain.project.service.ProjectPermissionService;
+import com.moonju.preprocess.api.global.error.BusinessException;
+import com.moonju.preprocess.api.infra.storage.ObjectStoragePort;
+import com.moonju.preprocess.api.infra.storage.PresignedDownloadCommand;
+import com.moonju.preprocess.api.infra.storage.PresignedDownloadTarget;
+import com.moonju.preprocess.api.infra.storage.PresignedDownloadUrlGenerator;
+import java.io.ByteArrayInputStream;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.zip.ZipInputStream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+class JobZipDownloadServiceTests {
+
+    @Mock
+    private JobRepository jobRepository;
+
+    @Mock
+    private JobItemRepository jobItemRepository;
+
+    @Mock
+    private ProjectPermissionService projectPermissionService;
+
+    @Mock
+    private ObjectStoragePort objectStoragePort;
+
+    @Mock
+    private PresignedDownloadUrlGenerator presignedDownloadUrlGenerator;
+
+    @InjectMocks
+    private JobZipDownloadService service;
+
+    @Test
+    void createsProcessedZipAndReturnsDownloadUrl() throws Exception {
+        Job job = job();
+        JobItem first = succeededItem(2L, 100L, "processed/10/1/2/processed.png");
+        JobItem second = succeededItem(3L, 101L, "processed/10/1/3/processed.webp");
+        when(jobRepository.findById(1L)).thenReturn(Optional.of(job));
+        when(jobItemRepository.findAllByJobIdAndStatusIn(eq(1L), any())).thenReturn(List.of(first, second));
+        when(objectStoragePort.downloadBytes("processed/10/1/2/processed.png")).thenReturn("first".getBytes());
+        when(objectStoragePort.downloadBytes("processed/10/1/3/processed.webp")).thenReturn("second".getBytes());
+        when(presignedDownloadUrlGenerator.generateDownloadUrl(any(PresignedDownloadCommand.class)))
+            .thenReturn(new PresignedDownloadTarget(
+                "archives/10/1/processed-results.zip",
+                "http://localhost/image-preprocess-local/archives/10/1/processed-results.zip",
+                Instant.parse("2026-05-16T00:00:00Z"),
+                Map.of()
+            ));
+
+        JobZipDownloadResponse response = service.createProcessedZip(20L, 1L);
+
+        assertThat(response.fileCount()).isEqualTo(2);
+        assertThat(response.objectKey()).isEqualTo("archives/10/1/processed-results.zip");
+        verify(projectPermissionService).validateReadable(10L, 20L);
+
+        ArgumentCaptor<byte[]> zipBytes = ArgumentCaptor.forClass(byte[].class);
+        verify(objectStoragePort).uploadBytes(
+            eq("archives/10/1/processed-results.zip"),
+            zipBytes.capture(),
+            eq("application/zip")
+        );
+        assertThat(zipEntryNames(zipBytes.getValue())).containsExactly(
+            "image-100-item-2-processed.png",
+            "image-101-item-3-processed.webp"
+        );
+    }
+
+    @Test
+    void rejectsZipDownloadWhenNoProcessedImagesAreReady() {
+        Job job = job();
+        when(jobRepository.findById(1L)).thenReturn(Optional.of(job));
+        when(jobItemRepository.findAllByJobIdAndStatusIn(eq(1L), any())).thenReturn(List.of());
+
+        assertThatThrownBy(() -> service.createProcessedZip(20L, 1L))
+            .isInstanceOf(BusinessException.class)
+            .hasMessage("No processed images are ready for ZIP download.");
+        verify(objectStoragePort, never()).uploadBytes(any(), any(), any());
+    }
+
+    private Job job() {
+        Job job = Job.create(10L, 20L, "A4_SCAN_300DPI", Map.of(), false, JobPriority.NORMAL, 2);
+        ReflectionTestUtils.setField(job, "id", 1L);
+        return job;
+    }
+
+    private JobItem succeededItem(Long id, Long imageId, String processedObjectKey) {
+        JobItem item = new JobItem(1L, imageId, JobItemStatus.SUCCEEDED, 1);
+        item.registerArtifacts(processedObjectKey, null, null);
+        ReflectionTestUtils.setField(item, "id", id);
+        return item;
+    }
+
+    private List<String> zipEntryNames(byte[] bytes) throws Exception {
+        List<String> names = new ArrayList<>();
+        try (ZipInputStream input = new ZipInputStream(new ByteArrayInputStream(bytes))) {
+            var entry = input.getNextEntry();
+            while (entry != null) {
+                names.add(entry.getName());
+                entry = input.getNextEntry();
+            }
+        }
+        return names;
+    }
+}

--- a/docs/api/job-api.md
+++ b/docs/api/job-api.md
@@ -57,7 +57,7 @@ All endpoints require `Authorization: Bearer <access-token>`.
 | `POST` | `/api/v1/jobs/{jobId}/retry` | Retry failed and dead-lettered items |
 | `POST` | `/api/v1/jobs/{jobId}/rerun` | Requeue all non-processing items |
 | `GET` | `/api/v1/jobs/{jobId}/artifacts` | Read artifact listing placeholder |
-| `GET` | `/api/v1/jobs/{jobId}/download.zip` | Read ZIP download placeholder |
+| `GET` | `/api/v1/jobs/{jobId}/download.zip` | Create processed image ZIP download URL |
 
 Internal Worker endpoints are not user-facing APIs. They require `X-Worker-Token` and are mounted under
 `/internal/v1/**`.
@@ -188,6 +188,46 @@ Rules:
 - `type` must be one of `processed`, `preview`, or `report`.
 - If the Worker has not registered the requested object key yet, the API returns `common404`.
 - Debug artifact expansion remains separate from this JobItem-level result download flow.
+
+## Processed ZIP Download
+
+```text
+GET /api/v1/jobs/{jobId}/download.zip
+```
+
+The API creates a ZIP archive from succeeded JobItems that have a `processedObjectKey`, uploads the archive to object
+storage, and returns a temporary download URL. The archive contains processed images only. Preview images, processing
+reports, and debug artifacts are intentionally excluded from this MVP download flow.
+
+Archive object key:
+
+```text
+archives/{projectId}/{jobId}/processed-results.zip
+```
+
+Response:
+
+```json
+{
+  "isSuccess": true,
+  "code": "common200",
+  "message": "Request succeeded.",
+  "result": {
+    "jobId": 1,
+    "fileCount": 3,
+    "objectKey": "archives/10/1/processed-results.zip",
+    "downloadUrl": "http://localhost/image-preprocess-local/archives/10/1/processed-results.zip?...",
+    "expiresAt": "2026-05-16T00:00:00Z"
+  }
+}
+```
+
+Rules:
+
+- The current user must have read permission for the Job's project.
+- Only `SUCCEEDED` items with a non-empty `processedObjectKey` are included.
+- If no processed images are ready, the API returns `common404`.
+- The ZIP file is regenerated on request so the archive reflects the latest processed item set.
 
 ## Summary
 
@@ -327,5 +367,5 @@ POST /api/v1/jobs/{jobId}/rerun
 
 ## Current Limitations
 
-- Artifact listing and ZIP download currently return placeholders.
+- Artifact listing currently returns a placeholder.
 - Detailed debug artifact row expansion is deferred to a later artifact domain task.

--- a/docs/api/upload-api.md
+++ b/docs/api/upload-api.md
@@ -15,6 +15,8 @@ then notify the API that the upload is complete.
 - Upload session access is controlled by project membership, not only by the user who created the session.
 - Supported image extensions are `png`, `jpg`, `jpeg`, `tif`, `tiff`, `bmp`, and `webp`.
 - Checksums are collected as SHA-256 hex strings and are used for duplicate detection.
+- In the local frontend MVP, ZIP files are expanded in the browser before this API is called. The API still receives
+  image file entries through the normal upload session and presigned URL flow.
 
 ## Endpoints
 
@@ -142,4 +144,4 @@ Response:
 
 - Replace the local presigned URL generator with a MinIO/S3 adapter.
 - Add image magic number validation after object download or metadata extraction.
-- Add ZIP upload as a separate expansion task.
+- Add server-side ZIP extraction only if browser-side extraction becomes too slow for the expected batch size.

--- a/docs/feature-specs/issue-87-zip-upload-result-download.md
+++ b/docs/feature-specs/issue-87-zip-upload-result-download.md
@@ -1,0 +1,117 @@
+# Issue 87 - ZIP Upload And Processed Result Download
+
+## Scope
+
+This task adds two local MVP workflow improvements:
+
+1. Users can select a ZIP file in the frontend upload page.
+2. Users can download all processed images for a Job as one ZIP file.
+
+This does not change the core architecture. The Spring API still avoids receiving large file bodies directly, and the
+Worker remains responsible for preprocessing images.
+
+## ZIP Upload Flow
+
+The frontend expands ZIP files in the browser with `jszip`.
+
+```text
+User selects images or a ZIP file
+  -> Frontend extracts supported image entries from ZIP
+  -> Frontend creates one upload session for extracted images
+  -> Frontend requests presigned upload URLs
+  -> Frontend uploads each extracted image to object storage
+  -> Frontend completes the upload session
+  -> Frontend creates a preprocessing Job
+```
+
+Supported image entries:
+
+- `png`
+- `jpg`
+- `jpeg`
+- `webp`
+- `bmp`
+- `tif`
+- `tiff`
+
+Limits:
+
+- Maximum extracted images per ZIP: `500`
+- Maximum extracted image bytes per ZIP: `512 MB`
+
+Reasoning:
+
+- Browser-side extraction keeps the Spring API out of large multipart ZIP uploads.
+- The existing presigned upload and checksum validation path is reused.
+- Each extracted image still becomes a separate JobItem and RabbitMQ message.
+
+## Processed ZIP Download Flow
+
+```text
+User clicks "Download processed ZIP"
+  -> Frontend calls GET /api/v1/jobs/{jobId}/download.zip
+  -> API validates project read permission
+  -> API finds SUCCEEDED JobItems with processedObjectKey
+  -> API downloads processed images from object storage
+  -> API creates processed-results.zip
+  -> API uploads archive to object storage
+  -> API returns a presigned download URL
+  -> Frontend downloads the ZIP file
+```
+
+Archive path:
+
+```text
+archives/{projectId}/{jobId}/processed-results.zip
+```
+
+ZIP contents:
+
+- Processed images only.
+- Preview images are excluded.
+- Processing reports are excluded.
+- Debug artifacts are excluded.
+
+Entry name format:
+
+```text
+image-{imageId}-item-{itemId}-processed.{ext}
+```
+
+## API Contract
+
+```text
+GET /api/v1/jobs/{jobId}/download.zip
+Authorization: Bearer <access-token>
+```
+
+Response:
+
+```json
+{
+  "isSuccess": true,
+  "code": "common200",
+  "message": "Request succeeded.",
+  "result": {
+    "jobId": 1,
+    "fileCount": 3,
+    "objectKey": "archives/10/1/processed-results.zip",
+    "downloadUrl": "http://localhost/image-preprocess-local/archives/10/1/processed-results.zip?...",
+    "expiresAt": "2026-05-16T00:00:00Z"
+  }
+}
+```
+
+Failure behavior:
+
+- `common404` when no processed images are ready.
+- Permission errors follow the project permission policy.
+
+## Completion Criteria
+
+- Frontend accepts image files and ZIP files on the upload page.
+- ZIP entries are expanded before presigned upload requests.
+- Backend creates a processed-only ZIP archive for completed JobItems.
+- Backend returns a presigned download URL for the generated archive.
+- API docs explain the ZIP upload and result download behavior.
+- Frontend build and backend tests pass.

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.1",
       "dependencies": {
         "@vitejs/plugin-react": "^4.3.4",
+        "jszip": "^3.10.1",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "typescript": "^5.6.3",
@@ -1151,6 +1152,11 @@
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg=="
     },
+    "node_modules/core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="
+    },
     "node_modules/csstype": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
@@ -1263,6 +1269,21 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/immediate": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ=="
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+    },
+    "node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -1288,6 +1309,25 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/jszip": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
+      "integrity": "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==",
+      "dependencies": {
+        "lie": "~3.3.0",
+        "pako": "~1.0.2",
+        "readable-stream": "~2.3.6",
+        "setimmediate": "^1.0.5"
+      }
+    },
+    "node_modules/lie": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
+      "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
+      "dependencies": {
+        "immediate": "~3.0.5"
       }
     },
     "node_modules/loose-envify": {
@@ -1336,6 +1376,11 @@
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.38.tgz",
       "integrity": "sha512-3qT/88Y3FbH/Kx4szpQQ4HzUbVrHPKTLVpVocKiLfoYvw9XSGOX2FmD2d6DrXbVYyAQTF2HeF6My8jmzx7/CRw=="
     },
+    "node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw=="
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -1379,6 +1424,11 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
+    },
     "node_modules/react": {
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
@@ -1408,6 +1458,20 @@
       "integrity": "sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
       }
     },
     "node_modules/rollup": {
@@ -1453,6 +1517,11 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+    },
     "node_modules/scheduler": {
       "version": "0.23.2",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
@@ -1469,12 +1538,25 @@
         "semver": "bin/semver.js"
       }
     },
+    "node_modules/setimmediate": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+      "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA=="
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
       "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
       }
     },
     "node_modules/tinyglobby": {
@@ -1532,6 +1614,11 @@
       "peerDependencies": {
         "browserslist": ">= 4.21.0"
       }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
     },
     "node_modules/vite": {
       "version": "6.4.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,10 +10,11 @@
   },
   "dependencies": {
     "@vitejs/plugin-react": "^4.3.4",
-    "vite": "^6.4.2",
-    "typescript": "^5.6.3",
+    "jszip": "^3.10.1",
     "react": "^18.3.1",
-    "react-dom": "^18.3.1"
+    "react-dom": "^18.3.1",
+    "typescript": "^5.6.3",
+    "vite": "^6.4.2"
   },
   "devDependencies": {
     "@types/react": "^18.3.12",

--- a/frontend/src/pages/UploadPage.tsx
+++ b/frontend/src/pages/UploadPage.tsx
@@ -1,4 +1,5 @@
 import { FormEvent, useEffect, useMemo, useState } from 'react';
+import JSZip from 'jszip';
 import { apiClient } from '../shared/api/apiClient';
 import { readStoredAccessToken } from '../shared/auth/accessTokenStore';
 import { PageSection } from '../shared/components/PageSection';
@@ -69,6 +70,14 @@ type JobItemDownloadUrlResponse = {
   expiresAt: string;
 };
 
+type JobZipDownloadResponse = {
+  jobId: number;
+  fileCount: number;
+  objectKey: string;
+  downloadUrl: string;
+  expiresAt: string;
+};
+
 type SelectedUploadFile = {
   key: string;
   file: File;
@@ -92,6 +101,11 @@ type SmokeResult = {
   items?: JobItemResponse[];
 };
 
+const imageExtensions = ['.png', '.jpg', '.jpeg', '.webp', '.bmp', '.tif', '.tiff'];
+const zipExtensions = ['.zip'];
+const maxZipImages = 500;
+const maxZipTotalBytes = 512 * 1024 * 1024;
+
 export function UploadPage() {
   const [accessToken] = useState(() => readStoredAccessToken() ?? '');
   const [projects, setProjects] = useState<ProjectResponse[]>([]);
@@ -101,6 +115,7 @@ export function UploadPage() {
   const [fileRows, setFileRows] = useState<FileUploadRow[]>([]);
   const [debug, setDebug] = useState(true);
   const [busy, setBusy] = useState(false);
+  const [zipDownloading, setZipDownloading] = useState(false);
   const [logs, setLogs] = useState<string[]>([]);
   const [result, setResult] = useState<SmokeResult>({});
   const [error, setError] = useState<string | null>(null);
@@ -110,6 +125,7 @@ export function UploadPage() {
     [selectedFiles]
   );
   const completedItems = result.summary ? result.summary.succeeded + result.summary.failed : 0;
+  const processedItems = result.items?.filter((item) => item.processedObjectKey) ?? [];
 
   useEffect(() => {
     if (!accessToken) {
@@ -372,21 +388,57 @@ export function UploadPage() {
     }
   }
 
-  function handleFileSelection(files: FileList | null) {
-    const nextFiles = Array.from(files ?? []).map((file, index) => ({
-      key: `${file.name}-${file.size}-${file.lastModified}-${index}`,
-      file
-    }));
-    setSelectedFiles(nextFiles);
-    setFileRows(nextFiles.map((entry) => ({
-      key: entry.key,
-      name: entry.file.name,
-      size: entry.file.size,
-      phase: 'selected',
-      detail: 'Waiting'
-    })));
-    setResult({});
+  async function downloadProcessedZip() {
+    if (!result.job) {
+      setError('Job result is not ready yet.');
+      return;
+    }
+    setZipDownloading(true);
     setError(null);
+    try {
+      const response = await apiClient.get<JobZipDownloadResponse>(
+        `/v1/jobs/${result.job.jobId}/download.zip`,
+        accessToken
+      );
+      const anchor = document.createElement('a');
+      anchor.href = response.result.downloadUrl;
+      anchor.target = '_blank';
+      anchor.rel = 'noopener noreferrer';
+      anchor.download = `job-${response.result.jobId}-processed-results.zip`;
+      document.body.appendChild(anchor);
+      anchor.click();
+      anchor.remove();
+      appendLog(`Processed ZIP opened: ${response.result.fileCount} images`);
+    } catch (exception) {
+      setError(describeError(exception, 'Failed to download processed ZIP.'));
+    } finally {
+      setZipDownloading(false);
+    }
+  }
+
+  async function handleFileSelection(files: FileList | null) {
+    setError(null);
+    try {
+      const expandedFiles = await expandInputFiles(Array.from(files ?? []));
+      const nextFiles = expandedFiles.map((file, index) => ({
+        key: `${file.name}-${file.size}-${file.lastModified}-${index}`,
+        file
+      }));
+      setSelectedFiles(nextFiles);
+      setFileRows(nextFiles.map((entry) => ({
+        key: entry.key,
+        name: entry.file.name,
+        size: entry.file.size,
+        phase: 'selected',
+        detail: 'Waiting'
+      })));
+      setResult({});
+    } catch (exception) {
+      setSelectedFiles([]);
+      setFileRows([]);
+      setResult({});
+      setError(describeError(exception, 'Failed to read selected files.'));
+    }
   }
 
   function updateFileRow(key: string, patch: Partial<FileUploadRow>) {
@@ -451,7 +503,7 @@ export function UploadPage() {
           value={`${result.summary?.progressPercent.toFixed(0) ?? '0'}%`}
           detail={result.summary ? `${completedItems}/${result.summary.total} done` : 'not started'}
         />
-        <MetricCard label="Artifacts" value={String(result.items?.filter((item) => item.processedObjectKey).length ?? 0)} detail="ready" />
+        <MetricCard label="Processed" value={String(processedItems.length)} detail="ready" />
       </section>
 
       <form className="upload-layout" onSubmit={handleSubmit}>
@@ -487,17 +539,17 @@ export function UploadPage() {
 
           <PageSection
             title="2. Files"
-            description="Select multiple document images. Each image becomes a separate queue message."
+            description="Select multiple document images or one ZIP file. Each image becomes a separate queue message."
           >
             <label className="file-dropzone">
               <span>Drop zone</span>
               <strong>{selectedFiles.length > 0 ? `${selectedFiles.length} files ready` : 'Choose document images'}</strong>
-              <small>PNG, JPEG, WEBP, BMP, or TIFF. Duplicate checksums are rejected per project.</small>
+              <small>PNG, JPEG, WEBP, BMP, TIFF, or ZIP. ZIP files are expanded in the browser before upload.</small>
               <input
                 type="file"
                 multiple
-                accept="image/png,image/jpeg,image/jpg,image/webp,image/bmp,image/tiff"
-                onChange={(event) => handleFileSelection(event.target.files)}
+                accept="image/png,image/jpeg,image/jpg,image/webp,image/bmp,image/tiff,.zip,application/zip,application/x-zip-compressed"
+                onChange={(event) => void handleFileSelection(event.target.files)}
               />
             </label>
 
@@ -568,6 +620,14 @@ export function UploadPage() {
             <span className="status-pill accent">Results</span>
             <h2>Processed images</h2>
           </div>
+          <button
+            className="primary-action"
+            type="button"
+            disabled={processedItems.length === 0 || zipDownloading}
+            onClick={downloadProcessedZip}
+          >
+            {zipDownloading ? 'Preparing ZIP...' : 'Download processed ZIP'}
+          </button>
           <div className="artifact-grid">
             {result.items.map((item) => (
               <div className="artifact-card" key={item.id}>
@@ -605,11 +665,91 @@ async function runStep<T>(stepName: string, action: () => Promise<T>): Promise<T
   }
 }
 
+async function expandInputFiles(files: File[]) {
+  const expanded: File[] = [];
+  for (const file of files) {
+    if (isZipFile(file)) {
+      expanded.push(...await expandZipFile(file));
+    } else {
+      if (!isSupportedImageName(file.name)) {
+        throw new Error(`Unsupported file type: ${file.name}`);
+      }
+      expanded.push(file);
+    }
+  }
+  return expanded;
+}
+
+async function expandZipFile(file: File) {
+  const zip = await JSZip.loadAsync(file);
+  const entries = Object.values(zip.files).filter((entry) => !entry.dir && isSupportedImageName(entry.name));
+  if (entries.length === 0) {
+    throw new Error(`ZIP file does not contain supported images: ${file.name}`);
+  }
+  if (entries.length > maxZipImages) {
+    throw new Error(`ZIP file contains too many images. Limit: ${maxZipImages}`);
+  }
+
+  let totalBytes = 0;
+  const zipBaseName = stripExtension(file.name);
+  const expanded: File[] = [];
+  for (const entry of entries) {
+    const blob = await entry.async('blob');
+    totalBytes += blob.size;
+    if (totalBytes > maxZipTotalBytes) {
+      throw new Error('ZIP extracted image size exceeds the local MVP limit of 512 MB.');
+    }
+    const safeName = `${zipBaseName}-${entry.name.replace(/[\\/]+/g, '__')}`;
+    expanded.push(new File([blob], safeName, {
+      type: contentTypeFor(safeName),
+      lastModified: file.lastModified
+    }));
+  }
+  return expanded;
+}
+
 function describeError(exception: unknown, fallback: string) {
   if (exception instanceof Error && exception.message) {
     return exception.message;
   }
   return fallback;
+}
+
+function isZipFile(file: File) {
+  const lowerName = file.name.toLowerCase();
+  return zipExtensions.some((extension) => lowerName.endsWith(extension))
+    || file.type === 'application/zip'
+    || file.type === 'application/x-zip-compressed';
+}
+
+function isSupportedImageName(name: string) {
+  const lowerName = name.toLowerCase();
+  return imageExtensions.some((extension) => lowerName.endsWith(extension));
+}
+
+function stripExtension(name: string) {
+  const index = name.lastIndexOf('.');
+  return index > 0 ? name.slice(0, index) : name;
+}
+
+function contentTypeFor(name: string) {
+  const lowerName = name.toLowerCase();
+  if (lowerName.endsWith('.png')) {
+    return 'image/png';
+  }
+  if (lowerName.endsWith('.jpg') || lowerName.endsWith('.jpeg')) {
+    return 'image/jpeg';
+  }
+  if (lowerName.endsWith('.webp')) {
+    return 'image/webp';
+  }
+  if (lowerName.endsWith('.bmp')) {
+    return 'image/bmp';
+  }
+  if (lowerName.endsWith('.tif') || lowerName.endsWith('.tiff')) {
+    return 'image/tiff';
+  }
+  return 'application/octet-stream';
 }
 
 function safeOrigin(url: string) {


### PR DESCRIPTION
## #️⃣ 기능 설명

ZIP 파일을 브라우저에서 이미지로 확장해 기존 presigned 업로드 플로우로 처리하고, 완료된 Job의 processed 결과만 ZIP으로 묶어 다운로드할 수 있게 했습니다.

Closes #87

## 🛠️ 작업 상세 내용

- [x] 프론트 업로드 화면에서 ZIP 파일 선택 및 브라우저 측 이미지 확장 지원
- [x] `GET /api/v1/jobs/{jobId}/download.zip` processed-only ZIP 생성 API 구현
- [x] MinIO/ObjectStorage byte download/upload 포트 추가
- [x] ZIP 다운로드 서비스 테스트 추가
- [x] API/기능 명세 문서 갱신

## 📁 변경 파일 요약

- `frontend/src/pages/UploadPage.tsx`
- `backend-api/src/main/java/com/moonju/preprocess/api/domain/job/...`
- `backend-api/src/main/java/com/moonju/preprocess/api/infra/storage/...`
- `docs/api/job-api.md`
- `docs/api/upload-api.md`
- `docs/feature-specs/issue-87-zip-upload-result-download.md`

## ✅ 검증 내용

- [x] `cd frontend && npm run build`: 통과
- [x] `docker run --rm -v <repo>:/workspace -w /workspace/backend-api gradle:8.10-jdk21 gradle test --no-daemon`: 통과
- [x] `docker run --rm -v <repo>:/workspace -w /workspace/backend-api gradle:8.10-jdk21 gradle build --no-daemon`: 통과

## 🔎 리뷰어가 확인해야 할 부분

- ZIP 업로드를 서버 multipart 업로드가 아니라 브라우저 확장 + 기존 presigned 업로드로 처리하는 방향이 맞는지 확인해주세요.
- 결과 ZIP에는 processed 이미지만 포함하고 preview/report/debug를 제외하는 정책을 확인해주세요.

## 📸 스크린샷

없음

## 💬 기타 공유사항 to 리뷰어

- ZIP 확장 제한은 로컬 MVP 기준 최대 500장, 총 512MB입니다.
- ZIP 다운로드 요청 시 archive object는 `archives/{projectId}/{jobId}/processed-results.zip` 경로에 재생성됩니다.