### PR TITLE
✨ [Feat] 업로드 이미지 magic number 검증 추가

### DIFF
--- a/backend-api/src/main/java/com/moonju/preprocess/api/domain/upload/service/UploadCompleteService.java
+++ b/backend-api/src/main/java/com/moonju/preprocess/api/domain/upload/service/UploadCompleteService.java
@@ -23,19 +23,22 @@ public class UploadCompleteService {
     private final ProjectPermissionService projectPermissionService;
     private final ObjectStoragePort objectStoragePort;
     private final ImageCreateService imageCreateService;
+    private final UploadedImageMagicNumberValidator magicNumberValidator;
 
     public UploadCompleteService(
         UploadSessionService uploadSessionService,
         UploadSessionFileRepository uploadSessionFileRepository,
         ProjectPermissionService projectPermissionService,
         ObjectStoragePort objectStoragePort,
-        ImageCreateService imageCreateService
+        ImageCreateService imageCreateService,
+        UploadedImageMagicNumberValidator magicNumberValidator
     ) {
         this.uploadSessionService = uploadSessionService;
         this.uploadSessionFileRepository = uploadSessionFileRepository;
         this.projectPermissionService = projectPermissionService;
         this.objectStoragePort = objectStoragePort;
         this.imageCreateService = imageCreateService;
+        this.magicNumberValidator = magicNumberValidator;
     }
 
     @Transactional
@@ -76,6 +79,7 @@ public class UploadCompleteService {
         if (!objectStoragePort.exists(file.getObjectKey())) {
             throw new UploadNotCompletedException("Uploaded object does not exist: " + file.getObjectKey());
         }
+        magicNumberValidator.validate(file, objectStoragePort.downloadBytes(file.getObjectKey()));
         file.markUploaded();
     }
 }

--- a/backend-api/src/main/java/com/moonju/preprocess/api/domain/upload/service/UploadedImageMagicNumberValidator.java
+++ b/backend-api/src/main/java/com/moonju/preprocess/api/domain/upload/service/UploadedImageMagicNumberValidator.java
@@ -1,0 +1,107 @@
+package com.moonju.preprocess.api.domain.upload.service;
+
+import com.moonju.preprocess.api.domain.upload.entity.UploadSessionFile;
+import com.moonju.preprocess.api.domain.upload.exception.InvalidUploadFileException;
+import java.util.Locale;
+import java.util.Set;
+import org.springframework.stereotype.Component;
+
+@Component
+public class UploadedImageMagicNumberValidator {
+
+    private static final byte[] PNG_SIGNATURE = {
+        (byte) 0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A
+    };
+
+    public void validate(UploadSessionFile file, byte[] bytes) {
+        DetectedImageFormat detected = detect(bytes);
+        String extension = extensionOf(file.getOriginalFileName());
+        String contentType = file.getContentType().toLowerCase(Locale.ROOT);
+
+        if (!detected.extensions.contains(extension)) {
+            throw new InvalidUploadFileException("Uploaded image signature does not match the file extension.");
+        }
+        if (!detected.contentTypes.contains(contentType)) {
+            throw new InvalidUploadFileException("Uploaded image signature does not match the content type.");
+        }
+    }
+
+    private DetectedImageFormat detect(byte[] bytes) {
+        if (startsWith(bytes, PNG_SIGNATURE)) {
+            return DetectedImageFormat.PNG;
+        }
+        if (bytes.length >= 3
+            && unsigned(bytes[0]) == 0xFF
+            && unsigned(bytes[1]) == 0xD8
+            && unsigned(bytes[2]) == 0xFF) {
+            return DetectedImageFormat.JPEG;
+        }
+        if (bytes.length >= 12
+            && asciiEquals(bytes, 0, "RIFF")
+            && asciiEquals(bytes, 8, "WEBP")) {
+            return DetectedImageFormat.WEBP;
+        }
+        if (bytes.length >= 2 && bytes[0] == 0x42 && bytes[1] == 0x4D) {
+            return DetectedImageFormat.BMP;
+        }
+        if (bytes.length >= 4
+            && ((bytes[0] == 0x49 && bytes[1] == 0x49 && bytes[2] == 0x2A && bytes[3] == 0x00)
+            || (bytes[0] == 0x4D && bytes[1] == 0x4D && bytes[2] == 0x00 && bytes[3] == 0x2A))) {
+            return DetectedImageFormat.TIFF;
+        }
+        throw new InvalidUploadFileException("Unsupported or corrupted image signature.");
+    }
+
+    private String extensionOf(String fileName) {
+        String normalized = fileName.toLowerCase(Locale.ROOT);
+        int lastDot = normalized.lastIndexOf('.');
+        if (lastDot < 0 || lastDot == normalized.length() - 1) {
+            throw new InvalidUploadFileException("Image file extension is required.");
+        }
+        return normalized.substring(lastDot);
+    }
+
+    private boolean startsWith(byte[] bytes, byte[] signature) {
+        if (bytes.length < signature.length) {
+            return false;
+        }
+        for (int index = 0; index < signature.length; index++) {
+            if (bytes[index] != signature[index]) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private boolean asciiEquals(byte[] bytes, int offset, String expected) {
+        if (bytes.length < offset + expected.length()) {
+            return false;
+        }
+        for (int index = 0; index < expected.length(); index++) {
+            if (bytes[offset + index] != (byte) expected.charAt(index)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private int unsigned(byte value) {
+        return value & 0xFF;
+    }
+
+    private enum DetectedImageFormat {
+        PNG(Set.of(".png"), Set.of("image/png")),
+        JPEG(Set.of(".jpg", ".jpeg"), Set.of("image/jpeg")),
+        WEBP(Set.of(".webp"), Set.of("image/webp")),
+        BMP(Set.of(".bmp"), Set.of("image/bmp", "image/x-ms-bmp")),
+        TIFF(Set.of(".tif", ".tiff"), Set.of("image/tiff"));
+
+        private final Set<String> extensions;
+        private final Set<String> contentTypes;
+
+        DetectedImageFormat(Set<String> extensions, Set<String> contentTypes) {
+            this.extensions = extensions;
+            this.contentTypes = contentTypes;
+        }
+    }
+}

--- a/backend-api/src/test/java/com/moonju/preprocess/api/domain/upload/service/UploadCompleteServiceTests.java
+++ b/backend-api/src/test/java/com/moonju/preprocess/api/domain/upload/service/UploadCompleteServiceTests.java
@@ -2,6 +2,9 @@ package com.moonju.preprocess.api.domain.upload.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -13,6 +16,7 @@ import com.moonju.preprocess.api.domain.upload.entity.UploadFileStatus;
 import com.moonju.preprocess.api.domain.upload.entity.UploadSession;
 import com.moonju.preprocess.api.domain.upload.entity.UploadSessionFile;
 import com.moonju.preprocess.api.domain.upload.entity.UploadSessionStatus;
+import com.moonju.preprocess.api.domain.upload.exception.InvalidUploadFileException;
 import com.moonju.preprocess.api.domain.upload.exception.UploadNotCompletedException;
 import com.moonju.preprocess.api.domain.upload.repository.UploadSessionFileRepository;
 import com.moonju.preprocess.api.infra.storage.ObjectStoragePort;
@@ -42,6 +46,9 @@ class UploadCompleteServiceTests {
     @Mock
     private ImageCreateService imageCreateService;
 
+    @Mock
+    private UploadedImageMagicNumberValidator magicNumberValidator;
+
     @InjectMocks
     private UploadCompleteService service;
 
@@ -49,11 +56,13 @@ class UploadCompleteServiceTests {
     void completesUploadSessionAfterObjectExistenceVerification() {
         UploadSession uploadSession = uploadSession(1L, 10L, 20L, 1, 4096L);
         UploadSessionFile file = uploadSessionFile(100L, 1L, 10L, "originals/10/1/file/scan_001.png");
+        byte[] validBytes = pngBytes();
 
         when(uploadSessionService.findOpenSession(1L)).thenReturn(uploadSession);
         when(projectPermissionService.validateEditable(10L, 20L)).thenReturn(null);
         when(uploadSessionFileRepository.findByUploadSessionIdAndIdIn(1L, List.of(100L))).thenReturn(List.of(file));
         when(objectStoragePort.exists(file.getObjectKey())).thenReturn(true);
+        when(objectStoragePort.downloadBytes(file.getObjectKey())).thenReturn(validBytes);
 
         UploadCompleteResponse response = service.complete(20L, 1L, new UploadCompleteRequest(List.of(100L)));
 
@@ -62,6 +71,7 @@ class UploadCompleteServiceTests {
         assertThat(response.uploadedFileCount()).isEqualTo(1);
         assertThat(uploadSession.getStatus()).isEqualTo(UploadSessionStatus.COMPLETED);
         assertThat(file.getStatus()).isEqualTo(UploadFileStatus.UPLOADED);
+        verify(magicNumberValidator).validate(file, validBytes);
         verify(imageCreateService).createFromCompletedUpload(uploadSession, List.of(file));
     }
 
@@ -78,6 +88,28 @@ class UploadCompleteServiceTests {
         assertThatThrownBy(() -> service.complete(20L, 1L, new UploadCompleteRequest(List.of(100L))))
             .isInstanceOf(UploadNotCompletedException.class)
             .hasMessage("Uploaded object does not exist: originals/10/1/file/scan_001.png");
+        verify(magicNumberValidator, never()).validate(any(UploadSessionFile.class), any(byte[].class));
+    }
+
+    @Test
+    void rejectsCompletionWhenUploadedObjectSignatureIsInvalid() {
+        UploadSession uploadSession = uploadSession(1L, 10L, 20L, 1, 4096L);
+        UploadSessionFile file = uploadSessionFile(100L, 1L, 10L, "originals/10/1/file/scan_001.png");
+        byte[] invalidBytes = "not-an-image".getBytes(java.nio.charset.StandardCharsets.UTF_8);
+
+        when(uploadSessionService.findOpenSession(1L)).thenReturn(uploadSession);
+        when(projectPermissionService.validateEditable(10L, 20L)).thenReturn(null);
+        when(uploadSessionFileRepository.findByUploadSessionIdAndIdIn(1L, List.of(100L))).thenReturn(List.of(file));
+        when(objectStoragePort.exists(file.getObjectKey())).thenReturn(true);
+        when(objectStoragePort.downloadBytes(file.getObjectKey())).thenReturn(invalidBytes);
+        doThrow(new InvalidUploadFileException("Unsupported or corrupted image signature."))
+            .when(magicNumberValidator)
+            .validate(file, invalidBytes);
+
+        assertThatThrownBy(() -> service.complete(20L, 1L, new UploadCompleteRequest(List.of(100L))))
+            .isInstanceOf(InvalidUploadFileException.class)
+            .hasMessage("Unsupported or corrupted image signature.");
+        verify(imageCreateService, never()).createFromCompletedUpload(uploadSession, List.of(file));
     }
 
     private UploadSession uploadSession(
@@ -115,5 +147,11 @@ class UploadCompleteServiceTests {
         );
         ReflectionTestUtils.setField(file, "id", id);
         return file;
+    }
+
+    private byte[] pngBytes() {
+        return new byte[] {
+            (byte) 0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A
+        };
     }
 }

--- a/backend-api/src/test/java/com/moonju/preprocess/api/domain/upload/service/UploadedImageMagicNumberValidatorTests.java
+++ b/backend-api/src/test/java/com/moonju/preprocess/api/domain/upload/service/UploadedImageMagicNumberValidatorTests.java
@@ -1,0 +1,92 @@
+package com.moonju.preprocess.api.domain.upload.service;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.moonju.preprocess.api.domain.upload.entity.UploadSessionFile;
+import com.moonju.preprocess.api.domain.upload.exception.InvalidUploadFileException;
+import org.junit.jupiter.api.Test;
+
+class UploadedImageMagicNumberValidatorTests {
+
+    private final UploadedImageMagicNumberValidator validator = new UploadedImageMagicNumberValidator();
+
+    @Test
+    void acceptsSupportedImageSignatures() {
+        validator.validate(file("scan.png", "image/png"), pngBytes());
+        validator.validate(file("scan.jpg", "image/jpeg"), jpegBytes());
+        validator.validate(file("scan.jpeg", "image/jpeg"), jpegBytes());
+        validator.validate(file("scan.webp", "image/webp"), webpBytes());
+        validator.validate(file("scan.bmp", "image/x-ms-bmp"), bmpBytes());
+        validator.validate(file("scan.tif", "image/tiff"), tiffLittleEndianBytes());
+        validator.validate(file("scan.tiff", "image/tiff"), tiffBigEndianBytes());
+    }
+
+    @Test
+    void rejectsSignatureThatDoesNotMatchExtension() {
+        assertThatThrownBy(() -> validator.validate(file("scan.png", "image/png"), jpegBytes()))
+            .isInstanceOf(InvalidUploadFileException.class)
+            .hasMessage("Uploaded image signature does not match the file extension.");
+    }
+
+    @Test
+    void rejectsSignatureThatDoesNotMatchContentType() {
+        assertThatThrownBy(() -> validator.validate(file("scan.jpg", "image/png"), jpegBytes()))
+            .isInstanceOf(InvalidUploadFileException.class)
+            .hasMessage("Uploaded image signature does not match the content type.");
+    }
+
+    @Test
+    void rejectsUnsupportedOrCorruptedSignature() {
+        assertThatThrownBy(() -> validator.validate(file("scan.png", "image/png"), "not-image".getBytes()))
+            .isInstanceOf(InvalidUploadFileException.class)
+            .hasMessage("Unsupported or corrupted image signature.");
+    }
+
+    private UploadSessionFile file(String name, String contentType) {
+        return UploadSessionFile.issued(
+            1L,
+            10L,
+            name,
+            "originals/10/1/file/" + name,
+            contentType,
+            1024L,
+            "a".repeat(64)
+        );
+    }
+
+    private byte[] pngBytes() {
+        return new byte[] {
+            (byte) 0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A
+        };
+    }
+
+    private byte[] jpegBytes() {
+        return new byte[] {
+            (byte) 0xFF, (byte) 0xD8, (byte) 0xFF, (byte) 0xE0
+        };
+    }
+
+    private byte[] webpBytes() {
+        return new byte[] {
+            0x52, 0x49, 0x46, 0x46, 0x24, 0x00, 0x00, 0x00, 0x57, 0x45, 0x42, 0x50
+        };
+    }
+
+    private byte[] bmpBytes() {
+        return new byte[] {
+            0x42, 0x4D, 0x1A, 0x00
+        };
+    }
+
+    private byte[] tiffLittleEndianBytes() {
+        return new byte[] {
+            0x49, 0x49, 0x2A, 0x00
+        };
+    }
+
+    private byte[] tiffBigEndianBytes() {
+        return new byte[] {
+            0x4D, 0x4D, 0x00, 0x2A
+        };
+    }
+}

--- a/docs/api/image-api.md
+++ b/docs/api/image-api.md
@@ -133,10 +133,12 @@ worker/report task and are empty until worker integration exists.
 When `POST /api/v1/upload-sessions/{sessionId}/complete` succeeds:
 
 1. API verifies the original objects exist.
-2. API marks upload files as `UPLOADED`.
-3. API marks the upload session as `COMPLETED`.
-4. API creates one `Image` row per uploaded file.
-5. API creates one `ORIGINAL` `ImageArtifact` row per image.
+2. API downloads each original object and validates the image magic number.
+3. API rejects files whose byte signature does not match the declared extension or content type.
+4. API marks upload files as `UPLOADED`.
+5. API marks the upload session as `COMPLETED`.
+6. API creates one `Image` row per uploaded file.
+7. API creates one `ORIGINAL` `ImageArtifact` row per image.
 
 The `Image` row is idempotent by `uploadSessionFileId`, so repeated internal finalization does not create duplicate
 images.
@@ -146,4 +148,3 @@ images.
 - Replace local download URL generator with a MinIO/S3 adapter.
 - Add metadata extraction for width, height, and DPI.
 - Add worker internal artifact registration for processed, preview, report, and debug files.
-- Add image magic number validation after object download.

--- a/docs/api/upload-api.md
+++ b/docs/api/upload-api.md
@@ -11,6 +11,7 @@ then notify the API that the upload is complete.
 - The Spring API must not receive large image file bodies.
 - Presigned upload URLs must include an expiration time.
 - Upload completion must verify object existence through `ObjectStoragePort`.
+- Upload completion must validate the stored object's image magic number against the declared file name and content type.
 - Image rows are not finalized before upload completion.
 - Upload session access is controlled by project membership, not only by the user who created the session.
 - Supported image extensions are `png`, `jpg`, `jpeg`, `tif`, `tiff`, `bmp`, and `webp`.
@@ -131,6 +132,25 @@ Response:
 }
 ```
 
+Completion verification:
+
+1. The requested upload file IDs must match the session's expected file count.
+2. Each object key must exist in Object Storage.
+3. Each stored object is downloaded through `ObjectStoragePort`.
+4. The API validates the image magic number.
+5. The detected image type must match the original file extension and content type.
+6. Only then does the API mark files as uploaded and create finalized image rows.
+
+Supported signatures:
+
+| Format | Extensions | Content types |
+| --- | --- | --- |
+| PNG | `.png` | `image/png` |
+| JPEG | `.jpg`, `.jpeg` | `image/jpeg` |
+| WEBP | `.webp` | `image/webp` |
+| BMP | `.bmp` | `image/bmp`, `image/x-ms-bmp` |
+| TIFF | `.tif`, `.tiff` | `image/tiff` |
+
 ## Status
 
 | Status | Meaning |
@@ -143,5 +163,4 @@ Response:
 ## Next Work
 
 - Replace the local presigned URL generator with a MinIO/S3 adapter.
-- Add image magic number validation after object download or metadata extraction.
 - Add server-side ZIP extraction only if browser-side extraction becomes too slow for the expected batch size.

--- a/docs/feature-specs/issue-106-upload-magic-number-validation.md
+++ b/docs/feature-specs/issue-106-upload-magic-number-validation.md
@@ -1,0 +1,66 @@
+# Issue 106 - Upload Magic Number Validation
+
+## Purpose
+
+Add server-side image signature validation to the upload completion flow. Frontend file filters and client-provided
+content types are not security boundaries, so the API must inspect the bytes stored in Object Storage before finalizing
+image metadata.
+
+## End-To-End Flow
+
+1. The frontend creates an upload session.
+2. The frontend requests presigned upload URLs with file name, content type, size, and checksum metadata.
+3. The frontend uploads each original file directly to Object Storage.
+4. The frontend calls `POST /api/v1/upload-sessions/{sessionId}/complete`.
+5. The API validates the requested upload file IDs and object existence.
+6. The API downloads each uploaded object through `ObjectStoragePort`.
+7. The API detects the actual image format from the magic number.
+8. The detected format must match the stored file name extension and content type.
+9. Only valid files are marked as uploaded and converted into finalized `Image` rows.
+
+## Supported Signatures
+
+| Format | Magic number rule | Extensions | Content types |
+| --- | --- | --- | --- |
+| PNG | `89 50 4E 47 0D 0A 1A 0A` | `.png` | `image/png` |
+| JPEG | `FF D8 FF` prefix | `.jpg`, `.jpeg` | `image/jpeg` |
+| WEBP | `RIFF` at offset 0 and `WEBP` at offset 8 | `.webp` | `image/webp` |
+| BMP | `42 4D` prefix | `.bmp` | `image/bmp`, `image/x-ms-bmp` |
+| TIFF | `49 49 2A 00` or `4D 4D 00 2A` | `.tif`, `.tiff` | `image/tiff` |
+
+## Functional Units
+
+### 1. Signature Validator
+
+- `UploadedImageMagicNumberValidator` detects the actual image format from bytes.
+- It compares detected format against `UploadSessionFile.originalFileName`.
+- It compares detected format against `UploadSessionFile.contentType`.
+- It throws `InvalidUploadFileException` when the signature is unsupported or mismatched.
+
+### 2. Upload Complete Integration
+
+- `UploadCompleteService` still verifies object existence first.
+- After existence verification, it downloads object bytes.
+- The validator runs before `UploadSessionFile.markUploaded()`.
+- Invalid files prevent session completion and image row creation.
+
+### 3. Tests
+
+- Validator accepts PNG, JPEG, WEBP, BMP, and TIFF signatures.
+- Validator rejects extension mismatches.
+- Validator rejects content type mismatches.
+- Validator rejects unsupported/corrupted signatures.
+- Upload completion rejects invalid uploaded object bytes before image finalization.
+
+## Out Of Scope
+
+- Server-side ZIP extraction.
+- Width, height, and DPI extraction.
+- Full checksum recomputation.
+- Antivirus scanning.
+
+## Verification
+
+- Backend test/build passes.
+- `docs/api/upload-api.md` describes completion-time signature validation.
+- `docs/api/image-api.md` describes magic validation before image row creation.


### PR DESCRIPTION
## #️⃣ 기능 설명

Presigned URL 업로드 완료 단계에서 Object Storage에 저장된 원본 이미지 바이트를 검사해 확장자/Content-Type 위장 파일을 차단하도록 magic number 검증을 추가했습니다.

Closes #106

## 🛠️ 작업 상세 내용

- [x] `UploadedImageMagicNumberValidator` 추가
- [x] PNG/JPEG/WEBP/BMP/TIFF magic number 검증 지원
- [x] detected format과 파일명 확장자/Content-Type 불일치 시 완료 거부
- [x] `UploadCompleteService`에서 object existence 확인 후 signature 검증 수행
- [x] validator/service 테스트 추가
- [x] upload/image API 문서와 feature spec 갱신

## 📁 변경 파일 요약

- `backend-api/src/main/java/com/moonju/preprocess/api/domain/upload/service/UploadCompleteService.java`
- `backend-api/src/main/java/com/moonju/preprocess/api/domain/upload/service/UploadedImageMagicNumberValidator.java`
- `backend-api/src/test/java/com/moonju/preprocess/api/domain/upload/service/UploadCompleteServiceTests.java`
- `backend-api/src/test/java/com/moonju/preprocess/api/domain/upload/service/UploadedImageMagicNumberValidatorTests.java`
- `docs/api/upload-api.md`
- `docs/api/image-api.md`
- `docs/feature-specs/issue-106-upload-magic-number-validation.md`

## ✅ 검증 내용

- [x] `docker run --rm -v "${pwdPath}:/workspace" -w /workspace gradle:8.10-jdk21 gradle test build --no-daemon`: 통과
- [x] `git diff --check`: 통과
- [ ] Swagger 확인: API contract shape 변경이 아닌 completion validation 강화라 Docker 기반 test/build로 대체했습니다.

## 🔎 리뷰어가 확인해야 할 부분

- complete 단계에서 object bytes 전체를 다운로드해 검증하는 방식이 현재 100MB per-file 제한 기준으로 적절한지 확인해주세요.
- signature mismatch 시 `InvalidUploadFileException`으로 completion을 거부하는 정책이 적절한지 확인해주세요.
- ZIP 내부 이미지는 프론트에서 개별 이미지로 확장된 뒤 동일 검증을 통과하는 정책이 맞는지 확인해주세요.

## 📸 스크린샷

- Backend validation PR이라 스크린샷은 없습니다.

## 💬 기타 공유사항 to 리뷰어

- 전체 checksum 재계산과 이미지 width/height/DPI 추출은 별도 후속 작업으로 남겼습니다.