### PR TITLE
✨ [Feat] Dashboard 운영 개요 화면 구현

### DIFF
--- a/docs/feature-specs/issue-100-dashboard-overview.md
+++ b/docs/feature-specs/issue-100-dashboard-overview.md
@@ -1,0 +1,67 @@
+# Issue 100 - Dashboard 운영 개요 화면
+
+## 작업 목적
+
+프론트 Dashboard의 placeholder를 제거하고, Docker Compose 기반 MVP에서 실제 사용자가 확인할 수 있는 운영 개요 화면을 제공한다.
+
+이 화면은 관리자/감사/벤치마크 기능을 되살리지 않고, 현재 구현된 Project, Image, Job API만 사용한다.
+
+## 전체 순서
+
+1. `GET /api/v1/projects?size=100`으로 사용자가 접근 가능한 프로젝트를 조회한다.
+2. 각 프로젝트에 대해 `GET /api/v1/projects/{projectId}/summary`를 호출해 이미지 수와 Job 수를 집계한다.
+3. `GET /api/v1/jobs?size=100`으로 최근 전처리 Job 목록을 조회한다.
+4. Job 카운터를 기준으로 대기, 처리 중, 성공, 실패, 성공률을 계산한다.
+5. 최근 Job과 최근 Project를 카드 형태로 표시한다.
+6. 사용자가 다음 행동으로 이동할 수 있도록 Upload, Projects, Job detail 링크를 제공한다.
+
+## 기능 단위
+
+### 1. Workspace Metrics
+
+- 프로젝트 수는 project page의 `totalElements`가 있으면 우선 사용한다.
+- 이미지 수는 프로젝트 요약의 `imageCount` 합계로 계산한다.
+- Job 수는 job page의 `totalElements`가 있으면 우선 사용한다.
+- 성공률은 `sum(succeededCount) / sum(totalCount)`로 계산한다.
+
+### 2. Pipeline Health
+
+- `queuedCount`, `processingCount`, `failedCount`를 전체 Job 기준으로 합산한다.
+- active Job은 `CREATED`, `QUEUED`, `RUNNING`, `RETRYING`, `CANCEL_REQUESTED` 상태를 기준으로 계산한다.
+- 별도 Admin API나 RabbitMQ 관리 API는 사용하지 않는다.
+
+### 3. Recent Jobs
+
+- `createdAt` 내림차순으로 최근 6개 Job을 표시한다.
+- 각 항목은 Job ID, Project ID, preset, 상태, 성공/실패/대기/처리 중 카운터를 표시한다.
+- Job detail 화면으로 이동하는 링크를 제공한다.
+
+### 4. Recent Projects
+
+- `updatedAt` 내림차순으로 최근 4개 프로젝트를 표시한다.
+- 각 항목은 이름, 설명, 권한, 이미지 수, Job 수, 기본 프리셋을 표시한다.
+- Project detail과 Upload 화면으로 이동하는 링크를 제공한다.
+
+### 5. Auth Handling
+
+- API 호출은 기존 `apiClient`를 사용한다.
+- access token은 UI에 표시하지 않는다.
+- 401 발생 시 기존 refresh-cookie 기반 재발급 흐름을 그대로 사용한다.
+- 인증 실패 시 Google 로그인 CTA와 retry 버튼을 표시한다.
+
+## 제외 범위
+
+- Admin dashboard
+- Audit log
+- OCR/Benchmark 화면
+- RabbitMQ queue health 직접 조회
+- Prometheus/Grafana 지표 연동
+
+위 항목은 현재 MVP 범위에서 제외된 상태다.
+
+## 검증 기준
+
+- `frontend/src/pages/DashboardPage.tsx`가 placeholder가 아닌 실제 API 기반 화면을 렌더링한다.
+- `frontend/src/styles/global.css`는 기존 디자인 시스템을 확장하며 외부 UI 템플릿을 추가하지 않는다.
+- `npm run build`가 통과한다.
+- `git diff --check`가 통과한다.

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -1,10 +1,345 @@
+import { useEffect, useMemo, useState } from 'react';
+import { apiClient } from '../shared/api/apiClient';
+import { readStoredAccessToken } from '../shared/auth/accessTokenStore';
 import { PageSection } from '../shared/components/PageSection';
 
+type PageResponse<T> = {
+  content: T[];
+  totalElements?: number;
+};
+
+type ProjectResponse = {
+  id: number;
+  name: string;
+  description?: string | null;
+  defaultPreset?: string | null;
+  status: string;
+  ownerEmail: string;
+  myRole: string;
+  createdAt: string;
+  updatedAt: string;
+};
+
+type ProjectSummaryResponse = {
+  projectId: number;
+  name: string;
+  memberCount: number;
+  imageCount: number;
+  jobCount: number;
+};
+
+type JobResponse = {
+  id: number;
+  projectId: number;
+  preset: string;
+  debug: boolean;
+  priority: string;
+  status: string;
+  totalCount: number;
+  queuedCount: number;
+  processingCount: number;
+  succeededCount: number;
+  failedCount: number;
+  createdAt: string;
+  startedAt?: string | null;
+  completedAt?: string | null;
+};
+
+type DashboardData = {
+  projects: ProjectResponse[];
+  summaries: ProjectSummaryResponse[];
+  jobs: JobResponse[];
+  projectTotal: number;
+  jobTotal: number;
+};
+
+const activeJobStatuses = new Set(['CREATED', 'QUEUED', 'RUNNING', 'RETRYING', 'CANCEL_REQUESTED']);
+
 export function DashboardPage() {
-  return (
-    <PageSection
-      title="Operations overview"
-      description="Placeholder for project count, image count, job success rate, and queue health."
-    />
+  const [data, setData] = useState<DashboardData>({
+    projects: [],
+    summaries: [],
+    jobs: [],
+    projectTotal: 0,
+    jobTotal: 0
+  });
+  const [loading, setLoading] = useState(true);
+  const [refreshing, setRefreshing] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const stats = useMemo(() => buildStats(data), [data]);
+  const recentJobs = useMemo(() => sortByCreatedAt(data.jobs).slice(0, 6), [data.jobs]);
+  const recentProjects = useMemo(
+    () => [...data.projects].sort((left, right) => Date.parse(right.updatedAt) - Date.parse(left.updatedAt)).slice(0, 4),
+    [data.projects]
   );
+
+  useEffect(() => {
+    void loadDashboard(true);
+  }, []);
+
+  async function loadDashboard(showLoading: boolean) {
+    if (showLoading) {
+      setLoading(true);
+    } else {
+      setRefreshing(true);
+    }
+    setError(null);
+
+    try {
+      const [projectResponse, jobResponse] = await Promise.all([
+        apiClient.get<PageResponse<ProjectResponse>>('/v1/projects?size=100', readStoredAccessToken()),
+        apiClient.get<PageResponse<JobResponse>>('/v1/jobs?size=100', readStoredAccessToken())
+      ]);
+      const projects = projectResponse.result.content;
+      const summaries = await Promise.all(
+        projects.map(async (project) => {
+          const response = await apiClient.get<ProjectSummaryResponse>(
+            `/v1/projects/${project.id}/summary`,
+            readStoredAccessToken()
+          );
+          return response.result;
+        })
+      );
+
+      setData({
+        projects,
+        summaries,
+        jobs: jobResponse.result.content,
+        projectTotal: projectResponse.result.totalElements ?? projects.length,
+        jobTotal: jobResponse.result.totalElements ?? jobResponse.result.content.length
+      });
+    } catch (exception) {
+      setError(describeError(exception, 'Failed to load dashboard.'));
+    } finally {
+      setLoading(false);
+      setRefreshing(false);
+    }
+  }
+
+  return (
+    <div className="project-console">
+      {error && (
+        <div className="status-card error">
+          <strong>Dashboard failed</strong>
+          <span>{error}</span>
+          <div className="download-actions">
+            <a className="primary-action" href="/oauth2/authorization/google">
+              Continue with Google
+            </a>
+            <button className="secondary-action" type="button" onClick={() => void loadDashboard(false)}>
+              Retry
+            </button>
+          </div>
+        </div>
+      )}
+
+      <section className="console-hero">
+        <div>
+          <span className="status-pill accent">Operations overview</span>
+          <h2>Track the preprocessing workspace before the next batch.</h2>
+          <p>
+            Dashboard data is loaded from the same MVP APIs used by Projects, Upload, and Job detail. It summarizes
+            project scope, uploaded images, queue-backed jobs, and processed outputs without reintroducing admin-only
+            features.
+          </p>
+        </div>
+        <div className="session-card">
+          <span className={`status-dot ${error ? 'offline' : 'online'}`} />
+          <strong>{loading ? 'Loading' : error ? 'Attention required' : 'Workspace ready'}</strong>
+          <small>{refreshing ? 'Refreshing...' : `Last read ${new Date().toLocaleTimeString()}`}</small>
+        </div>
+      </section>
+
+      <section className="metric-strip">
+        <MetricCard label="Projects" value={String(stats.projectCount)} detail="workspaces" />
+        <MetricCard label="Images" value={String(stats.imageCount)} detail="uploaded originals" />
+        <MetricCard label="Jobs" value={String(stats.jobCount)} detail={`${stats.activeJobs} active`} />
+        <MetricCard label="Success rate" value={stats.successRate} detail={`${stats.processedItems} processed`} />
+      </section>
+
+      <div className="dashboard-layout">
+        <PageSection title="Next action" description="Use the operational snapshot to decide what to run next.">
+          <div className="dashboard-action-grid">
+            <a className="dashboard-action-card primary" href="/upload">
+              <span>Run a batch</span>
+              <strong>Upload images or ZIP</strong>
+              <small>Create one JobItem per image and download processed-only results.</small>
+            </a>
+            <a className="dashboard-action-card" href="/projects">
+              <span>Manage scope</span>
+              <strong>Open projects</strong>
+              <small>Review images, default presets, and project-level job history.</small>
+            </a>
+          </div>
+        </PageSection>
+
+        <PageSection title="Pipeline health" description="Derived from recent Job counters, not from admin APIs.">
+          <div className="metadata-grid">
+            <span>Queued</span>
+            <strong>{stats.queuedItems}</strong>
+            <span>Processing</span>
+            <strong>{stats.processingItems}</strong>
+            <span>Failed items</span>
+            <strong>{stats.failedItems}</strong>
+            <span>Latest job</span>
+            <strong>{recentJobs[0] ? `#${recentJobs[0].id} ${recentJobs[0].status}` : 'none'}</strong>
+          </div>
+          <button
+            className="secondary-action"
+            type="button"
+            disabled={refreshing}
+            onClick={() => void loadDashboard(false)}
+          >
+            {refreshing ? 'Refreshing...' : 'Refresh dashboard'}
+          </button>
+        </PageSection>
+      </div>
+
+      <section className="artifact-board">
+        <div className="artifact-title">
+          <div>
+            <span className="status-pill accent">Recent jobs</span>
+            <h2>Preprocessing activity</h2>
+          </div>
+          <small>{loading ? 'loading' : `${recentJobs.length}/${data.jobTotal} shown`}</small>
+        </div>
+
+        {loading ? (
+          <div className="empty-state">
+            <strong>Loading jobs</strong>
+            <span>Reading recent preprocessing jobs.</span>
+          </div>
+        ) : recentJobs.length === 0 ? (
+          <div className="empty-state">
+            <strong>No jobs yet</strong>
+            <span>Upload images first to create preprocessing jobs.</span>
+          </div>
+        ) : (
+          <div className="job-item-list">
+            {recentJobs.map((job) => (
+              <article className="job-item-row dashboard-job-row" key={job.id}>
+                <div>
+                  <strong>Job #{job.id}</strong>
+                  <small>Project #{job.projectId} - {job.preset}</small>
+                </div>
+                <span className={`status-pill ${job.status.toLowerCase()}`}>{job.status}</span>
+                <div className="job-item-meta">
+                  <small>{job.succeededCount}/{job.totalCount} processed</small>
+                  <small>{job.failedCount} failed - {job.processingCount} processing - {job.queuedCount} queued</small>
+                  <small>Created: {formatDate(job.createdAt)}</small>
+                </div>
+                <a className="secondary-action" href={`/jobs/${job.id}`}>
+                  Open job
+                </a>
+              </article>
+            ))}
+          </div>
+        )}
+      </section>
+
+      <section className="artifact-board">
+        <div className="artifact-title">
+          <div>
+            <span className="status-pill accent">Recent projects</span>
+            <h2>Workspace scope</h2>
+          </div>
+          <small>{loading ? 'loading' : `${recentProjects.length}/${data.projectTotal} shown`}</small>
+        </div>
+
+        {loading ? (
+          <div className="empty-state">
+            <strong>Loading projects</strong>
+            <span>Reading project memberships and summaries.</span>
+          </div>
+        ) : recentProjects.length === 0 ? (
+          <div className="empty-state">
+            <strong>No projects yet</strong>
+            <span>Create a project from the upload flow or the project workspace.</span>
+          </div>
+        ) : (
+          <div className="project-grid">
+            {recentProjects.map((project) => {
+              const summary = data.summaries.find((candidate) => candidate.projectId === project.id);
+              return (
+                <article className="project-card" key={project.id}>
+                  <div className="artifact-title">
+                    <strong>{project.name}</strong>
+                    <span className="status-pill accent">{project.myRole}</span>
+                  </div>
+                  <p>{project.description || 'No description provided.'}</p>
+                  <div className="metadata-grid">
+                    <span>Images</span>
+                    <strong>{summary?.imageCount ?? 0}</strong>
+                    <span>Jobs</span>
+                    <strong>{summary?.jobCount ?? 0}</strong>
+                    <span>Preset</span>
+                    <strong>{project.defaultPreset || 'A4_SCAN_300DPI'}</strong>
+                    <span>Updated</span>
+                    <strong>{formatDate(project.updatedAt)}</strong>
+                  </div>
+                  <div className="download-actions">
+                    <a className="secondary-action" href={`/projects/${project.id}`}>
+                      Open project
+                    </a>
+                    <a className="secondary-action" href="/upload">
+                      Upload more
+                    </a>
+                  </div>
+                </article>
+              );
+            })}
+          </div>
+        )}
+      </section>
+    </div>
+  );
+}
+
+function buildStats(data: DashboardData) {
+  const imageCount = data.summaries.reduce((sum, summary) => sum + summary.imageCount, 0);
+  const totalItems = data.jobs.reduce((sum, job) => sum + job.totalCount, 0);
+  const processedItems = data.jobs.reduce((sum, job) => sum + job.succeededCount, 0);
+  const failedItems = data.jobs.reduce((sum, job) => sum + job.failedCount, 0);
+  const queuedItems = data.jobs.reduce((sum, job) => sum + job.queuedCount, 0);
+  const processingItems = data.jobs.reduce((sum, job) => sum + job.processingCount, 0);
+  const activeJobs = data.jobs.filter((job) => activeJobStatuses.has(job.status)).length;
+  const successRate = totalItems === 0 ? '-' : `${Math.round((processedItems / totalItems) * 100)}%`;
+
+  return {
+    projectCount: data.projectTotal || data.projects.length,
+    imageCount,
+    jobCount: data.jobTotal || data.jobs.length,
+    activeJobs,
+    processedItems,
+    failedItems,
+    queuedItems,
+    processingItems,
+    successRate
+  };
+}
+
+function sortByCreatedAt(jobs: JobResponse[]) {
+  return [...jobs].sort((left, right) => Date.parse(right.createdAt) - Date.parse(left.createdAt));
+}
+
+function MetricCard({ label, value, detail }: { label: string; value: string; detail: string }) {
+  return (
+    <div className="metric-card">
+      <span>{label}</span>
+      <strong>{value}</strong>
+      <small>{detail}</small>
+    </div>
+  );
+}
+
+function describeError(exception: unknown, fallback: string) {
+  return exception instanceof Error && exception.message ? exception.message : fallback;
+}
+
+function formatDate(value: string) {
+  return new Intl.DateTimeFormat(undefined, {
+    dateStyle: 'medium',
+    timeStyle: 'short'
+  }).format(new Date(value));
 }

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -619,6 +619,65 @@ button {
   align-items: start;
 }
 
+.dashboard-layout {
+  display: grid;
+  grid-template-columns: minmax(24rem, 1.05fr) minmax(18rem, 0.95fr);
+  gap: 1.1rem;
+  align-items: start;
+}
+
+.dashboard-action-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.9rem;
+}
+
+.dashboard-action-card {
+  display: grid;
+  gap: 0.4rem;
+  min-height: 9rem;
+  border: 1px solid rgba(18, 56, 45, 0.12);
+  border-radius: 1.15rem;
+  background:
+    radial-gradient(circle at 88% 18%, rgba(214, 180, 95, 0.18), transparent 8rem),
+    rgba(255, 254, 248, 0.88);
+  color: var(--ink);
+  padding: 1rem;
+}
+
+.dashboard-action-card.primary {
+  background:
+    radial-gradient(circle at 82% 12%, rgba(216, 109, 61, 0.24), transparent 8rem),
+    linear-gradient(135deg, rgba(18, 56, 45, 0.96), rgba(31, 90, 71, 0.9));
+  color: #fff8df;
+}
+
+.dashboard-action-card span,
+.dashboard-action-card small {
+  color: var(--muted);
+}
+
+.dashboard-action-card.primary span,
+.dashboard-action-card.primary small {
+  color: rgba(247, 243, 231, 0.72);
+}
+
+.dashboard-action-card span {
+  font-size: 0.76rem;
+  font-weight: 900;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.dashboard-action-card strong {
+  font-size: 1.2rem;
+  letter-spacing: -0.03em;
+}
+
+.dashboard-job-row {
+  grid-template-columns: minmax(10rem, 0.8fr) auto minmax(15rem, 1.2fr) auto;
+}
+
 .stack-form,
 .project-grid,
 .metadata-grid {
@@ -767,6 +826,7 @@ button {
   .upload-layout,
   .project-layout,
   .job-detail-layout,
+  .dashboard-layout,
   .console-hero {
     grid-template-columns: 1fr;
   }
@@ -782,7 +842,8 @@ button {
 
   .metric-strip,
   .artifact-grid,
-  .project-grid {
+  .project-grid,
+  .dashboard-action-grid {
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 }
@@ -801,7 +862,8 @@ button {
 
   .metric-strip,
   .artifact-grid,
-  .project-grid {
+  .project-grid,
+  .dashboard-action-grid {
     grid-template-columns: 1fr;
   }
 }


### PR DESCRIPTION
## #️⃣ 기능 설명

Dashboard placeholder를 제거하고, Project/Job API 기반 운영 개요 화면을 구현했습니다.

Closes #100

## 🛠️ 작업 상세 내용

- [x] 프로젝트 목록과 프로젝트별 summary를 조회해 프로젝트/이미지 통계 표시
- [x] Job 목록을 조회해 전체 작업 수, active job, 성공률, 실패/대기/처리 중 카운터 표시
- [x] 최근 Job과 최근 Project 카드 및 상세 화면 이동 링크 제공
- [x] 인증 실패 시 Google 로그인 CTA와 retry 제공
- [x] 기능 명세 문서 추가

## 📁 변경 파일 요약

- `frontend/src/pages/DashboardPage.tsx`
- `frontend/src/styles/global.css`
- `docs/feature-specs/issue-100-dashboard-overview.md`

## ✅ 검증 내용

- [x] `cd frontend && npm run build`
- [x] `git diff --check`
- [ ] Docker Compose 실행 확인: 이번 변경은 프론트 Dashboard 표시 로직만 수정하여 별도 Docker 재기동 검증은 수행하지 않았습니다.

## 🔎 리뷰어가 확인해야 할 부분

- Admin/Benchmark/Audit 기능을 다시 추가하지 않고 기존 MVP API만 사용하는지 확인해주세요.
- Dashboard 통계가 Project summary와 Job counters 기준으로 충분히 직관적인지 확인해주세요.

## 📸 스크린샷

- 로컬 UI 스크린샷은 사용자가 브랜치 확인 시 첨부 예정입니다.

## 💬 기타 공유사항 to 리뷰어

- Queue health는 Admin/RabbitMQ API 없이 Job counter 기반으로만 표시합니다.