### PR TITLE
✨ [Feat] Job 상세 화면 실사용 플로우 구현

### DIFF
--- a/docs/feature-specs/issue-96-job-detail-ui.md
+++ b/docs/feature-specs/issue-96-job-detail-ui.md
@@ -1,0 +1,66 @@
+# Issue 96 - Job Detail UI Flow
+
+## Goal
+
+Replace the `/jobs/{jobId}` placeholder with an API-backed Job detail screen for the local MVP.
+
+The screen focuses on OCR preprocessing operations only:
+
+- Job metadata
+- progress counters
+- image-level Worker item states
+- processed image download
+- processed-only ZIP download
+
+OCR text extraction, benchmark screens, preview display, report display, and debug artifact browsing remain out of scope.
+
+## User Flow
+
+```text
+User opens /jobs/{jobId}
+  -> frontend loads Job detail
+  -> frontend loads Job summary
+  -> frontend loads JobItems
+  -> while Job is not terminal, frontend refreshes every 2.5 seconds
+  -> user downloads one processed image or the processed ZIP
+```
+
+## API Calls
+
+```text
+GET /api/v1/jobs/{jobId}
+GET /api/v1/jobs/{jobId}/summary
+GET /api/v1/jobs/{jobId}/items?size=500
+GET /api/v1/jobs/{jobId}/items/{itemId}/download?type=processed
+GET /api/v1/jobs/{jobId}/download.zip
+```
+
+All calls use the existing access token and refresh-cookie behavior through the shared API client.
+
+## UI Behavior
+
+- Shows Job status, preset, priority, debug flag, created/started/completed timestamps.
+- Shows total, succeeded, failed, and processed-downloadable counts.
+- Shows a progress bar based on `progressPercent`.
+- Polls every `2.5s` until the Job reaches a terminal status.
+- Lists JobItems with status, image ID, attempt, worker ID, timestamps, errors, and processed object key.
+- Enables item download only when `processedObjectKey` exists.
+- Enables processed ZIP download only when at least one processed item exists.
+- Adds an "Open job detail" link from the upload result progress card.
+
+## Terminal Statuses
+
+```text
+SUCCEEDED
+FAILED
+PARTIAL_SUCCEEDED
+CANCELLED
+```
+
+## Completion Criteria
+
+- `/jobs/{jobId}` is no longer a placeholder.
+- Authenticated users can inspect Job progress and item results.
+- Processed image download opens a signed download URL.
+- Processed ZIP download opens a signed download URL.
+- Frontend build passes.

--- a/frontend/src/pages/JobDetailPage.tsx
+++ b/frontend/src/pages/JobDetailPage.tsx
@@ -1,13 +1,348 @@
+import { useEffect, useMemo, useState } from 'react';
+import { apiClient } from '../shared/api/apiClient';
+import { readStoredAccessToken } from '../shared/auth/accessTokenStore';
 import { PageSection } from '../shared/components/PageSection';
-import { JobProgressPanel } from '../features/job/JobProgressPanel';
+
+type PageResponse<T> = {
+  content: T[];
+};
+
+type JobResponse = {
+  id: number;
+  projectId: number;
+  userId: number;
+  preset: string;
+  presetParameters: Record<string, string>;
+  debug: boolean;
+  priority: string;
+  status: string;
+  totalCount: number;
+  queuedCount: number;
+  processingCount: number;
+  succeededCount: number;
+  failedCount: number;
+  createdAt: string;
+  startedAt?: string | null;
+  completedAt?: string | null;
+};
+
+type JobSummaryResponse = {
+  jobId: number;
+  total: number;
+  queued: number;
+  processing: number;
+  succeeded: number;
+  failed: number;
+  progressPercent: number;
+};
+
+type JobItemResponse = {
+  id: number;
+  jobId: number;
+  imageId: number;
+  status: string;
+  attempt: number;
+  workerId?: string | null;
+  processedObjectKey?: string | null;
+  previewObjectKey?: string | null;
+  reportObjectKey?: string | null;
+  errorCode?: string | null;
+  errorMessage?: string | null;
+  createdAt: string;
+  startedAt?: string | null;
+  completedAt?: string | null;
+};
+
+type JobItemDownloadUrlResponse = {
+  jobId: number;
+  itemId: number;
+  type: string;
+  objectKey: string;
+  downloadUrl: string;
+  expiresAt: string;
+};
+
+type JobZipDownloadResponse = {
+  jobId: number;
+  fileCount: number;
+  objectKey: string;
+  downloadUrl: string;
+  expiresAt: string;
+};
+
+const terminalStatuses = new Set(['SUCCEEDED', 'FAILED', 'PARTIAL_SUCCEEDED', 'CANCELLED']);
 
 export function JobDetailPage() {
+  const jobId = useMemo(() => {
+    const segments = window.location.pathname.split('/').filter(Boolean);
+    return Number(segments[segments.length - 1]);
+  }, []);
+  const [job, setJob] = useState<JobResponse | null>(null);
+  const [summary, setSummary] = useState<JobSummaryResponse | null>(null);
+  const [items, setItems] = useState<JobItemResponse[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [refreshing, setRefreshing] = useState(false);
+  const [zipDownloading, setZipDownloading] = useState(false);
+  const [itemDownloading, setItemDownloading] = useState<number | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const processedItems = items.filter((item) => item.processedObjectKey);
+  const isTerminal = job ? terminalStatuses.has(job.status) : false;
+
+  useEffect(() => {
+    void loadJob(true);
+  }, [jobId]);
+
+  useEffect(() => {
+    if (!job || isTerminal) {
+      return undefined;
+    }
+    const timer = window.setInterval(() => {
+      void loadJob(false);
+    }, 2500);
+    return () => window.clearInterval(timer);
+  }, [job?.id, job?.status, isTerminal]);
+
+  async function loadJob(showLoading: boolean) {
+    if (!Number.isFinite(jobId)) {
+      setError('Invalid job id.');
+      setLoading(false);
+      return;
+    }
+
+    if (showLoading) {
+      setLoading(true);
+    } else {
+      setRefreshing(true);
+    }
+    setError(null);
+
+    try {
+      const [jobResponse, summaryResponse, itemResponse] = await Promise.all([
+        apiClient.get<JobResponse>(`/v1/jobs/${jobId}`, readStoredAccessToken()),
+        apiClient.get<JobSummaryResponse>(`/v1/jobs/${jobId}/summary`, readStoredAccessToken()),
+        apiClient.get<PageResponse<JobItemResponse>>(`/v1/jobs/${jobId}/items?size=500`, readStoredAccessToken())
+      ]);
+      setJob(jobResponse.result);
+      setSummary(summaryResponse.result);
+      setItems(itemResponse.result.content);
+    } catch (exception) {
+      setError(describeError(exception, 'Failed to load job.'));
+    } finally {
+      setLoading(false);
+      setRefreshing(false);
+    }
+  }
+
+  async function downloadProcessedImage(item: JobItemResponse) {
+    setItemDownloading(item.id);
+    setError(null);
+    try {
+      const response = await apiClient.get<JobItemDownloadUrlResponse>(
+        `/v1/jobs/${jobId}/items/${item.id}/download?type=processed`,
+        readStoredAccessToken()
+      );
+      openDownload(response.result.downloadUrl, `job-${jobId}-item-${item.id}-processed.png`);
+    } catch (exception) {
+      setError(describeError(exception, 'Failed to download processed image.'));
+    } finally {
+      setItemDownloading(null);
+    }
+  }
+
+  async function downloadProcessedZip() {
+    setZipDownloading(true);
+    setError(null);
+    try {
+      const response = await apiClient.get<JobZipDownloadResponse>(
+        `/v1/jobs/${jobId}/download.zip`,
+        readStoredAccessToken()
+      );
+      openDownload(response.result.downloadUrl, `job-${response.result.jobId}-processed-results.zip`);
+    } catch (exception) {
+      setError(describeError(exception, 'Failed to download processed ZIP.'));
+    } finally {
+      setZipDownloading(false);
+    }
+  }
+
+  if (loading) {
+    return (
+      <PageSection title="Loading job" description="Fetching job state, item progress, and available processed outputs.">
+        <div className="status-card">
+          <strong>Loading</strong>
+          <span>Reading Job #{Number.isFinite(jobId) ? jobId : 'unknown'}.</span>
+        </div>
+      </PageSection>
+    );
+  }
+
   return (
-    <PageSection
-      title="Job detail"
-      description="Placeholder for job progress, image-level item states, retry actions, and SSE updates."
-    >
-      <JobProgressPanel jobId="placeholder" />
-    </PageSection>
+    <div className="project-console">
+      {error && (
+        <div className="status-card error">
+          <strong>Job detail failed</strong>
+          <span>{error}</span>
+        </div>
+      )}
+
+      <section className="console-hero">
+        <div>
+          <span className="status-pill accent">Preprocessing job</span>
+          <h2>{job ? `Job #${job.id}` : 'Job unavailable'}</h2>
+          <p>
+            Inspect queue progress, image-level Worker results, and processed-only downloads for this document
+            preprocessing batch.
+          </p>
+        </div>
+        <div className="session-card">
+          <span className={`status-dot ${isTerminal ? 'online' : 'offline'}`} />
+          <strong>{job?.status ?? 'Unavailable'}</strong>
+          <small>{refreshing ? 'Refreshing...' : isTerminal ? 'terminal state' : 'polling every 2.5s'}</small>
+        </div>
+      </section>
+
+      <section className="metric-strip">
+        <MetricCard label="Total" value={String(summary?.total ?? job?.totalCount ?? 0)} detail="images" />
+        <MetricCard label="Succeeded" value={String(summary?.succeeded ?? job?.succeededCount ?? 0)} detail="processed" />
+        <MetricCard label="Failed" value={String(summary?.failed ?? job?.failedCount ?? 0)} detail="items" />
+        <MetricCard label="Processed" value={String(processedItems.length)} detail="downloadable" />
+      </section>
+
+      <div className="job-detail-layout">
+        <PageSection title="Progress" description="Current counters are read from the Job summary endpoint.">
+          <div className="progress-card">
+            <div className="artifact-title">
+              <strong>{(summary?.progressPercent ?? 0).toFixed(1)}%</strong>
+              <span>{summary ? `${summary.succeeded + summary.failed}/${summary.total} completed` : 'No summary'}</span>
+            </div>
+            <div className="progress-track">
+              <span style={{ width: `${Math.min(summary?.progressPercent ?? 0, 100)}%` }} />
+            </div>
+          </div>
+
+          <div className="metadata-grid">
+            <span>Preset</span>
+            <strong>{job?.preset ?? '-'}</strong>
+            <span>Priority</span>
+            <strong>{job?.priority ?? '-'}</strong>
+            <span>Debug</span>
+            <strong>{job?.debug ? 'enabled' : 'disabled'}</strong>
+            <span>Created</span>
+            <strong>{job?.createdAt ? formatDate(job.createdAt) : '-'}</strong>
+            <span>Started</span>
+            <strong>{job?.startedAt ? formatDate(job.startedAt) : '-'}</strong>
+            <span>Completed</span>
+            <strong>{job?.completedAt ? formatDate(job.completedAt) : '-'}</strong>
+          </div>
+
+          <div className="download-actions">
+            <button className="secondary-action" type="button" onClick={() => void loadJob(false)} disabled={refreshing}>
+              {refreshing ? 'Refreshing...' : 'Refresh'}
+            </button>
+            {job && (
+              <a className="secondary-action" href={`/projects/${job.projectId}`}>
+                Open project
+              </a>
+            )}
+          </div>
+        </PageSection>
+
+        <PageSection title="Downloads" description="MVP downloads expose processed images only.">
+          <div className="status-card">
+            <strong>{processedItems.length} processed images ready</strong>
+            <span>Preview, report, and debug artifacts are intentionally hidden from the MVP UI.</span>
+          </div>
+          <button
+            className="primary-action"
+            type="button"
+            onClick={downloadProcessedZip}
+            disabled={processedItems.length === 0 || zipDownloading}
+          >
+            {zipDownloading ? 'Preparing ZIP...' : 'Download processed ZIP'}
+          </button>
+        </PageSection>
+      </div>
+
+      <section className="artifact-board">
+        <div className="artifact-title">
+          <div>
+            <span className="status-pill accent">Job items</span>
+            <h2>Image-level Worker results</h2>
+          </div>
+          <small>{items.length} items</small>
+        </div>
+
+        {items.length === 0 ? (
+          <div className="empty-state">
+            <strong>No JobItems</strong>
+            <span>The job has no image-level work items yet.</span>
+          </div>
+        ) : (
+          <div className="job-item-list">
+            {items.map((item) => (
+              <article className="job-item-row" key={item.id}>
+                <div>
+                  <strong>Item #{item.id}</strong>
+                  <small>Image #{item.imageId} - attempt {item.attempt}</small>
+                </div>
+                <span className={`status-pill ${item.status.toLowerCase()}`}>{item.status}</span>
+                <div className="job-item-meta">
+                  {item.workerId && <small>Worker: {item.workerId}</small>}
+                  {item.startedAt && <small>Started: {formatDate(item.startedAt)}</small>}
+                  {item.completedAt && <small>Completed: {formatDate(item.completedAt)}</small>}
+                  {item.errorMessage && (
+                    <small className="error-text">
+                      {item.errorCode}: {item.errorMessage}
+                    </small>
+                  )}
+                  {item.processedObjectKey && <code>{item.processedObjectKey}</code>}
+                </div>
+                <button
+                  className="secondary-action"
+                  type="button"
+                  disabled={!item.processedObjectKey || itemDownloading === item.id}
+                  onClick={() => downloadProcessedImage(item)}
+                >
+                  {itemDownloading === item.id ? 'Opening...' : 'Download processed'}
+                </button>
+              </article>
+            ))}
+          </div>
+        )}
+      </section>
+    </div>
   );
+}
+
+function MetricCard({ label, value, detail }: { label: string; value: string; detail: string }) {
+  return (
+    <div className="metric-card">
+      <span>{label}</span>
+      <strong>{value}</strong>
+      <small>{detail}</small>
+    </div>
+  );
+}
+
+function openDownload(url: string, fileName: string) {
+  const anchor = document.createElement('a');
+  anchor.href = url;
+  anchor.target = '_blank';
+  anchor.rel = 'noopener noreferrer';
+  anchor.download = fileName;
+  document.body.appendChild(anchor);
+  anchor.click();
+  anchor.remove();
+}
+
+function describeError(exception: unknown, fallback: string) {
+  return exception instanceof Error && exception.message ? exception.message : fallback;
+}
+
+function formatDate(value: string) {
+  return new Intl.DateTimeFormat(undefined, {
+    dateStyle: 'medium',
+    timeStyle: 'short'
+  }).format(new Date(value));
 }

--- a/frontend/src/pages/UploadPage.tsx
+++ b/frontend/src/pages/UploadPage.tsx
@@ -600,6 +600,11 @@ export function UploadPage() {
                 <div className="progress-track">
                   <span style={{ width: `${Math.min(result.summary.progressPercent, 100)}%` }} />
                 </div>
+                <div className="download-actions">
+                  <a className="secondary-action" href={`/jobs/${result.summary.jobId}`}>
+                    Open job detail
+                  </a>
+                </div>
               </div>
             )}
 

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -612,6 +612,13 @@ button {
   align-items: start;
 }
 
+.job-detail-layout {
+  display: grid;
+  grid-template-columns: minmax(22rem, 1fr) minmax(18rem, 0.58fr);
+  gap: 1.1rem;
+  align-items: start;
+}
+
 .stack-form,
 .project-grid,
 .metadata-grid {
@@ -714,6 +721,43 @@ button {
   font-size: 0.78rem;
 }
 
+.job-item-list {
+  display: grid;
+  gap: 0.8rem;
+}
+
+.job-item-row {
+  display: grid;
+  grid-template-columns: minmax(10rem, 0.9fr) auto minmax(16rem, 1.4fr) auto;
+  gap: 0.85rem;
+  align-items: center;
+  border: 1px solid rgba(18, 56, 45, 0.12);
+  border-radius: 1rem;
+  background: rgba(255, 254, 248, 0.86);
+  padding: 0.9rem;
+}
+
+.job-item-row strong,
+.job-item-row small {
+  display: block;
+}
+
+.job-item-meta {
+  display: grid;
+  min-width: 0;
+  gap: 0.25rem;
+}
+
+.job-item-meta code {
+  overflow-wrap: anywhere;
+  border-radius: 0.7rem;
+  background: rgba(18, 56, 45, 0.06);
+  color: var(--pine);
+  padding: 0.45rem;
+  font-family: "JetBrains Mono", "Consolas", monospace;
+  font-size: 0.72rem;
+}
+
 .error-text {
   color: var(--danger);
 }
@@ -722,6 +766,7 @@ button {
   .shell,
   .upload-layout,
   .project-layout,
+  .job-detail-layout,
   .console-hero {
     grid-template-columns: 1fr;
   }
@@ -748,7 +793,8 @@ button {
   }
 
   .topbar,
-  .file-row {
+  .file-row,
+  .job-item-row {
     align-items: stretch;
     grid-template-columns: 1fr;
   }


### PR DESCRIPTION
## #️⃣ 기능 설명

`/jobs/:jobId` placeholder를 실제 API 기반 Job 상세 화면으로 교체했습니다. Job 진행률, 이미지별 Worker 처리 상태, processed 개별 다운로드, processed ZIP 다운로드를 확인할 수 있습니다.

Closes #96

## 🛠️ 작업 상세 내용

- [x] route param 기반 Job 상세 조회 구현
- [x] Job summary/progress 표시
- [x] JobItem 목록과 상태/에러/worker metadata 표시
- [x] processed 이미지 다운로드 연결
- [x] processed ZIP 다운로드 연결
- [x] 진행 중 Job 자동 polling 추가
- [x] Upload 결과에서 Job 상세 화면으로 이동하는 링크 추가
- [x] 기능 명세 문서 추가

## 📁 변경 파일 요약

- `frontend/src/pages/JobDetailPage.tsx`
- `frontend/src/pages/UploadPage.tsx`
- `frontend/src/styles/global.css`
- `docs/feature-specs/issue-96-job-detail-ui.md`

## ✅ 검증 내용

- [x] `cd frontend && npm run build`: 통과
- [x] `git diff --check`: 통과

## 🔎 리뷰어가 확인해야 할 부분

- Job 상세 화면에서 MVP 정책상 preview/report/debug를 숨기고 processed 다운로드만 노출하는 방향을 확인해주세요.
- 진행 중 Job polling interval을 2.5초로 둔 것이 로컬 MVP에 적절한지 확인해주세요.

## 📸 스크린샷

없음

## 💬 기타 공유사항 to 리뷰어

OCR 텍스트 추출/벤치마크는 범위에서 제외했습니다.