### PR TITLE
🧹 [Chore] Docker Compose 배포 전 preflight 점검 추가

### DIFF
--- a/docs/feature-specs/issue-110-docker-compose-preflight.md
+++ b/docs/feature-specs/issue-110-docker-compose-preflight.md
@@ -1,0 +1,50 @@
+# Issue 110 - Docker Compose Preflight Checks
+
+## Purpose
+
+Before cloud deployment, the local Docker Compose stack needs a repeatable readiness check. The check should catch
+basic routing and service wiring failures before running OAuth login or full image preprocessing E2E tests.
+
+## Scope
+
+- Add a PowerShell preflight script for local Docker Compose.
+- Check Compose config interpolation.
+- Check expected container states.
+- Check NGINX, frontend, backend OpenAPI, backend health, MinIO health, and RabbitMQ queue topology.
+- Document how to run and how to triage failures.
+
+## Out Of Scope
+
+- OAuth login automation.
+- Authenticated upload/job/worker E2E flow.
+- Cloud Kubernetes checks.
+- Prometheus/Grafana/Jaeger validation.
+
+## Execution Order
+
+1. Start local Docker Compose.
+2. Run `scripts/docker-compose-preflight.ps1`.
+3. Fix any route or container health failure.
+4. Run `scripts/local-e2e-smoke.ps1` with a real access token.
+5. Continue to cloud deployment rehearsal.
+
+## Checks
+
+| Step | Verification |
+| --- | --- |
+| Compose config | `docker compose -f docker-compose.local.yml --env-file .env config` |
+| Containers | Required containers are running, bucket init exited successfully |
+| NGINX | `/health` returns `ok` |
+| Frontend | `/` returns HTML through NGINX |
+| OpenAPI | `/v3/api-docs` returns the backend API document through NGINX |
+| Backend | `/actuator/health` returns a health response |
+| MinIO | `/minio/health/live` returns 200 |
+| RabbitMQ | `image.preprocess.normal` queue exists through the management API |
+
+## Completion Criteria
+
+- `scripts/docker-compose-preflight.ps1` exists.
+- `docs/operation/docker-compose-preflight.md` explains usage and failure triage.
+- `scripts/README.md` and Docker Compose local docs reference the preflight script.
+- PowerShell parser validation passes.
+- Docker Compose config validation passes.

--- a/docs/operation/docker-compose-local.md
+++ b/docs/operation/docker-compose-local.md
@@ -61,6 +61,15 @@ Set it to `false` only when you want to inspect queued messages without Worker c
 
 ## Frontend Smoke Test
 
+Before browser testing, run the preflight check:
+
+```powershell
+.\scripts\docker-compose-preflight.ps1
+```
+
+The preflight script verifies Docker Compose config, container state, NGINX routing, backend health, Swagger/OpenAPI,
+MinIO health, and RabbitMQ queue topology. See `docs/operation/docker-compose-preflight.md` for failure triage.
+
 1. Start the stack.
 2. Open `http://localhost/login`.
 3. Sign in with Google.

--- a/docs/operation/docker-compose-preflight.md
+++ b/docs/operation/docker-compose-preflight.md
@@ -1,0 +1,96 @@
+# Docker Compose Preflight
+
+## Purpose
+
+Use this check after `docker compose up -d --build` and before browser or image-processing tests. It verifies that the
+local stack is reachable and that the main routes are wired correctly.
+
+This is not the authenticated image processing E2E test. For that workflow, use `scripts/local-e2e-smoke.ps1`.
+
+## Command
+
+Run from the repository root:
+
+```powershell
+.\scripts\docker-compose-preflight.ps1
+```
+
+The script automatically uses:
+
+```text
+infra/docker-compose/.env
+```
+
+If `.env` is missing, it falls back to:
+
+```text
+infra/docker-compose/.env.example
+```
+
+## Checked Items
+
+| Check | Purpose |
+| --- | --- |
+| `docker compose config` | Validates Compose and environment interpolation |
+| Docker container state | Verifies required containers are running or completed successfully |
+| `GET /health` through NGINX | Confirms the single entry point is reachable |
+| `GET /` through NGINX | Confirms frontend static routing works |
+| `GET /v3/api-docs` through NGINX | Confirms backend Swagger/OpenAPI routing works |
+| `GET /actuator/health` direct backend | Confirms Spring Boot health endpoint works |
+| `GET /minio/health/live` direct MinIO | Confirms object storage API is reachable |
+| RabbitMQ management queue lookup | Confirms queue topology exists |
+
+## Options
+
+Direct backend mode or non-default ports:
+
+```powershell
+.\scripts\docker-compose-preflight.ps1 `
+  -NginxBaseUrl "http://localhost" `
+  -BackendBaseUrl "http://localhost:8080" `
+  -MinioBaseUrl "http://localhost:9000" `
+  -RabbitManagementBaseUrl "http://localhost:15672"
+```
+
+Use a specific env file:
+
+```powershell
+.\scripts\docker-compose-preflight.ps1 -EnvFile ".env.example"
+```
+
+Skip Docker container checks and only check HTTP routes:
+
+```powershell
+.\scripts\docker-compose-preflight.ps1 -SkipDocker
+```
+
+Wait longer for slow cold starts:
+
+```powershell
+.\scripts\docker-compose-preflight.ps1 -TimeoutSeconds 60
+```
+
+## Expected Result
+
+```text
+Preflight passed. The stack is ready for browser login or scripts/local-e2e-smoke.ps1.
+```
+
+## Failure Triage
+
+| Failure | Check |
+| --- | --- |
+| NGINX health fails | `image-preprocess-nginx` container, port 80 binding, `infra/nginx/conf.d/app.conf` |
+| Frontend route fails | `image-preprocess-frontend` build and NGINX upstream routing |
+| OpenAPI docs fail | `backend-api` container, `/v3/api-docs`, `infra/nginx/conf.d/api.conf` |
+| Backend health fails | PostgreSQL/RabbitMQ health, Spring startup logs |
+| MinIO health fails | `image-preprocess-minio`, port 9000 binding, bucket init container |
+| RabbitMQ queue check fails | `image-preprocess-rabbitmq`, management port 15672, `definitions.json` import |
+
+## Follow-Up Test
+
+After preflight passes, run the authenticated E2E smoke flow:
+
+```powershell
+.\scripts\local-e2e-smoke.ps1 -AccessToken "<access-token>"
+```

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -7,8 +7,16 @@ This directory contains local development and operation helper scripts.
 - `local-e2e-smoke.ps1`: Runs the Docker Compose local MVP flow through HTTP APIs. It creates synthetic document
   images, simulates ZIP expansion, uploads through presigned URLs, creates a preprocessing Job, waits for Worker
   completion, and downloads processed outputs.
+- `docker-compose-preflight.ps1`: Checks Docker Compose config, container states, NGINX routing, backend health,
+  Swagger/OpenAPI, MinIO health, and RabbitMQ queue topology before running browser or E2E tests.
 
 Run from the repository root:
+
+```powershell
+.\scripts\docker-compose-preflight.ps1
+```
+
+Then run the authenticated E2E smoke flow:
 
 ```powershell
 .\scripts\local-e2e-smoke.ps1 -AccessToken "<access-token>"

--- a/scripts/docker-compose-preflight.ps1
+++ b/scripts/docker-compose-preflight.ps1
@@ -1,0 +1,312 @@
+<#
+.SYNOPSIS
+Runs deployment preflight checks against the local Docker Compose stack.
+
+.DESCRIPTION
+This script verifies that the local Docker Compose stack is ready before a browser smoke test or deployment rehearsal.
+It does not perform OAuth login or image preprocessing. Use local-e2e-smoke.ps1 for the authenticated image workflow.
+#>
+[CmdletBinding()]
+param(
+    [string]$ComposeDirectory = "infra/docker-compose",
+    [string]$ComposeFile = "docker-compose.local.yml",
+    [string]$EnvFile = "",
+    [string]$NginxBaseUrl = "http://localhost",
+    [string]$BackendBaseUrl = "http://localhost:8080",
+    [string]$MinioBaseUrl = "http://localhost:9000",
+    [string]$RabbitManagementBaseUrl = "http://localhost:15672",
+    [int]$TimeoutSeconds = 20,
+    [switch]$SkipDocker
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+$script:Failures = New-Object System.Collections.Generic.List[string]
+
+function Write-Step {
+    param([string]$Message)
+    Write-Host "==> $Message"
+}
+
+function Resolve-RepoRelativePath {
+    param([string]$Path)
+
+    if ([System.IO.Path]::IsPathRooted($Path)) {
+        return $Path
+    }
+    return (Join-Path (Get-Location).Path $Path)
+}
+
+function Read-DotEnv {
+    param([string]$Path)
+
+    $values = @{}
+    if (-not (Test-Path -LiteralPath $Path)) {
+        return $values
+    }
+
+    foreach ($rawLine in Get-Content -LiteralPath $Path) {
+        $line = $rawLine.Trim()
+        if ([string]::IsNullOrWhiteSpace($line) -or $line.StartsWith("#")) {
+            continue
+        }
+
+        $separator = $line.IndexOf("=")
+        if ($separator -le 0) {
+            continue
+        }
+
+        $key = $line.Substring(0, $separator).Trim()
+        $value = $line.Substring($separator + 1).Trim().Trim('"').Trim("'")
+        $values[$key] = $value
+    }
+    return $values
+}
+
+function Get-EnvValue {
+    param(
+        [hashtable]$Values,
+        [string]$Name,
+        [string]$DefaultValue
+    )
+
+    if ($Values.ContainsKey($Name) -and -not [string]::IsNullOrWhiteSpace($Values[$Name])) {
+        return $Values[$Name]
+    }
+    return $DefaultValue
+}
+
+function Invoke-PreflightCheck {
+    param(
+        [string]$Name,
+        [scriptblock]$Action
+    )
+
+    Write-Host "[check] $Name"
+    try {
+        & $Action
+        Write-Host "[ ok ] $Name"
+    } catch {
+        $message = "$Name failed: $($_.Exception.Message)"
+        $script:Failures.Add($message)
+        Write-Warning $message
+    }
+}
+
+function Wait-HttpStatus {
+    param(
+        [string]$Name,
+        [string]$Uri,
+        [int]$ExpectedStatus = 200,
+        [hashtable]$Headers = @{}
+    )
+
+    $deadline = (Get-Date).AddSeconds($TimeoutSeconds)
+    $lastError = $null
+
+    do {
+        try {
+            $response = Invoke-WebRequest -Uri $Uri -Headers $Headers -UseBasicParsing -TimeoutSec 8
+            if ([int]$response.StatusCode -eq $ExpectedStatus) {
+                return $response
+            }
+            $lastError = "HTTP $($response.StatusCode)"
+        } catch {
+            $lastError = $_.Exception.Message
+        }
+
+        Start-Sleep -Seconds 2
+    } while ((Get-Date) -lt $deadline)
+
+    throw "$Name did not return HTTP $ExpectedStatus from $Uri within $TimeoutSeconds seconds. Last error: $lastError"
+}
+
+function New-BasicAuthHeader {
+    param(
+        [string]$Username,
+        [string]$Password
+    )
+
+    $pair = "${Username}:${Password}"
+    $encoded = [Convert]::ToBase64String([Text.Encoding]::ASCII.GetBytes($pair))
+    return @{ Authorization = "Basic $encoded" }
+}
+
+function Get-ResponseText {
+    param([object]$Response)
+
+    if ($Response.Content -is [byte[]]) {
+        return [Text.Encoding]::UTF8.GetString($Response.Content)
+    }
+    return [string]$Response.Content
+}
+
+function Assert-DockerAvailable {
+    if ($SkipDocker) {
+        return
+    }
+    if ($null -eq (Get-Command docker -ErrorAction SilentlyContinue)) {
+        throw "docker command is not available."
+    }
+}
+
+function Invoke-ComposeConfig {
+    param(
+        [string]$Directory,
+        [string]$File,
+        [string]$EnvFilePath
+    )
+
+    Push-Location $Directory
+    try {
+        $output = & docker compose -f $File --env-file $EnvFilePath config 2>&1
+        if ($LASTEXITCODE -ne 0) {
+            throw ($output -join [Environment]::NewLine)
+        }
+    } finally {
+        Pop-Location
+    }
+}
+
+function Assert-ContainerState {
+    param(
+        [string]$Name,
+        [switch]$AllowExitedSuccess
+    )
+
+    $raw = & docker inspect $Name 2>&1
+    if ($LASTEXITCODE -ne 0) {
+        throw "Container not found: $Name"
+    }
+
+    $items = @(($raw -join [Environment]::NewLine) | ConvertFrom-Json)
+    $state = $items[0].State
+    if ($AllowExitedSuccess -and $state.Status -eq "exited" -and [int]$state.ExitCode -eq 0) {
+        return
+    }
+
+    if ($state.Status -ne "running") {
+        throw "Container $Name is $($state.Status)."
+    }
+
+    $healthProperty = $state.PSObject.Properties["Health"]
+    if ($null -ne $healthProperty -and $null -ne $healthProperty.Value) {
+        $health = $healthProperty.Value.Status
+        if ($health -eq "unhealthy") {
+            throw "Container $Name health is unhealthy."
+        }
+        if ($health -ne "healthy") {
+            Write-Host "    health=$health"
+        }
+    }
+}
+
+$composeDirectoryPath = Resolve-RepoRelativePath $ComposeDirectory
+if (-not (Test-Path -LiteralPath $composeDirectoryPath)) {
+    throw "Compose directory does not exist: $composeDirectoryPath"
+}
+
+if ([string]::IsNullOrWhiteSpace($EnvFile)) {
+    $candidate = Join-Path $composeDirectoryPath ".env"
+    if (Test-Path -LiteralPath $candidate) {
+        $EnvFile = ".env"
+    } else {
+        $EnvFile = ".env.example"
+    }
+}
+
+$envFilePath = Resolve-RepoRelativePath (Join-Path $ComposeDirectory $EnvFile)
+if (-not (Test-Path -LiteralPath $envFilePath)) {
+    throw "Env file does not exist: $envFilePath"
+}
+
+$envValues = Read-DotEnv $envFilePath
+$rabbitUser = Get-EnvValue $envValues "RABBITMQ_DEFAULT_USER" "local"
+$rabbitPassword = Get-EnvValue $envValues "RABBITMQ_DEFAULT_PASS" "local"
+$normalQueue = "image.preprocess.normal"
+
+Write-Step "Docker Compose preflight"
+Write-Host "Compose directory: $composeDirectoryPath"
+Write-Host "Env file: $envFilePath"
+Write-Host "NGINX: $NginxBaseUrl"
+Write-Host "Backend: $BackendBaseUrl"
+Write-Host "MinIO: $MinioBaseUrl"
+Write-Host "RabbitMQ management: $RabbitManagementBaseUrl"
+
+Invoke-PreflightCheck "docker command" {
+    Assert-DockerAvailable
+}
+
+if (-not $SkipDocker) {
+    Invoke-PreflightCheck "docker compose config" {
+        Invoke-ComposeConfig -Directory $composeDirectoryPath -File $ComposeFile -EnvFilePath $envFilePath
+    }
+
+    Invoke-PreflightCheck "containers are running" {
+        Assert-ContainerState "image-preprocess-nginx"
+        Assert-ContainerState "image-preprocess-frontend"
+        Assert-ContainerState "image-preprocess-backend-api"
+        Assert-ContainerState "image-preprocess-worker"
+        Assert-ContainerState "image-preprocess-postgres"
+        Assert-ContainerState "image-preprocess-rabbitmq"
+        Assert-ContainerState "image-preprocess-minio"
+        Assert-ContainerState "image-preprocess-minio-init" -AllowExitedSuccess
+    }
+}
+
+Invoke-PreflightCheck "NGINX health route" {
+    $response = Wait-HttpStatus -Name "NGINX health" -Uri "$($NginxBaseUrl.TrimEnd('/'))/health"
+    $content = Get-ResponseText $response
+    if ($content.Trim() -ne "ok") {
+        throw "Unexpected NGINX health body: $content"
+    }
+}
+
+Invoke-PreflightCheck "frontend route through NGINX" {
+    $response = Wait-HttpStatus -Name "Frontend" -Uri "$($NginxBaseUrl.TrimEnd('/'))/"
+    $content = Get-ResponseText $response
+    if ($content -notmatch "<html") {
+        throw "Frontend route did not return HTML."
+    }
+}
+
+Invoke-PreflightCheck "Swagger docs through NGINX" {
+    $response = Wait-HttpStatus -Name "OpenAPI docs" -Uri "$($NginxBaseUrl.TrimEnd('/'))/v3/api-docs"
+    $content = Get-ResponseText $response
+    if ($content -notmatch "Image Preprocess Platform API") {
+        throw "OpenAPI docs response does not contain the expected API title."
+    }
+}
+
+Invoke-PreflightCheck "backend actuator health direct" {
+    $response = Wait-HttpStatus -Name "Backend health" -Uri "$($BackendBaseUrl.TrimEnd('/'))/actuator/health"
+    $content = Get-ResponseText $response
+    if ($content -notmatch '"status"') {
+        throw "Backend health response does not contain status."
+    }
+}
+
+Invoke-PreflightCheck "MinIO health direct" {
+    Wait-HttpStatus -Name "MinIO health" -Uri "$($MinioBaseUrl.TrimEnd('/'))/minio/health/live" | Out-Null
+}
+
+Invoke-PreflightCheck "RabbitMQ management queue topology" {
+    $headers = New-BasicAuthHeader -Username $rabbitUser -Password $rabbitPassword
+    $queueUri = "$($RabbitManagementBaseUrl.TrimEnd('/'))/api/queues/%2F/$normalQueue"
+    $response = Wait-HttpStatus -Name "RabbitMQ queue" -Uri $queueUri -Headers $headers
+    $content = Get-ResponseText $response
+    if ($content -notmatch $normalQueue) {
+        throw "RabbitMQ queue response does not contain $normalQueue."
+    }
+}
+
+if ($script:Failures.Count -gt 0) {
+    Write-Host ""
+    Write-Host "Preflight failed:"
+    $script:Failures | ForEach-Object { Write-Host "- $_" }
+    exit 1
+}
+
+Write-Host ""
+Write-Host "Preflight passed. The stack is ready for browser login or scripts/local-e2e-smoke.ps1."


### PR DESCRIPTION
## #️⃣ 기능 설명

Docker Compose 로컬/배포 전 환경에서 핵심 서비스 상태를 빠르게 확인하는 preflight 스크립트와 운영 문서를 추가합니다.

Closes #110

## 🛠️ 작업 상세 내용

- [x] `scripts/docker-compose-preflight.ps1` 추가
- [x] Docker Compose config, 컨테이너 상태, NGINX, frontend, Swagger/OpenAPI, backend health, MinIO, RabbitMQ queue topology 점검
- [x] `docs/operation/docker-compose-preflight.md` 실행/실패 triage 문서 추가
- [x] Docker Compose local 문서와 scripts README에 preflight 실행 순서 추가

## 📁 변경 파일 요약

- `scripts/docker-compose-preflight.ps1`
- `scripts/README.md`
- `docs/operation/docker-compose-preflight.md`
- `docs/operation/docker-compose-local.md`
- `docs/feature-specs/issue-110-docker-compose-preflight.md`

## ✅ 검증 내용

- [x] PowerShell parser validation
- [x] `git diff --check`
- [x] `docker compose -f infra/docker-compose/docker-compose.local.yml --env-file infra/docker-compose/.env.example config`
- [x] `docker compose -f infra/docker-compose/docker-compose.local.yml --env-file infra/docker-compose/.env up -d --build`
- [x] `powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\docker-compose-preflight.ps1 -TimeoutSeconds 30`

## 🔎 리뷰어가 확인해야 할 부분

- preflight 범위를 OAuth/E2E가 아닌 서비스 readiness 점검으로 제한한 것이 적절한지 확인해주세요.
- RabbitMQ queue topology 확인을 management API 기준으로 둔 것이 로컬 운영에 충분한지 확인해주세요.

## 📸 스크린샷

없음

## 💬 기타 공유사항 to 리뷰어

- 실제 이미지 업로드/처리 검증은 기존 `scripts/local-e2e-smoke.ps1`가 담당합니다.
- 이번 PR은 배포 전 빠른 실패 탐지용입니다.