### PR TITLE
👷 [Ci] Production Compose와 GitHub Actions 배포 절차 추가

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -1,0 +1,113 @@
+name: Deploy Production
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+
+concurrency:
+  group: production-deploy
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    name: Deploy Docker Compose stack
+    runs-on: ubuntu-latest
+    environment: production
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Validate production compose template
+        run: |
+          docker compose \
+            -f infra/docker-compose/docker-compose.local.yml \
+            -f infra/docker-compose/docker-compose.prod.yml \
+            --env-file infra/docker-compose/.env.prod.example \
+            config >/tmp/image-preprocess-prod-compose.yml
+
+      - name: Create deployment archive
+        run: |
+          tar \
+            --exclude='.git' \
+            --exclude='.github' \
+            --exclude='infra/docker-compose/.env' \
+            --exclude='infra/docker-compose/.env.prod' \
+            --exclude='node_modules' \
+            --exclude='frontend/node_modules' \
+            --exclude='out' \
+            -czf /tmp/image-preprocess-release.tgz .
+
+      - name: Configure SSH
+        env:
+          DEPLOY_SSH_PRIVATE_KEY: ${{ secrets.DEPLOY_SSH_PRIVATE_KEY }}
+          DEPLOY_HOST: ${{ secrets.DEPLOY_HOST }}
+          DEPLOY_SSH_PORT: ${{ secrets.DEPLOY_SSH_PORT || '22' }}
+        run: |
+          mkdir -p ~/.ssh
+          printf '%s\n' "$DEPLOY_SSH_PRIVATE_KEY" > ~/.ssh/deploy_key
+          chmod 600 ~/.ssh/deploy_key
+          ssh-keyscan -p "$DEPLOY_SSH_PORT" "$DEPLOY_HOST" >> ~/.ssh/known_hosts
+
+      - name: Upload deployment archive
+        env:
+          DEPLOY_HOST: ${{ secrets.DEPLOY_HOST }}
+          DEPLOY_USER: ${{ secrets.DEPLOY_USER }}
+          DEPLOY_PATH: ${{ secrets.DEPLOY_PATH }}
+          DEPLOY_SSH_PORT: ${{ secrets.DEPLOY_SSH_PORT || '22' }}
+        run: |
+          ssh -i ~/.ssh/deploy_key -p "$DEPLOY_SSH_PORT" "$DEPLOY_USER@$DEPLOY_HOST" \
+            "mkdir -p '$DEPLOY_PATH/releases' '$DEPLOY_PATH/shared'"
+          scp -i ~/.ssh/deploy_key -P "$DEPLOY_SSH_PORT" /tmp/image-preprocess-release.tgz \
+            "$DEPLOY_USER@$DEPLOY_HOST:$DEPLOY_PATH/releases/image-preprocess-release.tgz"
+
+      - name: Deploy on server
+        env:
+          DEPLOY_HOST: ${{ secrets.DEPLOY_HOST }}
+          DEPLOY_USER: ${{ secrets.DEPLOY_USER }}
+          DEPLOY_PATH: ${{ secrets.DEPLOY_PATH }}
+          DEPLOY_SSH_PORT: ${{ secrets.DEPLOY_SSH_PORT || '22' }}
+        run: |
+          ssh -i ~/.ssh/deploy_key -p "$DEPLOY_SSH_PORT" "$DEPLOY_USER@$DEPLOY_HOST" \
+            "DEPLOY_PATH='$DEPLOY_PATH' bash -s" <<'REMOTE'
+          set -euo pipefail
+
+          cd "$DEPLOY_PATH"
+          rm -rf current
+          mkdir -p current
+          tar -xzf releases/image-preprocess-release.tgz -C current
+
+          if [ ! -f shared/.env.prod ]; then
+            echo "Missing $DEPLOY_PATH/shared/.env.prod"
+            echo "Create it from infra/docker-compose/.env.prod.example before deploying."
+            exit 1
+          fi
+
+          cp shared/.env.prod current/infra/docker-compose/.env.prod
+          cd current
+
+          docker compose \
+            -f infra/docker-compose/docker-compose.local.yml \
+            -f infra/docker-compose/docker-compose.prod.yml \
+            --env-file infra/docker-compose/.env.prod \
+            config >/tmp/image-preprocess-prod-compose.yml
+
+          docker compose \
+            -f infra/docker-compose/docker-compose.local.yml \
+            -f infra/docker-compose/docker-compose.prod.yml \
+            --env-file infra/docker-compose/.env.prod \
+            up -d --build
+
+          docker image prune -f
+          REMOTE
+
+      - name: Post-deploy HTTP checks
+        env:
+          PROD_BASE_URL: ${{ secrets.PROD_BASE_URL }}
+        run: |
+          test -n "$PROD_BASE_URL"
+          curl --fail --show-error --silent "$PROD_BASE_URL/health"
+          curl --fail --show-error --silent "$PROD_BASE_URL/v3/api-docs" | grep -q "Image Preprocess Platform API"

--- a/docs/feature-specs/issue-114-production-compose-github-actions-deploy.md
+++ b/docs/feature-specs/issue-114-production-compose-github-actions-deploy.md
@@ -1,0 +1,70 @@
+# Issue 114 - Production Compose And GitHub Actions Deployment
+
+## Purpose
+
+Prepare the MVP for cloud deployment by separating production Compose behavior, documenting HTTPS/domain policy,
+adding GitHub Actions deployment automation, and defining final E2E verification.
+
+## Scope
+
+- Add `infra/docker-compose/docker-compose.prod.yml`.
+- Add `.github/workflows/deploy-production.yml`.
+- Document GitHub Actions secrets and server prerequisites.
+- Document HTTPS/domain policy.
+- Document backup and restore operations.
+- Document final local and production E2E verification order.
+
+## Production Compose Behavior
+
+The production override is used with the existing local Compose file:
+
+```bash
+docker compose \
+  -f infra/docker-compose/docker-compose.local.yml \
+  -f infra/docker-compose/docker-compose.prod.yml \
+  --env-file infra/docker-compose/.env.prod \
+  up -d --build
+```
+
+It applies:
+
+- `restart: unless-stopped` to long-running services.
+- Direct port reset for backend-api, PostgreSQL, RabbitMQ, and MinIO.
+- NGINX remains the single public entry point.
+
+## GitHub Actions Deployment Flow
+
+1. Validate production Compose template.
+2. Create a repository archive.
+3. Upload archive to the deployment server over SSH.
+4. Extract into `${DEPLOY_PATH}/current`.
+5. Copy `${DEPLOY_PATH}/shared/.env.prod` into the release.
+6. Run Compose config validation on the server.
+7. Run Compose `up -d --build`.
+8. Check `${PROD_BASE_URL}/health`.
+9. Check `${PROD_BASE_URL}/v3/api-docs`.
+
+## Required GitHub Secrets
+
+| Secret | Purpose |
+| --- | --- |
+| `DEPLOY_HOST` | SSH host/IP |
+| `DEPLOY_USER` | SSH user |
+| `DEPLOY_SSH_PRIVATE_KEY` | SSH private key |
+| `DEPLOY_SSH_PORT` | Optional SSH port |
+| `DEPLOY_PATH` | Deployment directory |
+| `PROD_BASE_URL` | Public HTTPS base URL |
+
+## Out Of Scope
+
+- Creating real production secrets.
+- Running Google OAuth automatically in CI.
+- Implementing TLS certificates inside Compose NGINX.
+- Implementing timestamped rollback releases.
+
+## Validation
+
+- `docker compose` config with local and production files.
+- JSON/YAML/document syntax sanity checks.
+- Deployment workflow dry validation by reviewing generated Compose config.
+- Actual deployment requires GitHub Actions secrets and a prepared server.

--- a/docs/operation/backup-restore.md
+++ b/docs/operation/backup-restore.md
@@ -1,0 +1,125 @@
+# Backup And Restore
+
+## Purpose
+
+The MVP stores durable data in PostgreSQL and MinIO volumes. Backups must cover both. RabbitMQ queue definitions are in
+Git; queued messages are transient and should normally be drained before maintenance.
+
+## What To Back Up
+
+| Data | Source | Backup method |
+| --- | --- | --- |
+| PostgreSQL records | `image-preprocess-postgres` | `pg_dump` |
+| Original and processed images | MinIO data volume | MinIO mirror or volume archive |
+| Production secrets | `/opt/image-preprocess/shared/.env.prod` | Secure password manager or encrypted backup |
+| Queue topology | `infra/rabbitmq/definitions.json` | Git |
+
+## PostgreSQL Backup
+
+Run on the deployment server:
+
+```bash
+mkdir -p /opt/image-preprocess/backups/postgres
+docker exec image-preprocess-postgres \
+  pg_dump -U "$POSTGRES_USER" -d "$POSTGRES_DB" \
+  > "/opt/image-preprocess/backups/postgres/image-preprocess-$(date +%Y%m%d-%H%M%S).sql"
+```
+
+If the shell does not have `POSTGRES_USER` and `POSTGRES_DB`, read them from:
+
+```text
+/opt/image-preprocess/shared/.env.prod
+```
+
+or pass explicit values:
+
+```bash
+docker exec image-preprocess-postgres \
+  pg_dump -U image_preprocess -d image_preprocess \
+  > /opt/image-preprocess/backups/postgres/image-preprocess.sql
+```
+
+## PostgreSQL Restore
+
+Restore into an empty or intentionally reset database:
+
+```bash
+cat /opt/image-preprocess/backups/postgres/image-preprocess.sql | \
+  docker exec -i image-preprocess-postgres \
+  psql -U image_preprocess -d image_preprocess
+```
+
+Do not restore over active production traffic without stopping API and Worker first.
+
+## MinIO Backup
+
+Recommended MVP backup is a volume archive while the stack is stopped or quiesced:
+
+```bash
+mkdir -p /opt/image-preprocess/backups/minio
+docker compose \
+  -f /opt/image-preprocess/current/infra/docker-compose/docker-compose.local.yml \
+  -f /opt/image-preprocess/current/infra/docker-compose/docker-compose.prod.yml \
+  --env-file /opt/image-preprocess/current/infra/docker-compose/.env.prod \
+  stop backend-api preprocess-worker
+
+docker run --rm \
+  -v image-preprocess-prod_minio-data:/source:ro \
+  -v /opt/image-preprocess/backups/minio:/backup \
+  alpine \
+  tar -czf /backup/minio-data-$(date +%Y%m%d-%H%M%S).tgz -C /source .
+```
+
+Restart after the archive finishes:
+
+```bash
+docker compose \
+  -f /opt/image-preprocess/current/infra/docker-compose/docker-compose.local.yml \
+  -f /opt/image-preprocess/current/infra/docker-compose/docker-compose.prod.yml \
+  --env-file /opt/image-preprocess/current/infra/docker-compose/.env.prod \
+  up -d
+```
+
+## MinIO Restore
+
+Restore only when the stack is stopped:
+
+```bash
+docker compose \
+  -f /opt/image-preprocess/current/infra/docker-compose/docker-compose.local.yml \
+  -f /opt/image-preprocess/current/infra/docker-compose/docker-compose.prod.yml \
+  --env-file /opt/image-preprocess/current/infra/docker-compose/.env.prod \
+  down
+
+docker run --rm \
+  -v image-preprocess-prod_minio-data:/target \
+  -v /opt/image-preprocess/backups/minio:/backup \
+  alpine \
+  sh -c 'rm -rf /target/* && tar -xzf /backup/minio-data-YYYYMMDD-HHMMSS.tgz -C /target'
+```
+
+Then start the stack.
+
+## Secret Backup
+
+Back up:
+
+```text
+/opt/image-preprocess/shared/.env.prod
+```
+
+Store it in a password manager or encrypted secret storage. Never commit it to Git.
+
+## Minimum Backup Schedule
+
+For MVP demo:
+
+- PostgreSQL: before every deployment and after successful demo data upload.
+- MinIO: before every deployment that changes storage paths or worker artifact behavior.
+- `.env.prod`: whenever secrets change.
+
+For real usage:
+
+- PostgreSQL: daily.
+- MinIO: daily or object-storage-provider lifecycle backup.
+- Retention: at least 7 daily backups and 4 weekly backups.

--- a/docs/operation/deployment-checklist.md
+++ b/docs/operation/deployment-checklist.md
@@ -25,6 +25,7 @@ Use this checklist before exposing the MVP outside the local machine.
 ```powershell
 docker compose `
   -f infra/docker-compose/docker-compose.local.yml `
+  -f infra/docker-compose/docker-compose.prod.yml `
   --env-file infra/docker-compose/.env.prod `
   config
 ```
@@ -34,20 +35,30 @@ If using the template only:
 ```powershell
 docker compose `
   -f infra/docker-compose/docker-compose.local.yml `
+  -f infra/docker-compose/docker-compose.prod.yml `
   --env-file infra/docker-compose/.env.prod.example `
   config
 ```
 
-## 4. Build And Start
+## 4. Build And Start Manually
 
 ```powershell
 docker compose `
   -f infra/docker-compose/docker-compose.local.yml `
+  -f infra/docker-compose/docker-compose.prod.yml `
   --env-file infra/docker-compose/.env.prod `
   up -d --build
 ```
 
-## 5. Run Preflight
+For normal production deployment, prefer GitHub Actions:
+
+```text
+Actions -> Deploy Production -> Run workflow
+```
+
+See `docs/operation/github-actions-deployment.md`.
+
+## 5. Run Preflight Or Post-Deploy Checks
 
 For local host validation:
 
@@ -105,8 +116,7 @@ Then run:
 
 ## 9. Operational Follow-Up
 
-- Add a production Compose override with restart policies and restricted port exposure.
 - Add HTTPS termination configuration.
 - Add database migration tooling and change `JPA_DDL_AUTO` to `validate`.
-- Add backup policy for PostgreSQL and object storage volumes.
+- Follow `docs/operation/backup-restore.md` for PostgreSQL and object storage backup.
 - Add observability stack only after the MVP flow is stable.

--- a/docs/operation/final-e2e-verification.md
+++ b/docs/operation/final-e2e-verification.md
@@ -1,0 +1,119 @@
+# Final E2E Verification
+
+## Purpose
+
+This is the final verification order before and after deployment. It separates unauthenticated readiness checks from
+the authenticated Google OAuth image-processing flow.
+
+## 1. Local Compose Readiness
+
+```powershell
+.\scripts\docker-compose-preflight.ps1
+```
+
+Expected:
+
+```text
+Preflight passed.
+```
+
+## 2. Local Authenticated Image Processing
+
+1. Open `http://localhost/login`.
+2. Sign in with Google.
+3. Read the access token from DevTools:
+
+```javascript
+localStorage.getItem('doc-pipeline.access-token')
+```
+
+4. Run:
+
+```powershell
+.\scripts\local-e2e-smoke.ps1 -AccessToken "<access-token>"
+```
+
+Expected:
+
+- Project is created.
+- ZIP is expanded into image files.
+- Images upload through presigned URLs.
+- Upload completion creates image metadata.
+- Job is created.
+- Worker completes all JobItems.
+- Processed image and processed-only ZIP are downloaded under `out/local-e2e-smoke/{runId}`.
+
+## 3. Production Compose Config
+
+On the server:
+
+```bash
+cd /opt/image-preprocess/current
+docker compose \
+  -f infra/docker-compose/docker-compose.local.yml \
+  -f infra/docker-compose/docker-compose.prod.yml \
+  --env-file infra/docker-compose/.env.prod \
+  config
+```
+
+Expected:
+
+- Only NGINX publishes a public port.
+- backend-api, PostgreSQL, RabbitMQ, and MinIO direct ports are not published.
+- `REFRESH_TOKEN_COOKIE_SECURE=true`.
+- `MINIO_PUBLIC_ENDPOINT=https://YOUR_DOMAIN`.
+
+## 4. GitHub Actions Deployment
+
+Run `Deploy Production` from GitHub Actions or merge to `main` after the workflow is stable.
+
+Expected:
+
+- Compose template validation passes.
+- Archive upload succeeds.
+- Server deploy step succeeds.
+- `GET /health` succeeds.
+- `GET /v3/api-docs` contains `Image Preprocess Platform API`.
+
+## 5. Production Browser Smoke
+
+1. Open `https://YOUR_DOMAIN/login`.
+2. Sign in with Google.
+3. Confirm the browser returns to:
+
+```text
+https://YOUR_DOMAIN/oauth2/success
+```
+
+4. Confirm the URL does not contain an access token.
+5. Open Upload.
+6. Upload one PNG/JPEG document image.
+7. Confirm the Job reaches `SUCCEEDED`.
+8. Download the processed output.
+
+## 6. Production Authenticated Script Smoke
+
+After browser login:
+
+```powershell
+.\scripts\local-e2e-smoke.ps1 `
+  -BaseUrl "https://YOUR_DOMAIN/api" `
+  -AccessToken "<access-token>"
+```
+
+Expected:
+
+- All JobItems succeed.
+- Processed output ZIP downloads.
+
+## Stop Conditions
+
+Do not proceed to public use if any of these are true:
+
+- OAuth returns `invalid_client` or redirect URI mismatch.
+- `/health` fails.
+- Worker cannot call internal API.
+- Upload presigned URLs point to an unreachable host.
+- Processed ZIP download is empty.
+- Refresh token cookie is not Secure on HTTPS.
+- `.env.prod` contains placeholder `CHANGE_ME` or `YOUR_DOMAIN` values.

--- a/docs/operation/github-actions-deployment.md
+++ b/docs/operation/github-actions-deployment.md
@@ -1,0 +1,144 @@
+# GitHub Actions Production Deployment
+
+## Purpose
+
+Production deployment is driven by GitHub Actions. The workflow packages the repository, uploads it to a deployment
+server over SSH, copies the server-side `.env.prod`, starts the Docker Compose production stack, and runs unauthenticated
+HTTP checks.
+
+Workflow file:
+
+```text
+.github/workflows/deploy-production.yml
+```
+
+## Trigger
+
+The workflow runs on:
+
+- manual `workflow_dispatch`
+- push to `main`
+
+Use the manual trigger for the first deployment. Keep automatic `main` deployment only after the server is stable.
+
+## Required GitHub Environment
+
+Create a GitHub environment named:
+
+```text
+production
+```
+
+Then add these secrets to that environment.
+
+| Secret | Example | Purpose |
+| --- | --- | --- |
+| `DEPLOY_HOST` | `203.0.113.10` | SSH host or IP |
+| `DEPLOY_USER` | `deploy` | SSH user on the server |
+| `DEPLOY_SSH_PRIVATE_KEY` | private key text | Private key for the deploy user |
+| `DEPLOY_SSH_PORT` | `22` | Optional SSH port. Defaults to `22` when empty |
+| `DEPLOY_PATH` | `/opt/image-preprocess` | Server deployment directory |
+| `PROD_BASE_URL` | `https://YOUR_DOMAIN` | Public base URL used for post-deploy checks |
+
+Do not store application secrets such as `GOOGLE_CLIENT_SECRET`, `JWT_SECRET`, or DB passwords in this workflow. Those
+belong in the server-side `.env.prod`.
+
+Keep `DEPLOY_PATH` simple, for example `/opt/image-preprocess`. Do not use paths containing spaces or shell quotes.
+
+## Server Prerequisites
+
+On the deployment server:
+
+1. Install Docker Engine and Docker Compose plugin.
+2. Create a deploy user.
+3. Allow the deploy user to run Docker.
+4. Create deployment directories.
+5. Create the real production env file.
+
+Example:
+
+```bash
+sudo useradd -m -s /bin/bash deploy
+sudo usermod -aG docker deploy
+sudo mkdir -p /opt/image-preprocess/shared /opt/image-preprocess/releases
+sudo chown -R deploy:deploy /opt/image-preprocess
+```
+
+Create:
+
+```text
+/opt/image-preprocess/shared/.env.prod
+```
+
+Use this repo file as the template:
+
+```text
+infra/docker-compose/.env.prod.example
+```
+
+The workflow refuses to deploy if `/opt/image-preprocess/shared/.env.prod` is missing.
+
+## Workflow Deployment Steps
+
+1. Checkout repository.
+2. Validate production Compose using `.env.prod.example`.
+3. Create a release archive, excluding Git metadata, node modules, output files, and local env files.
+4. Configure SSH from GitHub Actions secrets.
+5. Upload the archive to `${DEPLOY_PATH}/releases/image-preprocess-release.tgz`.
+6. Extract into `${DEPLOY_PATH}/current`.
+7. Copy `${DEPLOY_PATH}/shared/.env.prod` into `current/infra/docker-compose/.env.prod`.
+8. Run Docker Compose config validation on the server.
+9. Run Docker Compose `up -d --build`.
+10. Prune unused Docker images.
+11. Run post-deploy checks against `${PROD_BASE_URL}/health` and `${PROD_BASE_URL}/v3/api-docs`.
+
+## Compose Command Used By The Workflow
+
+```bash
+docker compose \
+  -f infra/docker-compose/docker-compose.local.yml \
+  -f infra/docker-compose/docker-compose.prod.yml \
+  --env-file infra/docker-compose/.env.prod \
+  up -d --build
+```
+
+`docker-compose.prod.yml` is an override. It keeps only NGINX exposed and resets direct ports for backend-api,
+PostgreSQL, RabbitMQ, and MinIO.
+
+## Post-Deploy Checks
+
+The workflow checks only unauthenticated endpoints:
+
+- `GET /health`
+- `GET /v3/api-docs`
+
+Google OAuth and authenticated image preprocessing cannot be fully automated without a test identity and browser login.
+Run the authenticated E2E smoke manually after deployment.
+
+## Manual Authenticated E2E After Deploy
+
+1. Open `${PROD_BASE_URL}/login`.
+2. Sign in with Google.
+3. In browser DevTools, read:
+
+```javascript
+localStorage.getItem('doc-pipeline.access-token')
+```
+
+4. Run:
+
+```powershell
+.\scripts\local-e2e-smoke.ps1 `
+  -BaseUrl "https://YOUR_DOMAIN/api" `
+  -AccessToken "<access-token>"
+```
+
+## Rollback
+
+This workflow keeps a single `current` directory and does not implement release history rollback yet. A safe manual
+rollback is:
+
+1. Re-run a previous successful workflow commit.
+2. Or SSH into the server, checkout/restore a known-good archive, and run the same Compose command.
+
+Add timestamped release directories if rollback becomes a frequent operational need.

--- a/docs/operation/https-domain-policy.md
+++ b/docs/operation/https-domain-policy.md
@@ -1,0 +1,122 @@
+# HTTPS And Domain Policy
+
+## Purpose
+
+Google OAuth production login requires HTTPS. The application should be exposed through one public domain and keep
+backend, database, queue, and object storage ports private.
+
+## Recommended Layout
+
+```text
+User Browser
+  -> HTTPS domain
+  -> TLS terminator or cloud load balancer
+  -> NGINX container on HTTP :80
+  -> frontend / backend-api / MinIO bucket proxy
+```
+
+The current Docker Compose production override exposes only NGINX. Direct ports for backend-api, PostgreSQL, RabbitMQ,
+and MinIO are reset by `docker-compose.prod.yml`.
+
+## TLS Options
+
+### Option A: Cloudflare Or Load Balancer TLS Termination
+
+Use this for the first MVP deployment.
+
+- Public browser traffic uses `https://YOUR_DOMAIN`.
+- Cloudflare/load balancer terminates TLS.
+- It forwards HTTP to the server's NGINX container.
+- Keep `NGINX_HTTP_PORT=80` or bind NGINX to an internal port depending on your load balancer setup.
+
+### Option B: Host NGINX/Caddy In Front Of Compose
+
+Use a host-level reverse proxy with Let's Encrypt:
+
+```text
+host nginx/caddy :443
+  -> localhost:8088
+  -> compose nginx :80
+```
+
+Set:
+
+```text
+NGINX_HTTP_PORT=127.0.0.1:8088
+```
+
+### Option C: TLS Inside The Compose NGINX Container
+
+This is not implemented yet. It needs certificate volume mounts, port `443`, renewal automation, and a production NGINX
+server block. Treat it as a separate hardening task.
+
+## Required Google OAuth Values
+
+Configure Google Console:
+
+```text
+Authorized JavaScript origin: https://YOUR_DOMAIN
+Authorized redirect URI:      https://YOUR_DOMAIN/login/oauth2/code/google
+```
+
+Configure `.env.prod`:
+
+```text
+OAUTH2_SUCCESS_REDIRECT_URI=https://YOUR_DOMAIN/oauth2/success
+CORS_ALLOWED_ORIGINS=https://YOUR_DOMAIN
+REFRESH_TOKEN_COOKIE_SECURE=true
+REFRESH_TOKEN_COOKIE_SAME_SITE=Lax
+```
+
+## Object Storage URL Policy
+
+For the in-compose MinIO MVP:
+
+```text
+MINIO_ENDPOINT=http://minio:9000
+MINIO_PUBLIC_ENDPOINT=https://YOUR_DOMAIN
+MINIO_BUCKET=image-preprocess-prod
+```
+
+The frontend receives presigned URLs using the public endpoint. NGINX proxies this bucket prefix:
+
+```text
+/image-preprocess-prod/
+```
+
+If the bucket name changes, update:
+
+```text
+infra/nginx/conf.d/app.conf
+```
+
+## Public Port Policy
+
+Only one public entry point should be open:
+
+| Port | Public? | Reason |
+| --- | --- | --- |
+| `80` or `443` | Yes | NGINX or TLS terminator |
+| `8080` backend-api | No | Routed through NGINX |
+| `5432` PostgreSQL | No | Internal only |
+| `5672` RabbitMQ AMQP | No | Internal only |
+| `15672` RabbitMQ Management | No | SSH tunnel only |
+| `9000` MinIO API | No | Bucket path routed through NGINX |
+| `9001` MinIO Console | No | SSH tunnel only |
+
+## Swagger Policy
+
+The current MVP leaves:
+
+```text
+/swagger-ui/
+/v3/api-docs
+```
+
+reachable through NGINX. Before public production, choose one:
+
+1. Leave it open for MVP demo only.
+2. Restrict by IP at the load balancer/firewall.
+3. Add Basic Auth or disable the NGINX routes.
+
+For a student/demo MVP, option 1 is acceptable only if no real user data is uploaded.

--- a/docs/operation/production-env.md
+++ b/docs/operation/production-env.md
@@ -140,10 +140,8 @@ docker compose `
 
 ## Current MVP Limitations
 
-- `docker-compose.local.yml` is still the only Compose file. A separate production override should be added before a
-  real public deployment.
-- Direct service ports are still declared for local convenience. In production, firewall everything except HTTP/HTTPS
-  unless a service must be reachable for operations.
+- `docker-compose.prod.yml` is an MVP production override. It limits published service ports and adds restart policies,
+  but it does not implement TLS certificates inside the NGINX container.
 - HTTPS termination is not implemented in this Compose file. Put a TLS proxy or cloud load balancer in front of NGINX,
   or add a production NGINX/TLS task.
 - `JPA_DDL_AUTO=update` is acceptable for MVP rehearsal. Move to migrations and `validate` for durable production data.

--- a/infra/docker-compose/docker-compose.prod.yml
+++ b/infra/docker-compose/docker-compose.prod.yml
@@ -1,0 +1,30 @@
+services:
+  nginx:
+    restart: unless-stopped
+    ports:
+      - "${NGINX_HTTP_PORT:-80}:80"
+
+  frontend:
+    restart: unless-stopped
+
+  backend-api:
+    restart: unless-stopped
+    ports: !reset []
+
+  preprocess-worker:
+    restart: unless-stopped
+
+  postgres:
+    restart: unless-stopped
+    ports: !reset []
+
+  rabbitmq:
+    restart: unless-stopped
+    ports: !reset []
+
+  minio:
+    restart: unless-stopped
+    ports: !reset []
+
+  minio-bucket-init:
+    restart: "no"


### PR DESCRIPTION
## #️⃣ 기능 설명

Production Compose override, GitHub Actions 기반 SSH 배포 workflow, HTTPS/도메인 정책, 백업/복구, 최종 E2E 검증 절차를 추가합니다.

Closes #114

## 🛠️ 작업 상세 내용

- [x] `infra/docker-compose/docker-compose.prod.yml` 추가
- [x] production override에서 NGINX만 외부 공개하고 backend/PostgreSQL/RabbitMQ/MinIO 직접 포트 reset
- [x] `.github/workflows/deploy-production.yml` 추가
- [x] GitHub Actions secrets, 서버 사전 준비, 배포 흐름 문서화
- [x] HTTPS/도메인/OAuth redirect 정책 문서화
- [x] PostgreSQL/MinIO backup & restore 절차 문서화
- [x] 최종 local/production E2E 검증 순서 문서화

## 📁 변경 파일 요약

- `.github/workflows/deploy-production.yml`
- `infra/docker-compose/docker-compose.prod.yml`
- `docs/operation/github-actions-deployment.md`
- `docs/operation/https-domain-policy.md`
- `docs/operation/backup-restore.md`
- `docs/operation/final-e2e-verification.md`
- `docs/operation/deployment-checklist.md`
- `docs/operation/production-env.md`
- `docs/feature-specs/issue-114-production-compose-github-actions-deploy.md`

## ✅ 검증 내용

- [x] `git diff --check`
- [x] `docker compose -f infra/docker-compose/docker-compose.local.yml -f infra/docker-compose/docker-compose.prod.yml --env-file infra/docker-compose/.env.prod.example config`
- [x] `docker compose -f infra/docker-compose/docker-compose.local.yml -f infra/docker-compose/docker-compose.prod.yml --env-file infra/docker-compose/.env.example config`
- [x] `node`로 workflow 파일 필수 토큰 확인
- [x] `docker exec image-preprocess-nginx nginx -t`

## 🔎 리뷰어가 확인해야 할 부분

- GitHub Actions 배포 방식이 서버의 `/opt/image-preprocess/shared/.env.prod`를 진실 소스로 두는 정책과 맞는지 확인해주세요.
- production override의 `ports: !reset []` 사용을 서버 Docker Compose 버전에서 지원하는지 확인해주세요.
- HTTPS는 compose 내부 TLS가 아니라 Cloudflare/LB/host proxy 종료를 권장하는 정책입니다.

## 📸 스크린샷

없음

## 💬 기타 공유사항 to 리뷰어

- 실제 GitHub Actions 배포는 secrets 등록과 서버 준비 후 실행해야 합니다.
- OAuth 로그인 자동화는 하지 않고, 배포 후 수동 authenticated E2E smoke를 문서화했습니다.