### PR TITLE
✨ [Feat] Job 취소와 실패 재시도 UI 구현

### DIFF
--- a/docs/feature-specs/issue-102-job-actions-ui.md
+++ b/docs/feature-specs/issue-102-job-actions-ui.md
@@ -1,0 +1,72 @@
+# Issue 102 - Job 취소와 실패 재시도 UI
+
+## 작업 목적
+
+Job detail 화면에서 사용자가 전처리 작업을 직접 운영할 수 있도록 기존 Job command API를 연결한다.
+
+이번 범위는 UI 연결만 다룬다. Backend의 cancel/retry API는 이미 구현되어 있으며, 전체 rerun은 실수 위험이 커서 MVP 화면에서는 노출하지 않는다.
+
+## 전체 순서
+
+1. Job detail 진입 시 기존처럼 Job, summary, JobItem 목록을 조회한다.
+2. Job 상태가 취소 가능한 상태인지 계산한다.
+3. JobItem 중 `FAILED`, `DEAD_LETTERED` 상태인 항목 수를 계산한다.
+4. 사용자가 취소 버튼을 누르면 확인창 후 `POST /api/v1/jobs/{jobId}/cancel`을 호출한다.
+5. 사용자가 실패 재시도 버튼을 누르면 확인창 후 `POST /api/v1/jobs/{jobId}/retry`를 호출한다.
+6. command API 성공 후 Job, summary, JobItem 목록을 다시 조회한다.
+7. 처리 결과 메시지를 화면 상단에 표시한다.
+
+## 기능 단위
+
+### 1. Cancel Job
+
+- 연결 API: `POST /api/v1/jobs/{jobId}/cancel`
+- 취소 버튼 노출 위치: Job detail의 `Controls and downloads` 섹션
+- 버튼 활성 조건:
+  - Job 상태가 `CREATED`, `QUEUED`, `RUNNING`, `RETRYING` 중 하나
+  - 다른 Job action이 진행 중이 아님
+- 버튼 비활성 조건:
+  - `SUCCEEDED`, `FAILED`, `PARTIAL_SUCCEEDED`, `CANCEL_REQUESTED`, `CANCELLED`
+  - 이미 command API 요청이 진행 중인 경우
+
+### 2. Retry Failed Items
+
+- 연결 API: `POST /api/v1/jobs/{jobId}/retry`
+- 재시도 대상:
+  - `FAILED`
+  - `DEAD_LETTERED`
+- 버튼 라벨은 재시도 가능한 항목 수를 포함한다.
+- command API 응답의 `queuedItems`를 성공 메시지에 표시한다.
+- 전체 rerun API는 이번 UI에서 제공하지 않는다.
+
+### 3. Data Refresh
+
+- command API 성공 후 `loadJob(false)`를 호출한다.
+- 재조회 대상:
+  - `GET /api/v1/jobs/{jobId}`
+  - `GET /api/v1/jobs/{jobId}/summary`
+  - `GET /api/v1/jobs/{jobId}/items?size=500`
+- 기존 자동 polling 흐름은 유지한다.
+
+### 4. Error Handling
+
+- command API 실패 시 기존 `status-card error` 영역에 에러 메시지를 표시한다.
+- 성공 시 `status-card success` 영역에 command 결과를 표시한다.
+- access token/refresh token 처리는 기존 `apiClient` 흐름을 그대로 사용한다.
+
+## 제외 범위
+
+- `POST /api/v1/jobs/{jobId}/rerun` UI 노출
+- JobItem 개별 retry API
+- Backend cancel/retry 로직 변경
+- Worker retry policy 변경
+- Preview/report/debug artifact 다운로드
+
+## 검증 기준
+
+- `frontend/src/pages/JobDetailPage.tsx`에서 cancel/retry failed items 버튼이 표시된다.
+- 버튼 활성/비활성 조건이 Job/JobItem 상태와 맞는다.
+- command API 호출 후 Job detail 데이터가 다시 로드된다.
+- `frontend/src/styles/global.css`는 기존 디자인 시스템을 확장하며 외부 UI 템플릿을 추가하지 않는다.
+- `npm run build`가 통과한다.
+- `git diff --check`가 통과한다.

--- a/frontend/src/pages/JobDetailPage.tsx
+++ b/frontend/src/pages/JobDetailPage.tsx
@@ -70,7 +70,22 @@ type JobZipDownloadResponse = {
   expiresAt: string;
 };
 
+type JobCancelResponse = {
+  jobId: number;
+  status: string;
+};
+
+type JobRetryResponse = {
+  jobId: number;
+  status: string;
+  queuedItems: number;
+};
+
 const terminalStatuses = new Set(['SUCCEEDED', 'FAILED', 'PARTIAL_SUCCEEDED', 'CANCELLED']);
+const cancellableStatuses = new Set(['CREATED', 'QUEUED', 'RUNNING', 'RETRYING']);
+const retryableItemStatuses = new Set(['FAILED', 'DEAD_LETTERED']);
+
+type JobAction = 'cancel' | 'retry';
 
 export function JobDetailPage() {
   const jobId = useMemo(() => {
@@ -84,10 +99,15 @@ export function JobDetailPage() {
   const [refreshing, setRefreshing] = useState(false);
   const [zipDownloading, setZipDownloading] = useState(false);
   const [itemDownloading, setItemDownloading] = useState<number | null>(null);
+  const [actionPending, setActionPending] = useState<JobAction | null>(null);
+  const [actionNotice, setActionNotice] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
 
   const processedItems = items.filter((item) => item.processedObjectKey);
+  const retryableItems = items.filter((item) => retryableItemStatuses.has(item.status));
   const isTerminal = job ? terminalStatuses.has(job.status) : false;
+  const canCancel = Boolean(job && cancellableStatuses.has(job.status) && !actionPending);
+  const canRetry = retryableItems.length > 0 && !actionPending;
 
   useEffect(() => {
     void loadJob(true);
@@ -166,6 +186,58 @@ export function JobDetailPage() {
     }
   }
 
+  async function cancelJob() {
+    if (!job || !window.confirm(`Cancel Job #${job.id}? Queued items will be marked as cancelled.`)) {
+      return;
+    }
+
+    setActionPending('cancel');
+    setActionNotice(null);
+    setError(null);
+    try {
+      const response = await apiClient.post<JobCancelResponse>(
+        `/v1/jobs/${job.id}/cancel`,
+        {},
+        readStoredAccessToken()
+      );
+      setActionNotice(`Cancel requested for Job #${response.result.jobId}. Current status: ${response.result.status}.`);
+      await loadJob(false);
+    } catch (exception) {
+      setError(describeError(exception, 'Failed to cancel job.'));
+    } finally {
+      setActionPending(null);
+    }
+  }
+
+  async function retryFailedItems() {
+    if (!job || retryableItems.length === 0) {
+      return;
+    }
+    if (!window.confirm(`Retry ${retryableItems.length} failed items in Job #${job.id}?`)) {
+      return;
+    }
+
+    setActionPending('retry');
+    setActionNotice(null);
+    setError(null);
+    try {
+      const response = await apiClient.post<JobRetryResponse>(
+        `/v1/jobs/${job.id}/retry`,
+        {},
+        readStoredAccessToken()
+      );
+      setActionNotice(
+        `Retry queued ${response.result.queuedItems} items for Job #${response.result.jobId}. `
+        + `Current status: ${response.result.status}.`
+      );
+      await loadJob(false);
+    } catch (exception) {
+      setError(describeError(exception, 'Failed to retry failed items.'));
+    } finally {
+      setActionPending(null);
+    }
+  }
+
   if (loading) {
     return (
       <PageSection title="Loading job" description="Fetching job state, item progress, and available processed outputs.">
@@ -183,6 +255,13 @@ export function JobDetailPage() {
         <div className="status-card error">
           <strong>Job detail failed</strong>
           <span>{error}</span>
+        </div>
+      )}
+
+      {actionNotice && (
+        <div className="status-card success">
+          <strong>Job action completed</strong>
+          <span>{actionNotice}</span>
         </div>
       )}
 
@@ -248,7 +327,33 @@ export function JobDetailPage() {
           </div>
         </PageSection>
 
-        <PageSection title="Downloads" description="MVP downloads expose processed images only.">
+        <PageSection title="Controls and downloads" description="Cancel active work or retry only failed Worker items.">
+          <div className="job-action-stack">
+            <div className="status-card">
+              <strong>{retryableItems.length} retryable items</strong>
+              <span>
+                Retry only targets `FAILED` and `DEAD_LETTERED` items. Full rerun is intentionally hidden from MVP UI.
+              </span>
+            </div>
+            <div className="download-actions">
+              <button
+                className="secondary-action danger-action"
+                type="button"
+                onClick={cancelJob}
+                disabled={!canCancel}
+              >
+                {actionPending === 'cancel' ? 'Cancelling...' : 'Cancel job'}
+              </button>
+              <button
+                className="secondary-action"
+                type="button"
+                onClick={retryFailedItems}
+                disabled={!canRetry}
+              >
+                {actionPending === 'retry' ? 'Retrying...' : `Retry failed (${retryableItems.length})`}
+              </button>
+            </div>
+          </div>
           <div className="status-card">
             <strong>{processedItems.length} processed images ready</strong>
             <span>Preview, report, and debug artifacts are intentionally hidden from the MVP UI.</span>

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -557,6 +557,16 @@ button {
   background: rgba(186, 63, 53, 0.1);
 }
 
+.status-card.success {
+  border-color: rgba(47, 157, 104, 0.24);
+  background: rgba(47, 157, 104, 0.1);
+}
+
+.danger-action {
+  border-color: rgba(186, 63, 53, 0.24);
+  color: var(--danger);
+}
+
 .progress-card {
   background: rgba(18, 56, 45, 0.06);
 }
@@ -783,6 +793,11 @@ button {
 .job-item-list {
   display: grid;
   gap: 0.8rem;
+}
+
+.job-action-stack {
+  display: grid;
+  gap: 0.85rem;
 }
 
 .job-item-row {


### PR DESCRIPTION
## #️⃣ 기능 설명

Job detail 화면에 기존 Job command API를 연결해 active Job 취소와 실패 JobItem 재시도를 수행할 수 있게 했습니다.

Closes #102

## 🛠️ 작업 상세 내용

- [x] `POST /api/v1/jobs/{jobId}/cancel` UI 액션 연결
- [x] `POST /api/v1/jobs/{jobId}/retry` UI 액션 연결
- [x] Job 상태와 retryable JobItem 수에 따라 버튼 활성/비활성 처리
- [x] command API 성공 후 Job/detail/summary/items 재조회
- [x] 성공/실패 상태 메시지와 feature spec 문서 추가

## 📁 변경 파일 요약

- `frontend/src/pages/JobDetailPage.tsx`
- `frontend/src/styles/global.css`
- `docs/feature-specs/issue-102-job-actions-ui.md`

## ✅ 검증 내용

- [x] `cd frontend && npm run build`
- [x] `git diff --check`
- [ ] Docker Compose 실행 확인: 이번 변경은 기존 backend API를 연결하는 프론트 UI 변경이라 별도 컨테이너 재기동 검증은 수행하지 않았습니다.

## 🔎 리뷰어가 확인해야 할 부분

- 취소 버튼이 `CREATED`, `QUEUED`, `RUNNING`, `RETRYING` 상태에서만 활성화되는지 확인해주세요.
- retry 버튼이 `FAILED`, `DEAD_LETTERED` JobItem이 있을 때만 활성화되는지 확인해주세요.
- 전체 rerun API를 UI에 노출하지 않는 정책이 적절한지 확인해주세요.

## 📸 스크린샷

- 로컬 UI 스크린샷은 사용자가 브랜치 확인 시 첨부 예정입니다.

## 💬 기타 공유사항 to 리뷰어

- Backend cancel/retry 로직은 변경하지 않았습니다.