### PR TITLE
✨ [Feat] Job processed artifact 목록 API 구현

### DIFF
--- a/backend-api/src/main/java/com/moonju/preprocess/api/domain/job/dto/JobArtifactResponse.java
+++ b/backend-api/src/main/java/com/moonju/preprocess/api/domain/job/dto/JobArtifactResponse.java
@@ -1,11 +1,40 @@
 package com.moonju.preprocess.api.domain.job.dto;
 
+import com.moonju.preprocess.api.domain.job.entity.JobItem;
+import com.moonju.preprocess.api.domain.job.entity.JobItemStatus;
+import com.moonju.preprocess.api.infra.storage.PresignedDownloadTarget;
+import java.time.Instant;
+import java.util.List;
+
 public record JobArtifactResponse(
     Long jobId,
-    String message
+    int totalItems,
+    int processedReadyCount,
+    List<ProcessedArtifact> processedArtifacts
 ) {
 
-    public static JobArtifactResponse skeleton(Long jobId) {
-        return new JobArtifactResponse(jobId, "Job artifact listing is reserved for worker artifact integration.");
+    public static JobArtifactResponse of(Long jobId, int totalItems, List<ProcessedArtifact> processedArtifacts) {
+        return new JobArtifactResponse(jobId, totalItems, processedArtifacts.size(), processedArtifacts);
+    }
+
+    public record ProcessedArtifact(
+        Long itemId,
+        Long imageId,
+        JobItemStatus status,
+        String objectKey,
+        String downloadUrl,
+        Instant expiresAt
+    ) {
+
+        public static ProcessedArtifact of(JobItem item, PresignedDownloadTarget target) {
+            return new ProcessedArtifact(
+                item.getId(),
+                item.getImageId(),
+                item.getStatus(),
+                target.objectKey(),
+                target.downloadUrl(),
+                target.expiresAt()
+            );
+        }
     }
 }

--- a/backend-api/src/main/java/com/moonju/preprocess/api/domain/job/service/JobQueryService.java
+++ b/backend-api/src/main/java/com/moonju/preprocess/api/domain/job/service/JobQueryService.java
@@ -8,6 +8,7 @@ import com.moonju.preprocess.api.domain.job.dto.JobSummaryResponse;
 import com.moonju.preprocess.api.domain.job.entity.Job;
 import com.moonju.preprocess.api.domain.job.entity.JobItem;
 import com.moonju.preprocess.api.domain.job.entity.JobItemArtifactDownloadType;
+import com.moonju.preprocess.api.domain.job.entity.JobItemStatus;
 import com.moonju.preprocess.api.domain.job.exception.JobNotFoundException;
 import com.moonju.preprocess.api.domain.job.repository.JobItemRepository;
 import com.moonju.preprocess.api.domain.job.repository.JobRepository;
@@ -19,6 +20,7 @@ import com.moonju.preprocess.api.infra.storage.PresignedDownloadCommand;
 import com.moonju.preprocess.api.infra.storage.PresignedDownloadTarget;
 import com.moonju.preprocess.api.infra.storage.PresignedDownloadUrlGenerator;
 import java.time.Duration;
+import java.util.List;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -69,7 +71,12 @@ public class JobQueryService {
     @Transactional(readOnly = true)
     public JobArtifactResponse artifacts(Long currentUserId, Long jobId) {
         Job job = findReadableJob(currentUserId, jobId);
-        return JobArtifactResponse.skeleton(job.getId());
+        List<JobItem> items = jobItemRepository.findAllByJobId(job.getId());
+        List<JobArtifactResponse.ProcessedArtifact> processedArtifacts = items.stream()
+            .filter(this::hasReadyProcessedArtifact)
+            .map(this::createProcessedArtifact)
+            .toList();
+        return JobArtifactResponse.of(job.getId(), items.size(), processedArtifacts);
     }
 
     @Transactional(readOnly = true)
@@ -117,5 +124,18 @@ public class JobQueryService {
         } catch (IllegalArgumentException exception) {
             throw new BusinessException(ErrorCode.VALIDATION_ERROR, "Unsupported job item artifact type.");
         }
+    }
+
+    private boolean hasReadyProcessedArtifact(JobItem item) {
+        return item.getStatus() == JobItemStatus.SUCCEEDED
+            && item.getProcessedObjectKey() != null
+            && !item.getProcessedObjectKey().isBlank();
+    }
+
+    private JobArtifactResponse.ProcessedArtifact createProcessedArtifact(JobItem item) {
+        PresignedDownloadTarget target = presignedDownloadUrlGenerator.generateDownloadUrl(
+            new PresignedDownloadCommand(item.getProcessedObjectKey(), DOWNLOAD_URL_EXPIRES_IN)
+        );
+        return JobArtifactResponse.ProcessedArtifact.of(item, target);
     }
 }

--- a/backend-api/src/test/java/com/moonju/preprocess/api/domain/job/service/JobQueryServiceTests.java
+++ b/backend-api/src/test/java/com/moonju/preprocess/api/domain/job/service/JobQueryServiceTests.java
@@ -3,9 +3,11 @@ package com.moonju.preprocess.api.domain.job.service;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.moonju.preprocess.api.domain.job.dto.JobArtifactResponse;
 import com.moonju.preprocess.api.domain.job.dto.JobItemDownloadUrlResponse;
 import com.moonju.preprocess.api.domain.job.dto.JobResponse;
 import com.moonju.preprocess.api.domain.job.dto.JobSummaryResponse;
@@ -23,6 +25,7 @@ import com.moonju.preprocess.api.infra.storage.PresignedDownloadCommand;
 import com.moonju.preprocess.api.infra.storage.PresignedDownloadTarget;
 import com.moonju.preprocess.api.infra.storage.PresignedDownloadUrlGenerator;
 import java.time.Instant;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
@@ -113,6 +116,48 @@ class JobQueryServiceTests {
     }
 
     @Test
+    void listsProcessedArtifactsWithDownloadUrls() {
+        Job job = job(1L);
+        JobItem succeededItem = succeededItem(2L, job.getId());
+        JobItem failedItem = failedItem(3L, job.getId());
+        when(jobRepository.findById(1L)).thenReturn(Optional.of(job));
+        when(projectPermissionService.validateReadable(10L, 20L)).thenReturn(null);
+        when(jobItemRepository.findAllByJobId(1L)).thenReturn(List.of(succeededItem, failedItem));
+        when(presignedDownloadUrlGenerator.generateDownloadUrl(any(PresignedDownloadCommand.class)))
+            .thenReturn(new PresignedDownloadTarget(
+                "processed/10/1/2/processed.png",
+                "http://localhost:9000/image-preprocess-local/processed.png",
+                Instant.parse("2026-05-15T09:00:00Z"),
+                Map.of()
+            ));
+
+        JobArtifactResponse response = service.artifacts(20L, 1L);
+
+        assertThat(response.jobId()).isEqualTo(1L);
+        assertThat(response.totalItems()).isEqualTo(2);
+        assertThat(response.processedReadyCount()).isEqualTo(1);
+        assertThat(response.processedArtifacts()).hasSize(1);
+        assertThat(response.processedArtifacts().getFirst().itemId()).isEqualTo(2L);
+        assertThat(response.processedArtifacts().getFirst().downloadUrl()).contains("localhost:9000");
+        verify(projectPermissionService).validateReadable(10L, 20L);
+    }
+
+    @Test
+    void returnsEmptyArtifactListWhenNoProcessedImageIsReady() {
+        Job job = job(1L);
+        when(jobRepository.findById(1L)).thenReturn(Optional.of(job));
+        when(projectPermissionService.validateReadable(10L, 20L)).thenReturn(null);
+        when(jobItemRepository.findAllByJobId(1L)).thenReturn(List.of(failedItem(3L, job.getId())));
+
+        JobArtifactResponse response = service.artifacts(20L, 1L);
+
+        assertThat(response.totalItems()).isEqualTo(1);
+        assertThat(response.processedReadyCount()).isZero();
+        assertThat(response.processedArtifacts()).isEmpty();
+        verify(presignedDownloadUrlGenerator, never()).generateDownloadUrl(any(PresignedDownloadCommand.class));
+    }
+
+    @Test
     void rejectsUnsupportedJobItemArtifactType() {
         Job job = job(1L);
         JobItem item = succeededItem(2L, job.getId());
@@ -139,6 +184,12 @@ class JobQueryServiceTests {
             "processed/10/1/2/preview.png",
             "processed/10/1/2/processing-report.json"
         );
+        ReflectionTestUtils.setField(item, "id", id);
+        return item;
+    }
+
+    private JobItem failedItem(Long id, Long jobId) {
+        JobItem item = new JobItem(jobId, 101L, JobItemStatus.FAILED, 1);
         ReflectionTestUtils.setField(item, "id", id);
         return item;
     }

--- a/docs/api/job-api.md
+++ b/docs/api/job-api.md
@@ -56,7 +56,7 @@ All endpoints require `Authorization: Bearer <access-token>`.
 | `POST` | `/api/v1/jobs/{jobId}/cancel` | Request cancellation |
 | `POST` | `/api/v1/jobs/{jobId}/retry` | Retry failed and dead-lettered items |
 | `POST` | `/api/v1/jobs/{jobId}/rerun` | Requeue all non-processing items |
-| `GET` | `/api/v1/jobs/{jobId}/artifacts` | Read artifact listing placeholder |
+| `GET` | `/api/v1/jobs/{jobId}/artifacts` | List processed image artifacts |
 | `GET` | `/api/v1/jobs/{jobId}/download.zip` | Create processed image ZIP download URL |
 
 Internal Worker endpoints are not user-facing APIs. They require `X-Worker-Token` and are mounted under
@@ -188,6 +188,48 @@ Rules:
 - `type` must be one of `processed`, `preview`, or `report`.
 - If the Worker has not registered the requested object key yet, the API returns `common404`.
 - Debug artifact expansion remains separate from this JobItem-level result download flow.
+
+## Job Processed Artifact Listing
+
+```text
+GET /api/v1/jobs/{jobId}/artifacts
+```
+
+The API validates project read permission, scans JobItems for completed processed images, and returns processed-only
+artifact download URLs. Preview images, processing reports, and debug artifacts stay hidden from the MVP user-facing
+listing.
+
+Response:
+
+```json
+{
+  "isSuccess": true,
+  "code": "common200",
+  "message": "Request succeeded.",
+  "result": {
+    "jobId": 1,
+    "totalItems": 3,
+    "processedReadyCount": 2,
+    "processedArtifacts": [
+      {
+        "itemId": 10,
+        "imageId": 100,
+        "status": "SUCCEEDED",
+        "objectKey": "processed/1/1/10/processed.png",
+        "downloadUrl": "http://localhost:9000/image-preprocess-local/processed/1/1/10/processed.png?...",
+        "expiresAt": "2026-05-15T09:00:00Z"
+      }
+    ]
+  }
+}
+```
+
+Rules:
+
+- Only `SUCCEEDED` JobItems with a non-empty `processedObjectKey` are included.
+- If no processed images are ready, `processedArtifacts` is an empty list.
+- The endpoint does not expose preview, report, or debug artifact URLs.
+- Item-level artifact download remains available through `/items/{itemId}/download`.
 
 ## Processed ZIP Download
 
@@ -367,5 +409,4 @@ POST /api/v1/jobs/{jobId}/rerun
 
 ## Current Limitations
 
-- Artifact listing currently returns a placeholder.
 - Detailed debug artifact row expansion is deferred to a later artifact domain task.

--- a/docs/feature-specs/issue-104-job-processed-artifacts-api.md
+++ b/docs/feature-specs/issue-104-job-processed-artifacts-api.md
@@ -1,0 +1,85 @@
+# Issue 104 - Job Processed Artifact API
+
+## Purpose
+
+Replace the placeholder response from `GET /api/v1/jobs/{jobId}/artifacts` with a real processed-image artifact
+listing for the MVP flow.
+
+The endpoint is a user-facing read API. It exposes processed output images only. Preview images, processing reports, and
+debug artifacts stay out of the MVP response.
+
+## End-To-End Flow
+
+1. The user calls `GET /api/v1/jobs/{jobId}/artifacts`.
+2. The API loads the Job and validates project read permission.
+3. The API loads every JobItem for the Job.
+4. The API selects only JobItems with status `SUCCEEDED` and a non-empty `processedObjectKey`.
+5. The API creates a presigned download URL for each processed object key.
+6. The API returns the Job-level item count and processed artifact list in the common response format.
+
+## Response Shape
+
+```json
+{
+  "jobId": 1,
+  "totalItems": 3,
+  "processedReadyCount": 2,
+  "processedArtifacts": [
+    {
+      "itemId": 10,
+      "imageId": 100,
+      "status": "SUCCEEDED",
+      "objectKey": "processed/1/1/10/processed.png",
+      "downloadUrl": "http://localhost:9000/image-preprocess-local/processed/1/1/10/processed.png?...",
+      "expiresAt": "2026-05-15T09:00:00Z"
+    }
+  ]
+}
+```
+
+## Functional Units
+
+### 1. Placeholder Removal
+
+- Remove the previous `JobArtifactResponse.skeleton()` path.
+- Replace the old `message` field with a real artifact list response.
+
+### 2. Processed-Only Policy
+
+Included:
+
+- JobItem status is `SUCCEEDED`.
+- `processedObjectKey` is not null or blank.
+
+Excluded:
+
+- Preview artifacts.
+- Processing reports.
+- Debug artifacts.
+- Processing, failed, cancelled, queued, or retrying items.
+
+### 3. Download URL Generation
+
+- Use the existing `PresignedDownloadUrlGenerator`.
+- Use the same 10-minute expiration window as item-level downloads.
+- Do not call the generator when no processed artifacts are ready.
+
+### 4. Tests
+
+- Verify that processed artifacts are listed with download URLs.
+- Verify that an empty list is returned when no processed image is ready.
+- Keep existing item-level artifact download tests unchanged.
+
+## Out Of Scope
+
+- Preview/report/debug artifact listing.
+- `ImageArtifact` row-based artifact expansion.
+- Frontend changes.
+- ZIP download behavior changes.
+
+## Verification
+
+- `JobArtifactResponse` returns real processed artifact data instead of placeholder text.
+- `JobQueryService.artifacts()` keeps project read permission validation.
+- Backend tests pass.
+- `docs/api/job-api.md` matches the actual API behavior.


### PR DESCRIPTION
## #️⃣ 기능 설명

`GET /api/v1/jobs/{jobId}/artifacts` placeholder 응답을 제거하고, MVP 정책에 맞춰 processed image artifact 목록과 presigned download URL을 반환하도록 구현했습니다.

Closes #104

## 🛠️ 작업 상세 내용

- [x] `JobArtifactResponse`를 placeholder message에서 실제 목록 응답으로 변경
- [x] `SUCCEEDED` JobItem 중 `processedObjectKey`가 있는 항목만 artifact 목록에 포함
- [x] processed artifact별 presigned download URL 생성
- [x] processed artifact가 없으면 빈 목록 반환 및 URL 생성 생략
- [x] `JobQueryServiceTests`에 artifact listing 테스트 추가
- [x] `docs/api/job-api.md`와 feature spec 문서 갱신

## 📁 변경 파일 요약

- `backend-api/src/main/java/com/moonju/preprocess/api/domain/job/dto/JobArtifactResponse.java`
- `backend-api/src/main/java/com/moonju/preprocess/api/domain/job/service/JobQueryService.java`
- `backend-api/src/test/java/com/moonju/preprocess/api/domain/job/service/JobQueryServiceTests.java`
- `docs/api/job-api.md`
- `docs/feature-specs/issue-104-job-processed-artifacts-api.md`

## ✅ 검증 내용

- [x] `docker run --rm -v "${pwdPath}:/workspace" -w /workspace gradle:8.10-jdk21 gradle test build --no-daemon`: 통과
- [x] `git diff --check`: 통과
- [ ] Swagger 확인: 로컬 Gradle 미설치 환경이라 Docker 기반 build/test로 대체했습니다.

## 🔎 리뷰어가 확인해야 할 부분

- `/jobs/{jobId}/artifacts` 응답이 processed-only MVP 정책과 맞는지 확인해주세요.
- preview/report/debug artifact를 노출하지 않는 결정이 현재 UI 정책과 맞는지 확인해주세요.
- artifact가 없는 경우 404가 아니라 빈 목록을 반환하는 정책이 적절한지 확인해주세요.

## 📸 스크린샷

- API 응답 변경 PR이라 스크린샷은 없습니다.

## 💬 기타 공유사항 to 리뷰어

- 기존 item-level artifact download API와 processed ZIP download API는 변경하지 않았습니다.