### PR TITLE
✨ [Feat] 업로드 이미지 메타데이터 추출 추가

### DIFF
--- a/backend-api/src/main/java/com/moonju/preprocess/api/domain/image/entity/Image.java
+++ b/backend-api/src/main/java/com/moonju/preprocess/api/domain/image/entity/Image.java
@@ -1,5 +1,6 @@
 package com.moonju.preprocess.api.domain.image.entity;
 
+import com.moonju.preprocess.api.domain.image.model.ImageMetadata;
 import com.moonju.preprocess.api.domain.upload.entity.UploadSession;
 import com.moonju.preprocess.api.domain.upload.entity.UploadSessionFile;
 import com.moonju.preprocess.api.global.support.BaseEntity;
@@ -96,7 +97,11 @@ public class Image extends BaseEntity {
     }
 
     public static Image fromUpload(UploadSession uploadSession, UploadSessionFile file) {
-        return new Image(
+        return fromUpload(uploadSession, file, ImageMetadata.empty());
+    }
+
+    public static Image fromUpload(UploadSession uploadSession, UploadSessionFile file, ImageMetadata metadata) {
+        Image image = new Image(
             uploadSession.getProjectId(),
             uploadSession.getId(),
             file.getId(),
@@ -109,6 +114,18 @@ public class Image extends BaseEntity {
             ImageFormat.fromFileName(file.getOriginalFileName()),
             ImageStatus.UPLOADED
         );
+        image.applyMetadata(metadata);
+        return image;
+    }
+
+    public void applyMetadata(ImageMetadata metadata) {
+        if (metadata == null) {
+            return;
+        }
+        width = metadata.width();
+        height = metadata.height();
+        dpiX = metadata.dpiX();
+        dpiY = metadata.dpiY();
     }
 
     public void delete() {

--- a/backend-api/src/main/java/com/moonju/preprocess/api/domain/image/model/ImageMetadata.java
+++ b/backend-api/src/main/java/com/moonju/preprocess/api/domain/image/model/ImageMetadata.java
@@ -1,0 +1,13 @@
+package com.moonju.preprocess.api.domain.image.model;
+
+public record ImageMetadata(
+    Integer width,
+    Integer height,
+    Integer dpiX,
+    Integer dpiY
+) {
+
+    public static ImageMetadata empty() {
+        return new ImageMetadata(null, null, null, null);
+    }
+}

--- a/backend-api/src/main/java/com/moonju/preprocess/api/domain/image/service/ImageCreateService.java
+++ b/backend-api/src/main/java/com/moonju/preprocess/api/domain/image/service/ImageCreateService.java
@@ -2,12 +2,14 @@ package com.moonju.preprocess.api.domain.image.service;
 
 import com.moonju.preprocess.api.domain.image.entity.Image;
 import com.moonju.preprocess.api.domain.image.entity.ImageArtifact;
+import com.moonju.preprocess.api.domain.image.model.ImageMetadata;
 import com.moonju.preprocess.api.domain.image.repository.ImageArtifactRepository;
 import com.moonju.preprocess.api.domain.image.repository.ImageRepository;
 import com.moonju.preprocess.api.domain.upload.entity.UploadSession;
 import com.moonju.preprocess.api.domain.upload.entity.UploadSessionFile;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -27,12 +29,22 @@ public class ImageCreateService {
 
     @Transactional
     public List<Image> createFromCompletedUpload(UploadSession uploadSession, List<UploadSessionFile> files) {
+        return createFromCompletedUpload(uploadSession, files, Map.of());
+    }
+
+    @Transactional
+    public List<Image> createFromCompletedUpload(
+        UploadSession uploadSession,
+        List<UploadSessionFile> files,
+        Map<Long, ImageMetadata> metadataByUploadFileId
+    ) {
         List<Image> createdImages = new ArrayList<>();
         for (UploadSessionFile file : files) {
             if (imageRepository.existsByUploadSessionFileId(file.getId())) {
                 continue;
             }
-            Image image = imageRepository.save(Image.fromUpload(uploadSession, file));
+            ImageMetadata metadata = metadataByUploadFileId.getOrDefault(file.getId(), ImageMetadata.empty());
+            Image image = imageRepository.save(Image.fromUpload(uploadSession, file, metadata));
             imageArtifactRepository.save(ImageArtifact.original(image));
             createdImages.add(image);
         }

--- a/backend-api/src/main/java/com/moonju/preprocess/api/domain/image/service/ImageMetadataExtractor.java
+++ b/backend-api/src/main/java/com/moonju/preprocess/api/domain/image/service/ImageMetadataExtractor.java
@@ -1,0 +1,312 @@
+package com.moonju.preprocess.api.domain.image.service;
+
+import com.moonju.preprocess.api.domain.image.model.ImageMetadata;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ImageMetadataExtractor {
+
+    private static final byte[] PNG_SIGNATURE = {
+        (byte) 0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A
+    };
+
+    public ImageMetadata extract(byte[] bytes) {
+        try {
+            if (startsWith(bytes, PNG_SIGNATURE)) {
+                return extractPng(bytes);
+            }
+            if (isJpeg(bytes)) {
+                return extractJpeg(bytes);
+            }
+            if (isWebp(bytes)) {
+                return extractWebp(bytes);
+            }
+            if (isBmp(bytes)) {
+                return extractBmp(bytes);
+            }
+            if (isTiff(bytes)) {
+                return extractTiff(bytes);
+            }
+        } catch (RuntimeException exception) {
+            return ImageMetadata.empty();
+        }
+        return ImageMetadata.empty();
+    }
+
+    private ImageMetadata extractPng(byte[] bytes) {
+        Integer width = null;
+        Integer height = null;
+        Integer dpiX = null;
+        Integer dpiY = null;
+        int offset = 8;
+        while (offset + 12 <= bytes.length) {
+            int length = readIntBigEndian(bytes, offset);
+            String type = ascii(bytes, offset + 4, 4);
+            int dataOffset = offset + 8;
+            if (dataOffset + length > bytes.length) {
+                break;
+            }
+            if ("IHDR".equals(type) && length >= 8) {
+                width = readIntBigEndian(bytes, dataOffset);
+                height = readIntBigEndian(bytes, dataOffset + 4);
+            }
+            if ("pHYs".equals(type) && length >= 9 && bytes[dataOffset + 8] == 1) {
+                dpiX = pixelsPerMeterToDpi(readIntBigEndian(bytes, dataOffset));
+                dpiY = pixelsPerMeterToDpi(readIntBigEndian(bytes, dataOffset + 4));
+            }
+            offset = dataOffset + length + 4;
+        }
+        return new ImageMetadata(width, height, dpiX, dpiY);
+    }
+
+    private ImageMetadata extractJpeg(byte[] bytes) {
+        Integer width = null;
+        Integer height = null;
+        Integer dpiX = null;
+        Integer dpiY = null;
+        int offset = 2;
+        while (offset + 4 <= bytes.length) {
+            if (unsigned(bytes[offset]) != 0xFF) {
+                offset++;
+                continue;
+            }
+            int marker = unsigned(bytes[offset + 1]);
+            offset += 2;
+            if (marker == 0xD9 || marker == 0xDA) {
+                break;
+            }
+            if (offset + 2 > bytes.length) {
+                break;
+            }
+            int length = readUnsignedShortBigEndian(bytes, offset);
+            if (length < 2 || offset + length > bytes.length) {
+                break;
+            }
+            int dataOffset = offset + 2;
+            if (marker == 0xE0 && length >= 16 && asciiEquals(bytes, dataOffset, "JFIF")) {
+                int unit = unsigned(bytes[dataOffset + 7]);
+                int xDensity = readUnsignedShortBigEndian(bytes, dataOffset + 8);
+                int yDensity = readUnsignedShortBigEndian(bytes, dataOffset + 10);
+                if (unit == 1) {
+                    dpiX = xDensity;
+                    dpiY = yDensity;
+                } else if (unit == 2) {
+                    dpiX = dotsPerCentimeterToDpi(xDensity);
+                    dpiY = dotsPerCentimeterToDpi(yDensity);
+                }
+            }
+            if (isStartOfFrame(marker) && length >= 7) {
+                height = readUnsignedShortBigEndian(bytes, dataOffset + 1);
+                width = readUnsignedShortBigEndian(bytes, dataOffset + 3);
+            }
+            offset += length;
+        }
+        return new ImageMetadata(width, height, dpiX, dpiY);
+    }
+
+    private ImageMetadata extractWebp(byte[] bytes) {
+        String chunk = ascii(bytes, 12, 4);
+        if ("VP8X".equals(chunk) && bytes.length >= 30) {
+            int width = 1 + readUnsigned24LittleEndian(bytes, 24);
+            int height = 1 + readUnsigned24LittleEndian(bytes, 27);
+            return new ImageMetadata(width, height, null, null);
+        }
+        if ("VP8L".equals(chunk) && bytes.length >= 25 && unsigned(bytes[20]) == 0x2F) {
+            int b1 = unsigned(bytes[21]);
+            int b2 = unsigned(bytes[22]);
+            int b3 = unsigned(bytes[23]);
+            int b4 = unsigned(bytes[24]);
+            int width = 1 + (((b2 & 0x3F) << 8) | b1);
+            int height = 1 + (((b4 & 0x0F) << 10) | (b3 << 2) | ((b2 & 0xC0) >> 6));
+            return new ImageMetadata(width, height, null, null);
+        }
+        if ("VP8 ".equals(chunk) && bytes.length >= 30 && unsigned(bytes[23]) == 0x9D
+            && unsigned(bytes[24]) == 0x01 && unsigned(bytes[25]) == 0x2A) {
+            int width = readUnsignedShortLittleEndian(bytes, 26) & 0x3FFF;
+            int height = readUnsignedShortLittleEndian(bytes, 28) & 0x3FFF;
+            return new ImageMetadata(width, height, null, null);
+        }
+        return ImageMetadata.empty();
+    }
+
+    private ImageMetadata extractBmp(byte[] bytes) {
+        if (bytes.length < 26) {
+            return ImageMetadata.empty();
+        }
+        int width = readIntLittleEndian(bytes, 18);
+        int height = Math.abs(readIntLittleEndian(bytes, 22));
+        return new ImageMetadata(width, height, null, null);
+    }
+
+    private ImageMetadata extractTiff(byte[] bytes) {
+        ByteOrder byteOrder = tiffByteOrder(bytes);
+        long ifdOffset = readUnsignedInt(bytes, 4, byteOrder);
+        if (ifdOffset < 0 || ifdOffset + 2 > bytes.length) {
+            return ImageMetadata.empty();
+        }
+        int entryCount = readUnsignedShort(bytes, (int) ifdOffset, byteOrder);
+        int offset = (int) ifdOffset + 2;
+        Integer width = null;
+        Integer height = null;
+        Long xResolutionOffset = null;
+        Long yResolutionOffset = null;
+        Integer resolutionUnit = 2;
+
+        for (int index = 0; index < entryCount && offset + 12 <= bytes.length; index++) {
+            int tag = readUnsignedShort(bytes, offset, byteOrder);
+            int type = readUnsignedShort(bytes, offset + 2, byteOrder);
+            long count = readUnsignedInt(bytes, offset + 4, byteOrder);
+            int valueOffset = offset + 8;
+            if (count == 1 && tag == 256) {
+                width = readTiffScalar(bytes, valueOffset, type, byteOrder);
+            } else if (count == 1 && tag == 257) {
+                height = readTiffScalar(bytes, valueOffset, type, byteOrder);
+            } else if (count == 1 && tag == 282) {
+                xResolutionOffset = readUnsignedInt(bytes, valueOffset, byteOrder);
+            } else if (count == 1 && tag == 283) {
+                yResolutionOffset = readUnsignedInt(bytes, valueOffset, byteOrder);
+            } else if (count == 1 && tag == 296) {
+                resolutionUnit = readTiffScalar(bytes, valueOffset, type, byteOrder);
+            }
+            offset += 12;
+        }
+
+        Integer dpiX = readTiffDpi(bytes, xResolutionOffset, resolutionUnit, byteOrder);
+        Integer dpiY = readTiffDpi(bytes, yResolutionOffset, resolutionUnit, byteOrder);
+        return new ImageMetadata(width, height, dpiX, dpiY);
+    }
+
+    private Integer readTiffScalar(byte[] bytes, int offset, int type, ByteOrder byteOrder) {
+        if (type == 3) {
+            return readUnsignedShort(bytes, offset, byteOrder);
+        }
+        if (type == 4) {
+            return Math.toIntExact(readUnsignedInt(bytes, offset, byteOrder));
+        }
+        return null;
+    }
+
+    private Integer readTiffDpi(byte[] bytes, Long offset, Integer resolutionUnit, ByteOrder byteOrder) {
+        if (offset == null || offset + 8 > bytes.length) {
+            return null;
+        }
+        long numerator = readUnsignedInt(bytes, offset.intValue(), byteOrder);
+        long denominator = readUnsignedInt(bytes, offset.intValue() + 4, byteOrder);
+        if (denominator == 0) {
+            return null;
+        }
+        double value = (double) numerator / denominator;
+        if (resolutionUnit != null && resolutionUnit == 3) {
+            value *= 2.54;
+        }
+        return (int) Math.round(value);
+    }
+
+    private boolean isStartOfFrame(int marker) {
+        return marker == 0xC0 || marker == 0xC1 || marker == 0xC2 || marker == 0xC3
+            || marker == 0xC5 || marker == 0xC6 || marker == 0xC7
+            || marker == 0xC9 || marker == 0xCA || marker == 0xCB
+            || marker == 0xCD || marker == 0xCE || marker == 0xCF;
+    }
+
+    private boolean isJpeg(byte[] bytes) {
+        return bytes.length >= 3
+            && unsigned(bytes[0]) == 0xFF
+            && unsigned(bytes[1]) == 0xD8
+            && unsigned(bytes[2]) == 0xFF;
+    }
+
+    private boolean isWebp(byte[] bytes) {
+        return bytes.length >= 12 && asciiEquals(bytes, 0, "RIFF") && asciiEquals(bytes, 8, "WEBP");
+    }
+
+    private boolean isBmp(byte[] bytes) {
+        return bytes.length >= 2 && bytes[0] == 0x42 && bytes[1] == 0x4D;
+    }
+
+    private boolean isTiff(byte[] bytes) {
+        return bytes.length >= 4
+            && ((bytes[0] == 0x49 && bytes[1] == 0x49 && bytes[2] == 0x2A && bytes[3] == 0x00)
+            || (bytes[0] == 0x4D && bytes[1] == 0x4D && bytes[2] == 0x00 && bytes[3] == 0x2A));
+    }
+
+    private ByteOrder tiffByteOrder(byte[] bytes) {
+        if (bytes[0] == 0x49 && bytes[1] == 0x49) {
+            return ByteOrder.LITTLE_ENDIAN;
+        }
+        return ByteOrder.BIG_ENDIAN;
+    }
+
+    private boolean startsWith(byte[] bytes, byte[] signature) {
+        if (bytes.length < signature.length) {
+            return false;
+        }
+        for (int index = 0; index < signature.length; index++) {
+            if (bytes[index] != signature[index]) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private boolean asciiEquals(byte[] bytes, int offset, String expected) {
+        if (bytes.length < offset + expected.length()) {
+            return false;
+        }
+        for (int index = 0; index < expected.length(); index++) {
+            if (bytes[offset + index] != (byte) expected.charAt(index)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private String ascii(byte[] bytes, int offset, int length) {
+        if (bytes.length < offset + length) {
+            return "";
+        }
+        return new String(bytes, offset, length, java.nio.charset.StandardCharsets.US_ASCII);
+    }
+
+    private int readIntBigEndian(byte[] bytes, int offset) {
+        return ByteBuffer.wrap(bytes, offset, 4).order(ByteOrder.BIG_ENDIAN).getInt();
+    }
+
+    private int readIntLittleEndian(byte[] bytes, int offset) {
+        return ByteBuffer.wrap(bytes, offset, 4).order(ByteOrder.LITTLE_ENDIAN).getInt();
+    }
+
+    private int readUnsignedShortBigEndian(byte[] bytes, int offset) {
+        return readUnsignedShort(bytes, offset, ByteOrder.BIG_ENDIAN);
+    }
+
+    private int readUnsignedShortLittleEndian(byte[] bytes, int offset) {
+        return readUnsignedShort(bytes, offset, ByteOrder.LITTLE_ENDIAN);
+    }
+
+    private int readUnsignedShort(byte[] bytes, int offset, ByteOrder byteOrder) {
+        return Short.toUnsignedInt(ByteBuffer.wrap(bytes, offset, 2).order(byteOrder).getShort());
+    }
+
+    private long readUnsignedInt(byte[] bytes, int offset, ByteOrder byteOrder) {
+        return Integer.toUnsignedLong(ByteBuffer.wrap(bytes, offset, 4).order(byteOrder).getInt());
+    }
+
+    private int readUnsigned24LittleEndian(byte[] bytes, int offset) {
+        return unsigned(bytes[offset]) | (unsigned(bytes[offset + 1]) << 8) | (unsigned(bytes[offset + 2]) << 16);
+    }
+
+    private int pixelsPerMeterToDpi(int pixelsPerMeter) {
+        return (int) Math.round(pixelsPerMeter * 0.0254);
+    }
+
+    private int dotsPerCentimeterToDpi(int dotsPerCentimeter) {
+        return (int) Math.round(dotsPerCentimeter * 2.54);
+    }
+
+    private int unsigned(byte value) {
+        return value & 0xFF;
+    }
+}

--- a/backend-api/src/main/java/com/moonju/preprocess/api/domain/upload/service/UploadCompleteService.java
+++ b/backend-api/src/main/java/com/moonju/preprocess/api/domain/upload/service/UploadCompleteService.java
@@ -1,6 +1,8 @@
 package com.moonju.preprocess.api.domain.upload.service;
 
 import com.moonju.preprocess.api.domain.image.service.ImageCreateService;
+import com.moonju.preprocess.api.domain.image.model.ImageMetadata;
+import com.moonju.preprocess.api.domain.image.service.ImageMetadataExtractor;
 import com.moonju.preprocess.api.domain.project.service.ProjectPermissionService;
 import com.moonju.preprocess.api.domain.upload.dto.UploadCompleteRequest;
 import com.moonju.preprocess.api.domain.upload.dto.UploadCompleteResponse;
@@ -9,8 +11,10 @@ import com.moonju.preprocess.api.domain.upload.entity.UploadSessionFile;
 import com.moonju.preprocess.api.domain.upload.exception.UploadNotCompletedException;
 import com.moonju.preprocess.api.domain.upload.repository.UploadSessionFileRepository;
 import com.moonju.preprocess.api.infra.storage.ObjectStoragePort;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -24,6 +28,7 @@ public class UploadCompleteService {
     private final ObjectStoragePort objectStoragePort;
     private final ImageCreateService imageCreateService;
     private final UploadedImageMagicNumberValidator magicNumberValidator;
+    private final ImageMetadataExtractor imageMetadataExtractor;
 
     public UploadCompleteService(
         UploadSessionService uploadSessionService,
@@ -31,7 +36,8 @@ public class UploadCompleteService {
         ProjectPermissionService projectPermissionService,
         ObjectStoragePort objectStoragePort,
         ImageCreateService imageCreateService,
-        UploadedImageMagicNumberValidator magicNumberValidator
+        UploadedImageMagicNumberValidator magicNumberValidator,
+        ImageMetadataExtractor imageMetadataExtractor
     ) {
         this.uploadSessionService = uploadSessionService;
         this.uploadSessionFileRepository = uploadSessionFileRepository;
@@ -39,6 +45,7 @@ public class UploadCompleteService {
         this.objectStoragePort = objectStoragePort;
         this.imageCreateService = imageCreateService;
         this.magicNumberValidator = magicNumberValidator;
+        this.imageMetadataExtractor = imageMetadataExtractor;
     }
 
     @Transactional
@@ -52,9 +59,10 @@ public class UploadCompleteService {
         );
         validateCompletion(uploadSession, request.uploadFileIds(), files);
 
-        files.forEach(this::verifyAndMarkUploaded);
+        Map<Long, ImageMetadata> metadataByUploadFileId = new HashMap<>();
+        files.forEach(file -> metadataByUploadFileId.put(file.getId(), verifyAndMarkUploaded(file)));
         uploadSession.complete();
-        imageCreateService.createFromCompletedUpload(uploadSession, files);
+        imageCreateService.createFromCompletedUpload(uploadSession, files, metadataByUploadFileId);
         return UploadCompleteResponse.of(uploadSession, files.size());
     }
 
@@ -75,11 +83,14 @@ public class UploadCompleteService {
         }
     }
 
-    private void verifyAndMarkUploaded(UploadSessionFile file) {
+    private ImageMetadata verifyAndMarkUploaded(UploadSessionFile file) {
         if (!objectStoragePort.exists(file.getObjectKey())) {
             throw new UploadNotCompletedException("Uploaded object does not exist: " + file.getObjectKey());
         }
-        magicNumberValidator.validate(file, objectStoragePort.downloadBytes(file.getObjectKey()));
+        byte[] bytes = objectStoragePort.downloadBytes(file.getObjectKey());
+        magicNumberValidator.validate(file, bytes);
+        ImageMetadata metadata = imageMetadataExtractor.extract(bytes);
         file.markUploaded();
+        return metadata;
     }
 }

--- a/backend-api/src/test/java/com/moonju/preprocess/api/domain/image/entity/ImageTests.java
+++ b/backend-api/src/test/java/com/moonju/preprocess/api/domain/image/entity/ImageTests.java
@@ -2,6 +2,7 @@ package com.moonju.preprocess.api.domain.image.entity;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.moonju.preprocess.api.domain.image.model.ImageMetadata;
 import com.moonju.preprocess.api.domain.upload.entity.UploadSession;
 import com.moonju.preprocess.api.domain.upload.entity.UploadSessionFile;
 import org.junit.jupiter.api.Test;
@@ -24,7 +25,7 @@ class ImageTests {
         );
         ReflectionTestUtils.setField(file, "id", 100L);
 
-        Image image = Image.fromUpload(uploadSession, file);
+        Image image = Image.fromUpload(uploadSession, file, new ImageMetadata(1240, 1754, 300, 300));
 
         assertThat(image.getProjectId()).isEqualTo(10L);
         assertThat(image.getUploadSessionId()).isEqualTo(1L);
@@ -32,6 +33,10 @@ class ImageTests {
         assertThat(image.getUploaderId()).isEqualTo(20L);
         assertThat(image.getFormat()).isEqualTo(ImageFormat.PNG);
         assertThat(image.getStatus()).isEqualTo(ImageStatus.UPLOADED);
+        assertThat(image.getWidth()).isEqualTo(1240);
+        assertThat(image.getHeight()).isEqualTo(1754);
+        assertThat(image.getDpiX()).isEqualTo(300);
+        assertThat(image.getDpiY()).isEqualTo(300);
     }
 
     @Test

--- a/backend-api/src/test/java/com/moonju/preprocess/api/domain/image/service/ImageCreateServiceTests.java
+++ b/backend-api/src/test/java/com/moonju/preprocess/api/domain/image/service/ImageCreateServiceTests.java
@@ -9,11 +9,13 @@ import static org.mockito.Mockito.when;
 import com.moonju.preprocess.api.domain.image.entity.Image;
 import com.moonju.preprocess.api.domain.image.entity.ImageArtifact;
 import com.moonju.preprocess.api.domain.image.entity.ImageArtifactType;
+import com.moonju.preprocess.api.domain.image.model.ImageMetadata;
 import com.moonju.preprocess.api.domain.image.repository.ImageArtifactRepository;
 import com.moonju.preprocess.api.domain.image.repository.ImageRepository;
 import com.moonju.preprocess.api.domain.upload.entity.UploadSession;
 import com.moonju.preprocess.api.domain.upload.entity.UploadSessionFile;
 import java.util.List;
+import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
@@ -38,6 +40,7 @@ class ImageCreateServiceTests {
     void createsImageAndOriginalArtifactFromCompletedUpload() {
         UploadSession uploadSession = uploadSession();
         UploadSessionFile file = uploadSessionFile(100L);
+        ImageMetadata metadata = new ImageMetadata(1240, 1754, 300, 300);
         when(imageRepository.existsByUploadSessionFileId(100L)).thenReturn(false);
         when(imageRepository.save(any(Image.class))).thenAnswer(invocation -> {
             Image image = invocation.getArgument(0);
@@ -45,10 +48,14 @@ class ImageCreateServiceTests {
             return image;
         });
 
-        List<Image> images = service.createFromCompletedUpload(uploadSession, List.of(file));
+        List<Image> images = service.createFromCompletedUpload(uploadSession, List.of(file), Map.of(100L, metadata));
 
         assertThat(images).hasSize(1);
         assertThat(images.getFirst().getUploadSessionFileId()).isEqualTo(100L);
+        assertThat(images.getFirst().getWidth()).isEqualTo(1240);
+        assertThat(images.getFirst().getHeight()).isEqualTo(1754);
+        assertThat(images.getFirst().getDpiX()).isEqualTo(300);
+        assertThat(images.getFirst().getDpiY()).isEqualTo(300);
         ArgumentCaptor<ImageArtifact> artifactCaptor = ArgumentCaptor.forClass(ImageArtifact.class);
         verify(imageArtifactRepository).save(artifactCaptor.capture());
         assertThat(artifactCaptor.getValue().getImageId()).isEqualTo(200L);

--- a/backend-api/src/test/java/com/moonju/preprocess/api/domain/image/service/ImageMetadataExtractorTests.java
+++ b/backend-api/src/test/java/com/moonju/preprocess/api/domain/image/service/ImageMetadataExtractorTests.java
@@ -1,0 +1,160 @@
+package com.moonju.preprocess.api.domain.image.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.moonju.preprocess.api.domain.image.model.ImageMetadata;
+import java.nio.charset.StandardCharsets;
+import org.junit.jupiter.api.Test;
+
+class ImageMetadataExtractorTests {
+
+    private final ImageMetadataExtractor extractor = new ImageMetadataExtractor();
+
+    @Test
+    void extractsPngDimensionsAndDpi() {
+        ImageMetadata metadata = extractor.extract(pngBytes(1240, 1754, 300));
+
+        assertThat(metadata.width()).isEqualTo(1240);
+        assertThat(metadata.height()).isEqualTo(1754);
+        assertThat(metadata.dpiX()).isEqualTo(300);
+        assertThat(metadata.dpiY()).isEqualTo(300);
+    }
+
+    @Test
+    void extractsJpegDimensionsAndDpi() {
+        ImageMetadata metadata = extractor.extract(jpegBytes(1240, 1754, 300));
+
+        assertThat(metadata.width()).isEqualTo(1240);
+        assertThat(metadata.height()).isEqualTo(1754);
+        assertThat(metadata.dpiX()).isEqualTo(300);
+        assertThat(metadata.dpiY()).isEqualTo(300);
+    }
+
+    @Test
+    void extractsWebpVp8xDimensions() {
+        ImageMetadata metadata = extractor.extract(webpVp8xBytes(640, 480));
+
+        assertThat(metadata.width()).isEqualTo(640);
+        assertThat(metadata.height()).isEqualTo(480);
+        assertThat(metadata.dpiX()).isNull();
+        assertThat(metadata.dpiY()).isNull();
+    }
+
+    @Test
+    void extractsBmpDimensions() {
+        ImageMetadata metadata = extractor.extract(bmpBytes(1024, 768));
+
+        assertThat(metadata.width()).isEqualTo(1024);
+        assertThat(metadata.height()).isEqualTo(768);
+        assertThat(metadata.dpiX()).isNull();
+        assertThat(metadata.dpiY()).isNull();
+    }
+
+    @Test
+    void returnsEmptyMetadataForUnsupportedBytes() {
+        ImageMetadata metadata = extractor.extract("not-an-image".getBytes(StandardCharsets.UTF_8));
+
+        assertThat(metadata.width()).isNull();
+        assertThat(metadata.height()).isNull();
+        assertThat(metadata.dpiX()).isNull();
+        assertThat(metadata.dpiY()).isNull();
+    }
+
+    private byte[] pngBytes(int width, int height, int dpi) {
+        byte[] bytes = new byte[54];
+        byte[] signature = {
+            (byte) 0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A
+        };
+        System.arraycopy(signature, 0, bytes, 0, signature.length);
+        putIntBigEndian(bytes, 8, 13);
+        putAscii(bytes, 12, "IHDR");
+        putIntBigEndian(bytes, 16, width);
+        putIntBigEndian(bytes, 20, height);
+        bytes[24] = 8;
+        bytes[25] = 2;
+
+        putIntBigEndian(bytes, 33, 9);
+        putAscii(bytes, 37, "pHYs");
+        int pixelsPerMeter = Math.round(dpi / 0.0254F);
+        putIntBigEndian(bytes, 41, pixelsPerMeter);
+        putIntBigEndian(bytes, 45, pixelsPerMeter);
+        bytes[49] = 1;
+        return bytes;
+    }
+
+    private byte[] jpegBytes(int width, int height, int dpi) {
+        byte[] bytes = new byte[41];
+        bytes[0] = (byte) 0xFF;
+        bytes[1] = (byte) 0xD8;
+
+        bytes[2] = (byte) 0xFF;
+        bytes[3] = (byte) 0xE0;
+        putShortBigEndian(bytes, 4, 16);
+        putAscii(bytes, 6, "JFIF");
+        bytes[10] = 0;
+        bytes[11] = 1;
+        bytes[12] = 1;
+        bytes[13] = 1;
+        putShortBigEndian(bytes, 14, dpi);
+        putShortBigEndian(bytes, 16, dpi);
+
+        bytes[20] = (byte) 0xFF;
+        bytes[21] = (byte) 0xC0;
+        putShortBigEndian(bytes, 22, 17);
+        bytes[24] = 8;
+        putShortBigEndian(bytes, 25, height);
+        putShortBigEndian(bytes, 27, width);
+        bytes[29] = 3;
+        return bytes;
+    }
+
+    private byte[] webpVp8xBytes(int width, int height) {
+        byte[] bytes = new byte[30];
+        putAscii(bytes, 0, "RIFF");
+        putAscii(bytes, 8, "WEBP");
+        putAscii(bytes, 12, "VP8X");
+        putIntLittleEndian(bytes, 16, 10);
+        putUnsigned24LittleEndian(bytes, 24, width - 1);
+        putUnsigned24LittleEndian(bytes, 27, height - 1);
+        return bytes;
+    }
+
+    private byte[] bmpBytes(int width, int height) {
+        byte[] bytes = new byte[26];
+        bytes[0] = 0x42;
+        bytes[1] = 0x4D;
+        putIntLittleEndian(bytes, 18, width);
+        putIntLittleEndian(bytes, 22, height);
+        return bytes;
+    }
+
+    private void putAscii(byte[] bytes, int offset, String value) {
+        byte[] ascii = value.getBytes(StandardCharsets.US_ASCII);
+        System.arraycopy(ascii, 0, bytes, offset, ascii.length);
+    }
+
+    private void putShortBigEndian(byte[] bytes, int offset, int value) {
+        bytes[offset] = (byte) ((value >>> 8) & 0xFF);
+        bytes[offset + 1] = (byte) (value & 0xFF);
+    }
+
+    private void putIntBigEndian(byte[] bytes, int offset, int value) {
+        bytes[offset] = (byte) ((value >>> 24) & 0xFF);
+        bytes[offset + 1] = (byte) ((value >>> 16) & 0xFF);
+        bytes[offset + 2] = (byte) ((value >>> 8) & 0xFF);
+        bytes[offset + 3] = (byte) (value & 0xFF);
+    }
+
+    private void putIntLittleEndian(byte[] bytes, int offset, int value) {
+        bytes[offset] = (byte) (value & 0xFF);
+        bytes[offset + 1] = (byte) ((value >>> 8) & 0xFF);
+        bytes[offset + 2] = (byte) ((value >>> 16) & 0xFF);
+        bytes[offset + 3] = (byte) ((value >>> 24) & 0xFF);
+    }
+
+    private void putUnsigned24LittleEndian(byte[] bytes, int offset, int value) {
+        bytes[offset] = (byte) (value & 0xFF);
+        bytes[offset + 1] = (byte) ((value >>> 8) & 0xFF);
+        bytes[offset + 2] = (byte) ((value >>> 16) & 0xFF);
+    }
+}

--- a/backend-api/src/test/java/com/moonju/preprocess/api/domain/upload/service/UploadCompleteServiceTests.java
+++ b/backend-api/src/test/java/com/moonju/preprocess/api/domain/upload/service/UploadCompleteServiceTests.java
@@ -6,9 +6,12 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
+import com.moonju.preprocess.api.domain.image.model.ImageMetadata;
 import com.moonju.preprocess.api.domain.image.service.ImageCreateService;
+import com.moonju.preprocess.api.domain.image.service.ImageMetadataExtractor;
 import com.moonju.preprocess.api.domain.project.service.ProjectPermissionService;
 import com.moonju.preprocess.api.domain.upload.dto.UploadCompleteRequest;
 import com.moonju.preprocess.api.domain.upload.dto.UploadCompleteResponse;
@@ -21,6 +24,7 @@ import com.moonju.preprocess.api.domain.upload.exception.UploadNotCompletedExcep
 import com.moonju.preprocess.api.domain.upload.repository.UploadSessionFileRepository;
 import com.moonju.preprocess.api.infra.storage.ObjectStoragePort;
 import java.util.List;
+import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -49,6 +53,9 @@ class UploadCompleteServiceTests {
     @Mock
     private UploadedImageMagicNumberValidator magicNumberValidator;
 
+    @Mock
+    private ImageMetadataExtractor imageMetadataExtractor;
+
     @InjectMocks
     private UploadCompleteService service;
 
@@ -57,12 +64,14 @@ class UploadCompleteServiceTests {
         UploadSession uploadSession = uploadSession(1L, 10L, 20L, 1, 4096L);
         UploadSessionFile file = uploadSessionFile(100L, 1L, 10L, "originals/10/1/file/scan_001.png");
         byte[] validBytes = pngBytes();
+        ImageMetadata metadata = new ImageMetadata(1240, 1754, 300, 300);
 
         when(uploadSessionService.findOpenSession(1L)).thenReturn(uploadSession);
         when(projectPermissionService.validateEditable(10L, 20L)).thenReturn(null);
         when(uploadSessionFileRepository.findByUploadSessionIdAndIdIn(1L, List.of(100L))).thenReturn(List.of(file));
         when(objectStoragePort.exists(file.getObjectKey())).thenReturn(true);
         when(objectStoragePort.downloadBytes(file.getObjectKey())).thenReturn(validBytes);
+        when(imageMetadataExtractor.extract(validBytes)).thenReturn(metadata);
 
         UploadCompleteResponse response = service.complete(20L, 1L, new UploadCompleteRequest(List.of(100L)));
 
@@ -72,7 +81,8 @@ class UploadCompleteServiceTests {
         assertThat(uploadSession.getStatus()).isEqualTo(UploadSessionStatus.COMPLETED);
         assertThat(file.getStatus()).isEqualTo(UploadFileStatus.UPLOADED);
         verify(magicNumberValidator).validate(file, validBytes);
-        verify(imageCreateService).createFromCompletedUpload(uploadSession, List.of(file));
+        verify(imageMetadataExtractor).extract(validBytes);
+        verify(imageCreateService).createFromCompletedUpload(uploadSession, List.of(file), Map.of(100L, metadata));
     }
 
     @Test
@@ -89,6 +99,7 @@ class UploadCompleteServiceTests {
             .isInstanceOf(UploadNotCompletedException.class)
             .hasMessage("Uploaded object does not exist: originals/10/1/file/scan_001.png");
         verify(magicNumberValidator, never()).validate(any(UploadSessionFile.class), any(byte[].class));
+        verifyNoInteractions(imageMetadataExtractor, imageCreateService);
     }
 
     @Test
@@ -109,7 +120,7 @@ class UploadCompleteServiceTests {
         assertThatThrownBy(() -> service.complete(20L, 1L, new UploadCompleteRequest(List.of(100L))))
             .isInstanceOf(InvalidUploadFileException.class)
             .hasMessage("Unsupported or corrupted image signature.");
-        verify(imageCreateService, never()).createFromCompletedUpload(uploadSession, List.of(file));
+        verifyNoInteractions(imageMetadataExtractor, imageCreateService);
     }
 
     private UploadSession uploadSession(

--- a/docs/api/image-api.md
+++ b/docs/api/image-api.md
@@ -13,6 +13,7 @@ soft delete, original/processed/preview download URLs, processing report lookup,
 - Original files and preprocessing artifacts are stored separately as `ImageArtifact` rows.
 - Access is controlled by project membership through `ProjectPermissionService`.
 - Deleting an image is a soft delete and does not immediately remove Object Storage objects.
+- Upload completion extracts original width, height, and DPI when the source format exposes those values.
 
 ## Endpoints
 
@@ -80,14 +81,17 @@ Response:
     "checksumSha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
     "format": "PNG",
     "status": "UPLOADED",
-    "width": null,
-    "height": null,
-    "dpiX": null,
-    "dpiY": null,
+    "width": 1240,
+    "height": 1754,
+    "dpiX": 300,
+    "dpiY": 300,
     "createdAt": "2026-05-09T21:00:00"
   }
 }
 ```
+
+Metadata values may be `null` when the uploaded file does not expose reliable dimensions or DPI in the supported
+header fields. The API treats metadata extraction failure as non-fatal after the magic number validation succeeds.
 
 ## Download URL
 
@@ -135,10 +139,11 @@ When `POST /api/v1/upload-sessions/{sessionId}/complete` succeeds:
 1. API verifies the original objects exist.
 2. API downloads each original object and validates the image magic number.
 3. API rejects files whose byte signature does not match the declared extension or content type.
-4. API marks upload files as `UPLOADED`.
-5. API marks the upload session as `COMPLETED`.
-6. API creates one `Image` row per uploaded file.
-7. API creates one `ORIGINAL` `ImageArtifact` row per image.
+4. API extracts width, height, and optional DPI from PNG, JPEG, WEBP, BMP, or TIFF headers.
+5. API marks upload files as `UPLOADED`.
+6. API marks the upload session as `COMPLETED`.
+7. API creates one `Image` row per uploaded file with extracted metadata.
+8. API creates one `ORIGINAL` `ImageArtifact` row per image.
 
 The `Image` row is idempotent by `uploadSessionFileId`, so repeated internal finalization does not create duplicate
 images.
@@ -146,5 +151,4 @@ images.
 ## Next Work
 
 - Replace local download URL generator with a MinIO/S3 adapter.
-- Add metadata extraction for width, height, and DPI.
 - Add worker internal artifact registration for processed, preview, report, and debug files.

--- a/docs/api/upload-api.md
+++ b/docs/api/upload-api.md
@@ -12,6 +12,7 @@ then notify the API that the upload is complete.
 - Presigned upload URLs must include an expiration time.
 - Upload completion must verify object existence through `ObjectStoragePort`.
 - Upload completion must validate the stored object's image magic number against the declared file name and content type.
+- Upload completion extracts original image width, height, and optional DPI from supported image headers.
 - Image rows are not finalized before upload completion.
 - Upload session access is controlled by project membership, not only by the user who created the session.
 - Supported image extensions are `png`, `jpg`, `jpeg`, `tif`, `tiff`, `bmp`, and `webp`.
@@ -139,7 +140,8 @@ Completion verification:
 3. Each stored object is downloaded through `ObjectStoragePort`.
 4. The API validates the image magic number.
 5. The detected image type must match the original file extension and content type.
-6. Only then does the API mark files as uploaded and create finalized image rows.
+6. The API extracts width, height, and DPI metadata when available.
+7. Only then does the API mark files as uploaded and create finalized image rows.
 
 Supported signatures:
 

--- a/docs/feature-specs/issue-108-upload-image-metadata-extraction.md
+++ b/docs/feature-specs/issue-108-upload-image-metadata-extraction.md
@@ -1,0 +1,51 @@
+# Issue 108 - Upload Image Metadata Extraction
+
+## Purpose
+
+Upload completion should finalize `Image` rows with original image metadata, not only file name and object key fields.
+The metadata is used by project views, job preparation, and later worker output comparison.
+
+## Scope
+
+- Extract metadata from the same object bytes already downloaded during upload completion validation.
+- Persist width, height, `dpiX`, and `dpiY` into the `Image` entity.
+- Keep metadata extraction non-fatal after magic number validation succeeds.
+- Do not add OCR or preprocessing work to the API server.
+
+## Supported Formats
+
+| Format | Metadata |
+| --- | --- |
+| PNG | Width, height, DPI from `pHYs` when present |
+| JPEG | Width, height, DPI from JFIF APP0 when present |
+| WEBP | Width, height from VP8X, VP8L, or VP8 headers |
+| BMP | Width and height |
+| TIFF | Width, height, DPI from baseline IFD tags when present |
+
+## Upload Completion Flow
+
+1. Find the open upload session.
+2. Validate project edit permission.
+3. Verify requested upload file IDs match the session expectation.
+4. Verify each object exists in object storage.
+5. Download each object once.
+6. Validate the image magic number against file name and content type.
+7. Extract image metadata from the downloaded bytes.
+8. Mark upload files as `UPLOADED`.
+9. Mark the upload session as `COMPLETED`.
+10. Create one `Image` row per file with extracted metadata.
+11. Create one `ORIGINAL` artifact row per image.
+
+## Failure Policy
+
+- Missing object: fail upload completion.
+- Invalid or mismatched image signature: fail upload completion.
+- Metadata parsing failure: continue with `null` metadata fields.
+- Duplicate upload finalization: skip existing `Image` rows by `uploadSessionFileId`.
+
+## Tests
+
+- `ImageMetadataExtractorTests` covers PNG, JPEG, WEBP VP8X, BMP, and unsupported bytes.
+- `UploadCompleteServiceTests` verifies metadata is extracted and passed into image finalization.
+- `ImageCreateServiceTests` verifies metadata is applied to created images.
+- `ImageTests` verifies `Image.fromUpload` stores metadata fields.


### PR DESCRIPTION
## #️⃣ 기능 설명

업로드 완료 시 원본 이미지 바이트에서 width, height, dpiX, dpiY 메타데이터를 추출해 Image row에 저장합니다.

Closes #108

## 🛠️ 작업 상세 내용

- [x] PNG/JPEG/WEBP/BMP/TIFF 헤더 기반 ImageMetadataExtractor 추가
- [x] UploadCompleteService에서 magic number 검증 후 동일 바이트로 메타데이터 추출
- [x] ImageCreateService와 Image.fromUpload에 metadata 전달 경로 추가
- [x] Image/Upload API 문서와 feature spec 갱신
- [x] metadata extractor, upload complete, image create, image entity 테스트 추가/수정

## 📁 변경 파일 요약

- `backend-api/src/main/java/com/moonju/preprocess/api/domain/image/...`
- `backend-api/src/main/java/com/moonju/preprocess/api/domain/upload/service/UploadCompleteService.java`
- `backend-api/src/test/java/com/moonju/preprocess/api/domain/image/...`
- `backend-api/src/test/java/com/moonju/preprocess/api/domain/upload/...`
- `docs/api/image-api.md`
- `docs/api/upload-api.md`
- `docs/feature-specs/issue-108-upload-image-metadata-extraction.md`

## ✅ 검증 내용

- [x] `git diff --cached --check`
- [x] `docker run --rm -v "${pwdPath}:/workspace" -w /workspace gradle:8.10-jdk21 gradle test build --no-daemon`

## 🔎 리뷰어가 확인해야 할 부분

- Metadata parsing failure를 업로드 실패로 보지 않고 null metadata로 진행하는 정책이 적절한지 확인해주세요.
- API 서버에는 OCR/전처리 로직을 넣지 않았고, 파일 헤더 메타데이터 추출만 수행합니다.

## 📸 스크린샷

없음

## 💬 기타 공유사항 to 리뷰어

- TIFF 파서는 baseline IFD 태그 중심입니다.
- Worker artifact/report 흐름은 별도 작업으로 유지합니다.