### PR TITLE
🧪 [Test] Docker Compose 로컬 E2E 스모크 검증 추가

### DIFF
--- a/docs/feature-specs/issue-94-local-e2e-smoke.md
+++ b/docs/feature-specs/issue-94-local-e2e-smoke.md
@@ -1,0 +1,108 @@
+# Issue 94 - Docker Compose Local E2E Smoke
+
+## Goal
+
+Add a reproducible local MVP smoke flow for Docker Compose. The smoke flow verifies that the core preprocessing path
+works end to end before cloud deployment:
+
+```text
+Google-authenticated user token
+  -> create project
+  -> generate ZIP input and expand images
+  -> create upload session
+  -> upload originals through presigned URLs
+  -> complete upload session
+  -> create preprocessing Job
+  -> wait for Worker completion
+  -> download one processed image
+  -> download processed-results ZIP
+```
+
+OCR text extraction is intentionally out of scope. The smoke target is OCR preprocessing output generation.
+
+## Implementation
+
+The smoke runner is:
+
+```text
+scripts/local-e2e-smoke.ps1
+```
+
+The script:
+
+- Generates two synthetic document-like PNG images.
+- Compresses them into a ZIP file.
+- Expands the ZIP locally to mirror the frontend browser-side ZIP upload behavior.
+- Uses the normal API upload session and presigned object storage upload flow.
+- Creates one Job with both uploaded image IDs.
+- Polls Job summary and JobItem status until terminal state.
+- Downloads one processed image through the JobItem artifact download API.
+- Downloads the processed-only ZIP through `GET /api/v1/jobs/{jobId}/download.zip`.
+- Writes a `summary.json` file under `out/local-e2e-smoke/{runId}`.
+
+## Authentication
+
+The public APIs require a user access token. The script does not add a development auth bypass.
+
+To obtain a local token:
+
+1. Start Docker Compose.
+2. Open `http://localhost/login`.
+3. Sign in with Google.
+4. Open browser DevTools.
+5. Read the token:
+
+```javascript
+localStorage.getItem('doc-pipeline.access-token')
+```
+
+Then pass it as `-AccessToken` or set `ACCESS_TOKEN`.
+
+## Command
+
+From the repository root:
+
+```powershell
+.\scripts\local-e2e-smoke.ps1 -AccessToken "<access-token>"
+```
+
+Optional direct-backend mode:
+
+```powershell
+.\scripts\local-e2e-smoke.ps1 `
+  -BaseUrl "http://localhost:8080/api" `
+  -AccessToken "<access-token>"
+```
+
+## Success Criteria
+
+- Project creation returns `common200` or `common201`.
+- Upload session completes.
+- Job reaches terminal state before timeout.
+- `failed` count is `0`.
+- At least one JobItem has `processedObjectKey`.
+- Processed image download file exists and is non-empty.
+- Processed ZIP download file exists and is non-empty.
+
+## Output
+
+```text
+out/local-e2e-smoke/{runId}/
+  source/
+    smoke-document-001.png
+    smoke-document-002.png
+  extracted/
+    smoke-document-001.png
+    smoke-document-002.png
+  downloads/
+    processed-item-{itemId}.png
+    job-{jobId}-processed-results.zip
+  smoke-input.zip
+  summary.json
+```
+
+## Notes
+
+- The script creates a fresh project per run, so duplicate checksum validation should not block repeat runs.
+- The ZIP upload part is simulated at the client boundary by local expansion, matching the frontend design.
+- If the Worker is disabled, the script times out while polling the Job.

--- a/docs/operation/docker-compose-local.md
+++ b/docs/operation/docker-compose-local.md
@@ -74,7 +74,7 @@ The frontend uploads the original directly to MinIO through a presigned URL gene
 to the browser through:
 
 ```text
-MINIO_PUBLIC_ENDPOINT=http://localhost:9000
+MINIO_PUBLIC_ENDPOINT=http://localhost
 MINIO_API_CORS_ALLOW_ORIGIN=http://localhost,http://localhost:5173
 ```
 
@@ -89,6 +89,63 @@ processedObjectKey: processed/{projectId}/{jobId}/{itemId}/processed.png
 previewObjectKey: processed/{projectId}/{jobId}/{itemId}/preview.png
 reportObjectKey: processed/{projectId}/{jobId}/{itemId}/processing-report.json
 ```
+
+## API E2E Smoke Script
+
+For a repeatable Docker Compose MVP check, use:
+
+```powershell
+.\scripts\local-e2e-smoke.ps1 -AccessToken "<access-token>"
+```
+
+The script creates synthetic document images, packages them into a ZIP, expands the ZIP like the frontend upload page,
+uploads the extracted images through presigned URLs, creates a preprocessing Job, waits for Worker completion, and
+downloads:
+
+- one processed image
+- one processed-only ZIP archive
+
+The script writes run artifacts under:
+
+```text
+out/local-e2e-smoke/{runId}
+```
+
+### Access Token
+
+The script uses the normal authenticated APIs. It does not create a dev auth bypass.
+
+After signing in through `http://localhost/login`, open DevTools and read:
+
+```javascript
+localStorage.getItem('doc-pipeline.access-token')
+```
+
+Then either pass the token directly:
+
+```powershell
+.\scripts\local-e2e-smoke.ps1 -AccessToken "<access-token>"
+```
+
+Or set it for the current PowerShell session:
+
+```powershell
+$env:ACCESS_TOKEN = "<access-token>"
+.\scripts\local-e2e-smoke.ps1
+```
+
+### Direct Backend Mode
+
+If you want to bypass NGINX for API calls, use:
+
+```powershell
+.\scripts\local-e2e-smoke.ps1 `
+  -BaseUrl "http://localhost:8080/api" `
+  -AccessToken "<access-token>"
+```
+
+Keep the stack's `MINIO_PUBLIC_ENDPOINT` browser reachable. The default Docker Compose value points presigned URLs
+through `http://localhost`, which keeps MinIO downloads and uploads reachable from the host.
 
 ## Google OAuth Redirect URI
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,12 +1,28 @@
 # scripts
 
-로컬 실행, 정리, 운영 보조 스크립트를 두는 경로다.
+This directory contains local development and operation helper scripts.
 
-## 예정 파일
+## Current Scripts
 
-1. `local-up.sh`
-2. `local-down.sh`
-3. `seed-dev-data.sh`
-4. `clean-object-storage.sh`
+- `local-e2e-smoke.ps1`: Runs the Docker Compose local MVP flow through HTTP APIs. It creates synthetic document
+  images, simulates ZIP expansion, uploads through presigned URLs, creates a preprocessing Job, waits for Worker
+  completion, and downloads processed outputs.
 
-현재 PR에서는 실제 스크립트 구현 없이 경로만 고정한다.
+Run from the repository root:
+
+```powershell
+.\scripts\local-e2e-smoke.ps1 -AccessToken "<access-token>"
+```
+
+To get the token, sign in through `http://localhost/login` and read this value in browser DevTools:
+
+```javascript
+localStorage.getItem('doc-pipeline.access-token')
+```
+
+## Planned Scripts
+
+- `local-up.sh`
+- `local-down.sh`
+- `seed-dev-data.sh`
+- `clean-object-storage.sh`

--- a/scripts/local-e2e-smoke.ps1
+++ b/scripts/local-e2e-smoke.ps1
@@ -1,0 +1,325 @@
+<#
+.SYNOPSIS
+Runs the local Docker Compose MVP smoke flow through HTTP APIs.
+
+.DESCRIPTION
+This script creates synthetic document images, packages them into a ZIP, expands the ZIP locally to mirror the
+frontend ZIP-upload behavior, uploads the extracted images through presigned URLs, creates a preprocessing Job, waits
+for Worker completion, and downloads one processed image plus the processed-results ZIP.
+
+The script needs a real user access token because the public APIs are protected by Google OAuth login.
+#>
+[CmdletBinding()]
+param(
+    [string]$AccessToken = $env:ACCESS_TOKEN,
+    [string]$BaseUrl = "http://localhost/api",
+    [string]$ProjectName = "Local E2E Smoke $(Get-Date -Format 'yyyyMMdd-HHmmss')",
+    [string]$OutputDirectory = "out/local-e2e-smoke",
+    [int]$TimeoutSeconds = 180
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+if ([string]::IsNullOrWhiteSpace($AccessToken)) {
+    throw "Access token is required. Sign in at http://localhost/login, then run localStorage.getItem('doc-pipeline.access-token') in DevTools, or set ACCESS_TOKEN."
+}
+
+$script:AccessToken = $AccessToken
+$script:BaseUrl = $BaseUrl.TrimEnd("/")
+
+function Write-Step {
+    param([string]$Message)
+    Write-Host "==> $Message"
+}
+
+function Join-ApiUrl {
+    param([string]$Path)
+    if ($Path.StartsWith("/")) {
+        return "$script:BaseUrl$Path"
+    }
+    return "$script:BaseUrl/$Path"
+}
+
+function Invoke-Api {
+    param(
+        [ValidateSet("GET", "POST")]
+        [string]$Method,
+        [string]$Path,
+        [object]$Body = $null
+    )
+
+    $headers = @{
+        Authorization = "Bearer $script:AccessToken"
+    }
+    $parameters = @{
+        Method  = $Method
+        Uri     = (Join-ApiUrl $Path)
+        Headers = $headers
+    }
+    if ($Method -ne "GET") {
+        $parameters.ContentType = "application/json"
+        $parameters.Body = ($Body | ConvertTo-Json -Depth 20)
+    }
+
+    try {
+        $response = Invoke-RestMethod @parameters
+    } catch {
+        throw "API $Method $Path failed: $($_.Exception.Message)"
+    }
+
+    if (-not $response.isSuccess) {
+        throw "API $Method $Path returned failure: $($response.code) $($response.message)"
+    }
+    return $response.result
+}
+
+function New-SmokeDocumentImage {
+    param(
+        [string]$Path,
+        [string]$Title,
+        [string]$BodyText
+    )
+
+    Add-Type -AssemblyName System.Drawing
+    $bitmap = New-Object System.Drawing.Bitmap 900, 1200
+    $graphics = [System.Drawing.Graphics]::FromImage($bitmap)
+    $fontTitle = New-Object System.Drawing.Font([System.Drawing.FontFamily]::GenericSansSerif, 42, [System.Drawing.FontStyle]::Bold)
+    $fontBody = New-Object System.Drawing.Font([System.Drawing.FontFamily]::GenericSansSerif, 26, [System.Drawing.FontStyle]::Regular)
+    $pen = New-Object System.Drawing.Pen([System.Drawing.Color]::Black, 4)
+    try {
+        $graphics.Clear([System.Drawing.Color]::White)
+        $graphics.DrawRectangle($pen, 60, 60, 780, 1080)
+        $graphics.DrawString($Title, $fontTitle, [System.Drawing.Brushes]::Black, 120, 140)
+        $graphics.DrawString($BodyText, $fontBody, [System.Drawing.Brushes]::Black, 120, 240)
+        $graphics.DrawLine($pen, 120, 340, 780, 340)
+        $graphics.DrawString("Queue-backed preprocessing smoke input", $fontBody, [System.Drawing.Brushes]::Black, 120, 410)
+        $bitmap.Save($Path, [System.Drawing.Imaging.ImageFormat]::Png)
+    } finally {
+        $pen.Dispose()
+        $fontBody.Dispose()
+        $fontTitle.Dispose()
+        $graphics.Dispose()
+        $bitmap.Dispose()
+    }
+}
+
+function Expand-SmokeZip {
+    param(
+        [string]$ZipPath,
+        [string]$Destination
+    )
+
+    if (Test-Path $Destination) {
+        Remove-Item -LiteralPath $Destination -Recurse -Force
+    }
+    New-Item -ItemType Directory -Path $Destination | Out-Null
+    Expand-Archive -Path $ZipPath -DestinationPath $Destination -Force
+    return @(Get-ChildItem -Path $Destination -Recurse -File | Where-Object {
+        $_.Extension.ToLowerInvariant() -in @(".png", ".jpg", ".jpeg", ".webp", ".bmp", ".tif", ".tiff")
+    } | Sort-Object FullName)
+}
+
+function Get-ContentType {
+    param([string]$Path)
+
+    $extension = [System.IO.Path]::GetExtension($Path).ToLowerInvariant()
+    switch ($extension) {
+        ".png" { return "image/png" }
+        ".jpg" { return "image/jpeg" }
+        ".jpeg" { return "image/jpeg" }
+        ".webp" { return "image/webp" }
+        ".bmp" { return "image/bmp" }
+        ".tif" { return "image/tiff" }
+        ".tiff" { return "image/tiff" }
+        default { return "application/octet-stream" }
+    }
+}
+
+function Send-PresignedUpload {
+    param(
+        [object]$Target,
+        [System.IO.FileInfo]$File
+    )
+
+    Add-Type -AssemblyName System.Net.Http
+    $contentType = Get-ContentType $File.FullName
+    if ($null -ne $Target.requiredHeaders -and $null -ne $Target.requiredHeaders."Content-Type") {
+        $contentType = $Target.requiredHeaders."Content-Type"
+    }
+
+    $client = [System.Net.Http.HttpClient]::new()
+    $content = $null
+    try {
+        $bytes = [System.IO.File]::ReadAllBytes($File.FullName)
+        $content = [System.Net.Http.ByteArrayContent]::new($bytes)
+        $content.Headers.ContentType = [System.Net.Http.Headers.MediaTypeHeaderValue]::Parse($contentType)
+        $response = $client.PutAsync([Uri]$Target.uploadUrl, $content).GetAwaiter().GetResult()
+        if (-not $response.IsSuccessStatusCode) {
+            $responseBody = $response.Content.ReadAsStringAsync().GetAwaiter().GetResult()
+            throw "Presigned upload failed for $($File.Name): HTTP $([int]$response.StatusCode) $responseBody"
+        }
+    } finally {
+        if ($null -ne $content) {
+            $content.Dispose()
+        }
+        $client.Dispose()
+    }
+}
+
+function Save-Download {
+    param(
+        [string]$Url,
+        [string]$Path
+    )
+
+    Invoke-WebRequest -Uri $Url -OutFile $Path
+    $item = Get-Item -LiteralPath $Path
+    if ($item.Length -le 0) {
+        throw "Downloaded file is empty: $Path"
+    }
+}
+
+$runId = Get-Date -Format "yyyyMMdd-HHmmss"
+$runDirectory = Join-Path $OutputDirectory $runId
+$sourceDirectory = Join-Path $runDirectory "source"
+$extractDirectory = Join-Path $runDirectory "extracted"
+$downloadDirectory = Join-Path $runDirectory "downloads"
+New-Item -ItemType Directory -Path $sourceDirectory, $downloadDirectory -Force | Out-Null
+
+Write-Step "Generating synthetic document images"
+$firstImage = Join-Path $sourceDirectory "smoke-document-001.png"
+$secondImage = Join-Path $sourceDirectory "smoke-document-002.png"
+New-SmokeDocumentImage -Path $firstImage -Title "Smoke Document 001" -BodyText "Generated at $runId"
+New-SmokeDocumentImage -Path $secondImage -Title "Smoke Document 002" -BodyText "Generated at $runId"
+
+Write-Step "Creating and expanding ZIP input"
+$zipPath = Join-Path $runDirectory "smoke-input.zip"
+Compress-Archive -Path (Join-Path $sourceDirectory "*.png") -DestinationPath $zipPath -Force
+$files = Expand-SmokeZip -ZipPath $zipPath -Destination $extractDirectory
+if ($files.Count -eq 0) {
+    throw "No image files were extracted from $zipPath"
+}
+
+Write-Step "Creating project"
+$project = Invoke-Api -Method POST -Path "/v1/projects" -Body @{
+    name = $ProjectName
+    description = "Created by scripts/local-e2e-smoke.ps1"
+    defaultPreset = "A4_SCAN_300DPI"
+}
+
+Write-Step "Creating upload session"
+$expectedBytes = ($files | Measure-Object -Property Length -Sum).Sum
+$session = Invoke-Api -Method POST -Path "/v1/projects/$($project.id)/upload-sessions" -Body @{
+    expectedFileCount = $files.Count
+    expectedTotalSizeBytes = [long]$expectedBytes
+}
+
+Write-Step "Requesting presigned upload URLs"
+$fileRequests = @($files | ForEach-Object {
+    @{
+        fileName = $_.Name
+        contentType = Get-ContentType $_.FullName
+        sizeBytes = [long]$_.Length
+        checksumSha256 = (Get-FileHash -Algorithm SHA256 -Path $_.FullName).Hash.ToLowerInvariant()
+    }
+})
+$presigned = Invoke-Api -Method POST -Path "/v1/upload-sessions/$($session.id)/files/presigned-url" -Body @{
+    files = $fileRequests
+}
+$uploadTargets = @($presigned.uploadTargets)
+if ($uploadTargets.Count -ne $files.Count) {
+    throw "Upload target count mismatch. expected=$($files.Count), actual=$($uploadTargets.Count)"
+}
+
+Write-Step "Uploading originals to object storage"
+for ($index = 0; $index -lt $uploadTargets.Count; $index++) {
+    Send-PresignedUpload -Target $uploadTargets[$index] -File $files[$index]
+}
+
+Write-Step "Completing upload session"
+$uploadFileIds = @($uploadTargets | ForEach-Object { [long]$_.uploadFileId })
+Invoke-Api -Method POST -Path "/v1/upload-sessions/$($session.id)/complete" -Body @{
+    uploadFileIds = $uploadFileIds
+} | Out-Null
+
+Write-Step "Resolving uploaded image metadata"
+$imagesPage = Invoke-Api -Method GET -Path "/v1/projects/$($project.id)/images?size=200"
+$images = @($imagesPage.content | Sort-Object id)
+if ($images.Count -lt $files.Count) {
+    throw "Image metadata count is lower than uploaded file count. images=$($images.Count), files=$($files.Count)"
+}
+$imageIds = @($images | Select-Object -Last $files.Count | ForEach-Object { [long]$_.id })
+
+Write-Step "Creating preprocessing job"
+$job = Invoke-Api -Method POST -Path "/v1/jobs" -Body @{
+    projectId = [long]$project.id
+    imageIds = $imageIds
+    preset = "A4_SCAN_300DPI"
+    presetParameters = @{
+        targetDpi = "300"
+    }
+    debug = $false
+    priority = "NORMAL"
+    outputOptions = @{
+        saveProcessedImage = $true
+        savePreview = $false
+        saveReportJson = $false
+        saveDebugArtifacts = $false
+    }
+}
+
+Write-Step "Polling job until terminal state"
+$deadline = (Get-Date).AddSeconds($TimeoutSeconds)
+$summary = $null
+$items = @()
+do {
+    Start-Sleep -Seconds 2
+    $summary = Invoke-Api -Method GET -Path "/v1/jobs/$($job.jobId)/summary"
+    $itemsPage = Invoke-Api -Method GET -Path "/v1/jobs/$($job.jobId)/items?size=200"
+    $items = @($itemsPage.content)
+    Write-Host ("    progress={0}% succeeded={1} failed={2} total={3}" -f `
+        [math]::Round([double]$summary.progressPercent, 1),
+        $summary.succeeded,
+        $summary.failed,
+        $summary.total)
+    $finished = ([int]$summary.succeeded + [int]$summary.failed) -ge [int]$summary.total
+} while (-not $finished -and (Get-Date) -lt $deadline)
+
+if (-not $finished) {
+    throw "Timed out waiting for job #$($job.jobId)."
+}
+if ([int]$summary.failed -gt 0) {
+    throw "Job #$($job.jobId) finished with failed items."
+}
+
+Write-Step "Downloading one processed image"
+$processedItem = @($items | Where-Object { -not [string]::IsNullOrWhiteSpace($_.processedObjectKey) } | Select-Object -First 1)
+if ($processedItem.Count -eq 0) {
+    throw "No processed item object key was registered."
+}
+$processedDownload = Invoke-Api -Method GET -Path "/v1/jobs/$($job.jobId)/items/$($processedItem[0].id)/download?type=processed"
+$processedOutputPath = Join-Path $downloadDirectory "processed-item-$($processedItem[0].id).png"
+Save-Download -Url $processedDownload.downloadUrl -Path $processedOutputPath
+
+Write-Step "Downloading processed ZIP"
+$zipDownload = Invoke-Api -Method GET -Path "/v1/jobs/$($job.jobId)/download.zip"
+$zipOutputPath = Join-Path $downloadDirectory "job-$($job.jobId)-processed-results.zip"
+Save-Download -Url $zipDownload.downloadUrl -Path $zipOutputPath
+
+$summaryPath = Join-Path $runDirectory "summary.json"
+[ordered]@{
+    projectId = $project.id
+    jobId = $job.jobId
+    uploadedImages = $files.Count
+    succeeded = $summary.succeeded
+    failed = $summary.failed
+    processedImage = $processedOutputPath
+    processedZip = $zipOutputPath
+    zipObjectKey = $zipDownload.objectKey
+} | ConvertTo-Json -Depth 8 | Set-Content -Path $summaryPath -Encoding UTF8
+
+Write-Step "Smoke flow succeeded"
+Write-Host "Summary: $summaryPath"
+Write-Host "Processed image: $processedOutputPath"
+Write-Host "Processed ZIP: $zipOutputPath"


### PR DESCRIPTION
## #️⃣ 기능 설명

Docker Compose 로컬 MVP 흐름을 API 기준으로 재현하는 PowerShell 스모크 스크립트와 실행 문서를 추가했습니다.

Closes #94

## 🛠️ 작업 상세 내용

- [x] `scripts/local-e2e-smoke.ps1` 추가
- [x] synthetic document PNG 생성
- [x] ZIP 생성/확장으로 프론트 ZIP 업로드 경계 시뮬레이션
- [x] 프로젝트 생성, 업로드 세션, presigned upload, Job 생성, Job polling 흐름 자동화
- [x] processed image 및 processed ZIP 다운로드 검증
- [x] Docker Compose 로컬 실행 문서 갱신
- [x] issue feature spec 문서 추가

## 📁 변경 파일 요약

- `scripts/local-e2e-smoke.ps1`
- `scripts/README.md`
- `docs/operation/docker-compose-local.md`
- `docs/feature-specs/issue-94-local-e2e-smoke.md`

## ✅ 검증 내용

- [x] PowerShell parser syntax check: 통과
- [x] `git diff --check`: 통과
- [ ] Full Docker E2E run: 미실행

Full Docker E2E는 현재 Docker Desktop 엔진에 연결되지 않아 실행하지 못했습니다. `docker compose ps` 결과: `open //./pipe/dockerDesktopLinuxEngine: The system cannot find the file specified.`

## 🔎 리뷰어가 확인해야 할 부분

- 스모크 스크립트가 dev auth bypass 없이 실제 Google 로그인 access token을 받는 방식이 맞는지 확인해주세요.
- ZIP 업로드 검증을 서버 ZIP 업로드가 아니라 클라이언트 확장 시뮬레이션으로 둔 정책을 확인해주세요.

## 📸 스크린샷

없음

## 💬 기타 공유사항 to 리뷰어

실행 예시:

```powershell
$env:ACCESS_TOKEN = "<access-token>"
.\scripts\local-e2e-smoke.ps1
```

access token은 로그인 후 DevTools에서 `localStorage.getItem('doc-pipeline.access-token')`로 확인합니다.