### PR TITLE
✨ [Feat] Worker 전처리 품질 파라미터 튜닝

### DIFF
--- a/backend-api/src/main/java/com/moonju/preprocess/api/domain/preprocess/service/PreprocessPresetRegistry.java
+++ b/backend-api/src/main/java/com/moonju/preprocess/api/domain/preprocess/service/PreprocessPresetRegistry.java
@@ -63,7 +63,7 @@ public class PreprocessPresetRegistry {
             "General A4 document scan preset for OCR preprocessing.",
             true,
             DOCUMENT_PIPELINE_STEPS,
-            commonParameters(300, "otsu", 1.2, false)
+            commonParameters(300, "otsu", 2.0, "median", false)
         ));
         register(new PreprocessPreset(
             PreprocessPresetName.LOW_CONTRAST_SCAN,
@@ -72,7 +72,7 @@ public class PreprocessPresetRegistry {
             "Improves low contrast scans using stronger contrast normalization before binarization.",
             true,
             DOCUMENT_PIPELINE_STEPS,
-            commonParameters(300, "adaptive", 1.6, true)
+            commonParameters(300, "adaptive", 2.4, "median", true)
         ));
         register(new PreprocessPreset(
             PreprocessPresetName.RECEIPT,
@@ -81,7 +81,7 @@ public class PreprocessPresetRegistry {
             "Narrow receipt-like document preset with adaptive thresholding and light morphology cleanup.",
             true,
             DOCUMENT_PIPELINE_STEPS,
-            commonParameters(300, "adaptive", 1.4, true)
+            commonParameters(300, "adaptive", 2.2, "median", true)
         ));
         register(new PreprocessPreset(
             PreprocessPresetName.NOISY_SCAN,
@@ -90,7 +90,7 @@ public class PreprocessPresetRegistry {
             "Preset for scans with strong background noise and more aggressive denoise settings.",
             true,
             DOCUMENT_PIPELINE_STEPS,
-            commonParameters(300, "adaptive", 1.5, false)
+            commonParameters(300, "adaptive", 2.0, "bilateral", false)
         ));
         register(new PreprocessPreset(
             PreprocessPresetName.AUTO,
@@ -115,6 +115,7 @@ public class PreprocessPresetRegistry {
         int targetDpi,
         String binarizationMode,
         double contrastClipLimit,
+        String denoiseMode,
         boolean sharpen
     ) {
         return List.of(
@@ -141,6 +142,22 @@ public class PreprocessPresetRegistry {
                 binarizationMode,
                 Set.of("otsu", "adaptive")
             ),
+            PresetParameterDefinition.integer(
+                "adaptiveBlockSize",
+                "Odd block size for adaptive thresholding.",
+                true,
+                21,
+                3,
+                99
+            ),
+            PresetParameterDefinition.decimal(
+                "adaptiveC",
+                "Constant subtracted from the adaptive threshold mean.",
+                true,
+                5.0,
+                -20.0,
+                20.0
+            ),
             PresetParameterDefinition.decimal(
                 "contrastClipLimit",
                 "CLAHE-like contrast normalization strength.",
@@ -149,10 +166,88 @@ public class PreprocessPresetRegistry {
                 1.0,
                 4.0
             ),
+            PresetParameterDefinition.integer(
+                "contrastTileGridSize",
+                "CLAHE tile grid size.",
+                true,
+                8,
+                1,
+                32
+            ),
+            PresetParameterDefinition.option(
+                "denoiseMode",
+                "Denoise strategy used by the worker.",
+                true,
+                denoiseMode,
+                Set.of("median", "bilateral", "none", "off", "false")
+            ),
+            PresetParameterDefinition.integer(
+                "denoiseKernelSize",
+                "Median blur kernel size.",
+                true,
+                3,
+                3,
+                15
+            ),
+            PresetParameterDefinition.integer(
+                "denoiseDiameter",
+                "Bilateral filter neighborhood diameter.",
+                true,
+                5,
+                3,
+                15
+            ),
+            PresetParameterDefinition.decimal(
+                "denoiseSigmaColor",
+                "Bilateral filter color sigma. Lower values preserve text edges.",
+                true,
+                25.0,
+                0.1,
+                200.0
+            ),
+            PresetParameterDefinition.decimal(
+                "denoiseSigmaRange",
+                "Bilateral filter spatial sigma range.",
+                true,
+                75.0,
+                0.1,
+                200.0
+            ),
+            PresetParameterDefinition.option(
+                "morphologyMode",
+                "Morphology cleanup strategy.",
+                true,
+                "open_close",
+                Set.of("open", "close", "open_close", "none", "off", "false")
+            ),
+            PresetParameterDefinition.integer(
+                "morphologyKernelSize",
+                "Morphology cleanup kernel size.",
+                true,
+                2,
+                1,
+                7
+            ),
             PresetParameterDefinition.bool(
                 "sharpen",
                 "Whether optional sharpen step should run after DPI normalization.",
                 sharpen
+            ),
+            PresetParameterDefinition.decimal(
+                "sharpenAmount",
+                "Unsharp mask weight for optional sharpen.",
+                true,
+                0.8,
+                0.1,
+                3.0
+            ),
+            PresetParameterDefinition.decimal(
+                "sharpenSigma",
+                "Gaussian blur sigma for optional sharpen.",
+                true,
+                1.5,
+                0.1,
+                10.0
             ),
             PresetParameterDefinition.bool(
                 "debugArtifacts",

--- a/backend-api/src/test/java/com/moonju/preprocess/api/domain/preprocess/service/PreprocessParameterValidatorTests.java
+++ b/backend-api/src/test/java/com/moonju/preprocess/api/domain/preprocess/service/PreprocessParameterValidatorTests.java
@@ -22,6 +22,16 @@ class PreprocessParameterValidatorTests {
         assertThat(response.resolvedParameters())
             .containsEntry("targetDpi", "300")
             .containsEntry("binarizationMode", "otsu")
+            .containsEntry("adaptiveBlockSize", "21")
+            .containsEntry("adaptiveC", "5.0")
+            .containsEntry("contrastClipLimit", "2.0")
+            .containsEntry("denoiseMode", "median")
+            .containsEntry("denoiseSigmaColor", "25.0")
+            .containsEntry("denoiseSigmaRange", "75.0")
+            .containsEntry("morphologyMode", "open_close")
+            .containsEntry("morphologyKernelSize", "2")
+            .containsEntry("sharpenAmount", "0.8")
+            .containsEntry("sharpenSigma", "1.5")
             .containsEntry("debugArtifacts", "false");
     }
 

--- a/backend-api/src/test/java/com/moonju/preprocess/api/domain/preprocess/service/PreprocessPresetRegistryTests.java
+++ b/backend-api/src/test/java/com/moonju/preprocess/api/domain/preprocess/service/PreprocessPresetRegistryTests.java
@@ -35,4 +35,21 @@ class PreprocessPresetRegistryTests {
         assertThatThrownBy(() -> registry.findByName("resize_only"))
             .isInstanceOf(PresetNotFoundException.class);
     }
+
+    @Test
+    void exposesWorkerQualityParameters() {
+        assertThat(registry.findByName("NOISY_SCAN").getParameters())
+            .extracting(parameter -> parameter.name())
+            .contains(
+                "adaptiveBlockSize",
+                "adaptiveC",
+                "denoiseMode",
+                "denoiseSigmaColor",
+                "denoiseSigmaRange",
+                "morphologyMode",
+                "morphologyKernelSize",
+                "sharpenAmount",
+                "sharpenSigma"
+            );
+    }
 }

--- a/docs/api/preprocess-preset-api.md
+++ b/docs/api/preprocess-preset-api.md
@@ -1,40 +1,40 @@
 # Preprocess Preset API
 
-## Purpose
+## 목적
 
-Preprocess Preset API exposes the preprocessing parameter contract shared by the API server, Job creation flow, and
-Worker. The API server validates preset names and parameters, but it does not execute OpenCV image preprocessing.
+Preprocess Preset API는 backend-api, Job 생성 흐름, Worker가 공유하는 전처리 파라미터 계약을 제공합니다.
+API 서버는 프리셋 이름과 파라미터 범위를 검증하지만 OpenCV 이미지 전처리를 직접 수행하지 않습니다.
 
-## Rules
+## 규칙
 
-- Built-in preset names must match Worker preset names.
-- API server validates parameter shape and range before a Job is created.
-- API server must not perform document preprocessing directly.
-- Presets describe OCR-oriented document preprocessing, not simple thumbnail resizing.
-- Custom presets are user-owned skeleton records derived from a built-in preset.
+- built-in preset 이름은 Worker preset 이름과 정확히 일치해야 합니다.
+- API 서버는 Job 생성 전에 파라미터 형태와 범위를 검증합니다.
+- API 서버는 문서 이미지 전처리를 직접 수행하지 않습니다.
+- 프리셋은 단순 썸네일 resize가 아니라 OCR용 문서 전처리 파이프라인을 설명합니다.
+- custom preset은 built-in preset에서 파생되는 사용자 소유 skeleton record입니다.
 
-## Built-In Presets
+## Built-in preset
 
-| Name | Purpose |
+| 이름 | 용도 |
 | --- | --- |
-| `A4_SCAN_300DPI` | General A4 document scan preset |
-| `LOW_CONTRAST_SCAN` | Low contrast scan preset with stronger contrast normalization |
-| `RECEIPT` | Narrow receipt-like document preset |
-| `NOISY_SCAN` | Strong background noise scan preset |
-| `AUTO` | Worker-side preset selection based on image characteristics |
+| `A4_SCAN_300DPI` | 일반 A4 문서 스캔 |
+| `LOW_CONTRAST_SCAN` | 저대비 문서 |
+| `RECEIPT` | 영수증처럼 폭이 좁은 문서 |
+| `NOISY_SCAN` | 배경 노이즈가 강한 문서 |
+| `AUTO` | Worker가 이미지 특성에 따라 프리셋 선택 |
 
-## Endpoints
+## Endpoint
 
-| Method | Path | Purpose |
+| Method | Path | 설명 |
 | --- | --- | --- |
-| `GET` | `/api/v1/preprocess/presets` | List built-in presets |
-| `GET` | `/api/v1/preprocess/presets/{presetName}` | Read built-in preset detail |
-| `POST` | `/api/v1/preprocess/presets/validate` | Validate preset parameters |
-| `POST` | `/api/v1/preprocess/presets/custom` | Create custom preset |
-| `GET` | `/api/v1/preprocess/presets/custom` | List my custom presets |
-| `DELETE` | `/api/v1/preprocess/presets/custom/{presetId}` | Delete my custom preset |
+| `GET` | `/api/v1/preprocess/presets` | built-in preset 목록 |
+| `GET` | `/api/v1/preprocess/presets/{presetName}` | built-in preset 상세 |
+| `POST` | `/api/v1/preprocess/presets/validate` | preset 파라미터 검증 |
+| `POST` | `/api/v1/preprocess/presets/custom` | custom preset 생성 |
+| `GET` | `/api/v1/preprocess/presets/custom` | 내 custom preset 목록 |
+| `DELETE` | `/api/v1/preprocess/presets/custom/{presetId}` | custom preset 삭제 |
 
-## List Built-In Presets
+## built-in preset 목록
 
 Response:
 
@@ -55,7 +55,7 @@ Response:
 }
 ```
 
-## Preset Detail
+## preset 상세
 
 Response:
 
@@ -85,12 +85,12 @@ Response:
     ],
     "parameters": [
       {
-        "name": "targetDpi",
-        "type": "INTEGER",
+        "name": "contrastClipLimit",
+        "type": "DECIMAL",
         "required": true,
-        "defaultValue": "300",
-        "minValue": "150",
-        "maxValue": "600",
+        "defaultValue": "2.4",
+        "minValue": "1.0",
+        "maxValue": "4.0",
         "allowedValues": []
       }
     ]
@@ -98,7 +98,7 @@ Response:
 }
 ```
 
-## Validate Parameters
+## 파라미터 검증
 
 Request:
 
@@ -108,6 +108,8 @@ Request:
   "parameters": {
     "targetDpi": "300",
     "binarizationMode": "otsu",
+    "contrastClipLimit": "2.0",
+    "denoiseMode": "median",
     "debugArtifacts": "false"
   }
 }
@@ -128,18 +130,29 @@ Response:
       "targetDpi": "300",
       "maxDeskewAngle": "40.0",
       "binarizationMode": "otsu",
-      "contrastClipLimit": "1.2",
+      "adaptiveBlockSize": "21",
+      "adaptiveC": "5.0",
+      "contrastClipLimit": "2.0",
+      "contrastTileGridSize": "8",
+      "denoiseMode": "median",
+      "denoiseKernelSize": "3",
+      "denoiseDiameter": "5",
+      "denoiseSigmaColor": "25.0",
+      "denoiseSigmaRange": "75.0",
+      "morphologyMode": "open_close",
+      "morphologyKernelSize": "2",
       "sharpen": "false",
+      "sharpenAmount": "0.8",
+      "sharpenSigma": "1.5",
       "debugArtifacts": "false"
     }
   }
 }
 ```
 
-Invalid parameter values return `valid=false` with error messages in `result.errors`; unknown preset names return a
-normal API error response.
+잘못된 파라미터 값은 `valid=false`와 `result.errors`로 반환합니다. 알 수 없는 preset 이름은 일반 API 오류 응답을 반환합니다.
 
-## Custom Presets
+## custom preset
 
 Create request:
 
@@ -150,16 +163,17 @@ Create request:
   "basePresetName": "LOW_CONTRAST_SCAN",
   "parameters": {
     "targetDpi": "300",
-    "contrastClipLimit": "1.8"
+    "contrastClipLimit": "2.4",
+    "adaptiveBlockSize": "21",
+    "adaptiveC": "5.0"
   }
 }
 ```
 
-Custom presets are currently a backend skeleton. Job creation and Worker execution will connect custom presets in a
-later task.
+custom preset은 현재 backend skeleton입니다. Job 생성과 Worker 실행 연결은 후속 작업에서 처리합니다.
 
-## Next Work
+## 다음 작업
 
-- Connect Job creation to preset validation.
-- Add Worker internal preset lookup endpoint.
-- Connect Worker preset registry to this API contract.
+- Job 생성 시 preset validation 연결 상태를 계속 유지합니다.
+- Worker internal preset lookup endpoint가 필요하면 별도 이슈에서 추가합니다.
+- Worker preset registry와 API contract가 다른 값으로 갈라지지 않도록 테스트를 유지합니다.

--- a/docs/feature-specs/issue-118-worker-preprocess-quality-parameter-tuning.md
+++ b/docs/feature-specs/issue-118-worker-preprocess-quality-parameter-tuning.md
@@ -1,0 +1,47 @@
+# Issue 118. Worker 전처리 품질 파라미터 튜닝
+
+## 목적
+
+문서 OCR 전처리 품질을 높이기 위해 Worker의 품질 관련 기본 파라미터를 조정한다.  
+API 서버는 전처리를 직접 수행하지 않고, preset validation contract만 Worker와 맞춘다.
+
+## 변경 파라미터
+
+| 대상 | 이전 값 | 변경 값 |
+| --- | --- | --- |
+| `BinarizationStep.DEFAULT_ADAPTIVE_BLOCK_SIZE` | `31` | `21` |
+| `BinarizationStep.DEFAULT_ADAPTIVE_C` | `7.0` | `5.0` |
+| `ContrastNormalizeStep.DEFAULT_CLIP_LIMIT` | `1.2` | `2.0` |
+| `SharpenStep.DEFAULT_SHARPEN_AMOUNT` | `0.6` | `0.8` |
+| `SharpenStep.DEFAULT_SHARPEN_SIGMA` | `1.0` | `1.5` |
+| `DenoiseStep` bilateral sigmaColor | `75.0` | `25.0` |
+| `DenoiseStep` bilateral sigmaRange | 고정 `75.0` | `denoiseSigmaRange` 파라미터로 노출 |
+
+## 추가 파라미터
+
+| 파라미터 | 기본값 | 설명 |
+| --- | --- | --- |
+| `denoiseSigmaColor` | `25.0` | bilateral filter color sigma |
+| `denoiseSigmaRange` | `75.0` | bilateral filter spatial sigma |
+| `adaptiveBlockSize` | `21` | adaptive threshold block size |
+| `adaptiveC` | `5.0` | adaptive threshold C |
+| `morphologyMode` | `open_close` | morphology cleanup strategy |
+| `morphologyKernelSize` | `2` | morphology kernel size |
+| `sharpenAmount` | `0.8` | unsharp mask amount |
+| `sharpenSigma` | `1.5` | unsharp mask sigma |
+
+## 프리셋 기본값
+
+| 프리셋 | contrastClipLimit | denoiseMode | morphologyMode | sharpen |
+| --- | --- | --- | --- | --- |
+| `A4_SCAN_300DPI` | `2.0` | `median` | `open_close` | `false` |
+| `LOW_CONTRAST_SCAN` | `2.4` | `median` | `open_close` | `true` |
+| `RECEIPT` | `2.2` | `median` | `open_close` | `true` |
+| `NOISY_SCAN` | `2.0` | `bilateral` | `open_close` | `false` |
+
+## 검증 기준
+
+- Worker step 테스트가 기본값 변경을 확인한다.
+- Worker preset registry 테스트가 모든 built-in preset의 품질 파라미터를 확인한다.
+- backend-api preset validation 테스트가 새 파라미터 기본값을 확인한다.
+- `docs/worker/preset-spec.md`와 `docs/api/preprocess-preset-api.md`가 같은 contract를 설명한다.

--- a/docs/worker/preset-spec.md
+++ b/docs/worker/preset-spec.md
@@ -1,23 +1,21 @@
-# Worker Preset Spec
+# Worker 프리셋 명세
 
-## Purpose
+이 문서는 backend-api와 preprocess-worker가 공유하는 전처리 프리셋 이름과 파라미터 계약을 정의합니다.
+API 서버는 프리셋 이름과 파라미터 범위를 검증하고, 실제 OpenCV 문서 전처리는 Worker가 수행합니다.
 
-This document defines the preset names and parameter contract that the Worker must support. The backend API validates
-these names and parameter ranges before publishing preprocessing jobs.
+## 지원 프리셋
 
-## Required Preset Names
+| 프리셋 | 용도 |
+| --- | --- |
+| `A4_SCAN_300DPI` | 일반 A4 300 DPI 스캔 문서 |
+| `LOW_CONTRAST_SCAN` | 저대비 문서 |
+| `RECEIPT` | 영수증처럼 폭이 좁은 문서 |
+| `NOISY_SCAN` | 배경 노이즈가 강한 문서 |
+| `AUTO` | Worker가 이미지 특성에 따라 프리셋 선택 |
 
-Worker preset names must exactly match backend names:
+## 처리 단계
 
-- `A4_SCAN_300DPI`
-- `LOW_CONTRAST_SCAN`
-- `RECEIPT`
-- `NOISY_SCAN`
-- `AUTO`
-
-## Required Pipeline Steps
-
-Except `AUTO`, built-in document presets describe the following OCR-oriented processing sequence:
+`AUTO`를 제외한 기본 문서 프리셋은 아래 순서를 따릅니다.
 
 1. `DECODE`
 2. `COLOR_NORMALIZE`
@@ -31,41 +29,57 @@ Except `AUTO`, built-in document presets describe the following OCR-oriented pro
 10. `DPI_NORMALIZE`
 11. `OPTIONAL_SHARPEN`
 
-These steps are not a simple resize pipeline. `DPI_NORMALIZE` is for OCR-oriented DPI normalization and must not be
-implemented as a thumbnail resize shortcut.
+이 파이프라인은 단순 resize가 아닙니다. `DPI_NORMALIZE`는 OCR 품질을 맞추기 위한 DPI 정규화 단계입니다.
 
-## Common Parameters
+## 공통 파라미터
 
-| Parameter | Type | Range/Values | Meaning |
+| 파라미터 | 타입 | 기본값 | 설명 |
 | --- | --- | --- | --- |
-| `targetDpi` | integer | `150` to `600` | Target DPI for OCR normalization |
-| `maxDeskewAngle` | decimal | `0.0` to `45.0` | Maximum allowed deskew angle |
-| `binarizationMode` | enum | `otsu`, `adaptive` | Binarization strategy |
-| `contrastClipLimit` | decimal | `1.0` to `4.0` | Contrast normalization strength |
-| `sharpen` | boolean | `true`, `false` | Whether optional sharpen step should run |
-| `debugArtifacts` | boolean | `true`, `false` | Whether to save intermediate debug images |
+| `targetDpi` | integer | `300` | OCR용 목표 DPI |
+| `maxDeskewAngle` | decimal | `40.0` | 허용할 최대 deskew 각도 |
+| `binarizationMode` | enum | 프리셋별 | `otsu`, `adaptive` |
+| `adaptiveBlockSize` | integer | `21` | adaptive threshold block size. 홀수로 보정됨 |
+| `adaptiveC` | decimal | `5.0` | adaptive threshold 평균에서 뺄 C 값 |
+| `contrastClipLimit` | decimal | 프리셋별 | CLAHE clip limit |
+| `contrastTileGridSize` | integer | `8` | CLAHE tile grid size |
+| `denoiseMode` | enum | 프리셋별 | `median`, `bilateral`, `none`, `off`, `false` |
+| `denoiseKernelSize` | integer | `3` | median blur kernel size |
+| `denoiseDiameter` | integer | `5` | bilateral filter diameter |
+| `denoiseSigmaColor` | decimal | `25.0` | bilateral filter color sigma. 텍스트 경계 보존을 위해 낮춤 |
+| `denoiseSigmaRange` | decimal | `75.0` | bilateral filter spatial sigma range |
+| `morphologyMode` | enum | `open_close` | `open`, `close`, `open_close`, `none`, `off`, `false` |
+| `morphologyKernelSize` | integer | `2` | morphology kernel size |
+| `sharpen` | boolean | 프리셋별 | optional sharpen 실행 여부 |
+| `sharpenAmount` | decimal | `0.8` | unsharp mask weight |
+| `sharpenSigma` | decimal | `1.5` | unsharp mask Gaussian sigma |
+| `debugArtifacts` | boolean | `false` | 단계별 debug artifact 저장 여부 |
 
-## Preset Defaults
+## 이번 튜닝 기준
 
-| Preset | targetDpi | binarizationMode | contrastClipLimit | sharpen |
-| --- | --- | --- | --- | --- |
-| `A4_SCAN_300DPI` | `300` | `otsu` | `1.2` | `false` |
-| `LOW_CONTRAST_SCAN` | `300` | `adaptive` | `1.6` | `true` |
-| `RECEIPT` | `300` | `adaptive` | `1.4` | `true` |
-| `NOISY_SCAN` | `300` | `adaptive` | `1.5` | `false` |
+| 항목 | 이전 값 | 변경 값 | 의도 |
+| --- | --- | --- | --- |
+| `adaptiveBlockSize` | `31` | `21` | 지역 threshold가 더 작은 글자 영역에 반응하도록 조정 |
+| `adaptiveC` | `7.0` | `5.0` | 얇은 획 손실을 줄이기 위해 threshold offset 완화 |
+| `contrastClipLimit` 기본값 | `1.2` | `2.0` | 저대비 문서 대비 개선 강화 |
+| `sharpenAmount` | `0.6` | `0.8` | OCR 전 획 선명도 강화 |
+| `sharpenSigma` | `1.0` | `1.5` | 노이즈보다 문자 획 중심으로 sharpening 조정 |
+| `denoiseSigmaColor` | `75.0` | `25.0` | bilateral denoise에서 텍스트 경계 보존 |
 
-`AUTO` supports `debugArtifacts` and delegates final preset selection to the Worker based on image characteristics.
+## 프리셋 기본값
 
-## Backend Contract
+| 프리셋 | binarizationMode | contrastClipLimit | denoiseMode | morphologyMode | sharpen |
+| --- | --- | --- | --- | --- | --- |
+| `A4_SCAN_300DPI` | `otsu` | `2.0` | `median` | `open_close` | `false` |
+| `LOW_CONTRAST_SCAN` | `adaptive` | `2.4` | `median` | `open_close` | `true` |
+| `RECEIPT` | `adaptive` | `2.2` | `median` | `open_close` | `true` |
+| `NOISY_SCAN` | `adaptive` | `2.0` | `bilateral` | `open_close` | `false` |
 
-- Backend exposes preset list/detail through `/api/v1/preprocess/presets`.
-- Backend validates parameters through `/api/v1/preprocess/presets/validate`.
-- Backend does not execute OpenCV processing.
-- Worker must reject messages with unknown preset names or invalid parameter payloads.
+모든 built-in preset은 `adaptiveBlockSize=21`, `adaptiveC=5.0`, `denoiseSigmaColor=25.0`,
+`denoiseSigmaRange=75.0`, `morphologyKernelSize=2`, `sharpenAmount=0.8`, `sharpenSigma=1.5`를 포함합니다.
 
-## Future Worker Work
+## Backend 계약
 
-- Replace Worker-side `PreprocessPresetRegistry` skeleton with image-test-backed runtime behavior.
-- Map backend preset parameters to real OpenCV step parameters.
-- Add `AutoPresetSelector` based on image characteristics.
-- Add Worker tests that compare supported preset names with backend documentation.
+- backend-api는 `/api/v1/preprocess/presets`에서 프리셋 목록과 파라미터를 노출합니다.
+- backend-api는 Job 생성 전 파라미터 이름과 범위를 검증합니다.
+- backend-api는 OpenCV 전처리를 직접 수행하지 않습니다.
+- Worker는 알 수 없는 프리셋 이름이나 잘못된 파라미터 payload를 거부해야 합니다.

--- a/preprocess-worker/src/main/java/com/moonju/preprocess/worker/domain/preprocess/preset/A4Scan300DpiPreset.java
+++ b/preprocess-worker/src/main/java/com/moonju/preprocess/worker/domain/preprocess/preset/A4Scan300DpiPreset.java
@@ -1,5 +1,7 @@
 package com.moonju.preprocess.worker.domain.preprocess.preset;
 
+import static java.util.Map.entry;
+
 import java.util.Map;
 import org.springframework.stereotype.Component;
 
@@ -13,11 +15,23 @@ public class A4Scan300DpiPreset implements PreprocessPresetDefinition {
             "A4 300 DPI scan",
             "General A4 document scan preset for OCR preprocessing.",
             DocumentStepSequence.standard(),
-            Map.of(
-                "targetDpi", "300",
-                "binarizationMode", "otsu",
-                "contrastClipLimit", "1.2",
-                "sharpen", "false"
+            Map.ofEntries(
+                entry("targetDpi", "300"),
+                entry("binarizationMode", "otsu"),
+                entry("adaptiveBlockSize", "21"),
+                entry("adaptiveC", "5.0"),
+                entry("contrastClipLimit", "2.0"),
+                entry("contrastTileGridSize", "8"),
+                entry("denoiseMode", "median"),
+                entry("denoiseKernelSize", "3"),
+                entry("denoiseDiameter", "5"),
+                entry("denoiseSigmaColor", "25.0"),
+                entry("denoiseSigmaRange", "75.0"),
+                entry("morphologyMode", "open_close"),
+                entry("morphologyKernelSize", "2"),
+                entry("sharpen", "false"),
+                entry("sharpenAmount", "0.8"),
+                entry("sharpenSigma", "1.5")
             )
         );
     }

--- a/preprocess-worker/src/main/java/com/moonju/preprocess/worker/domain/preprocess/preset/LowContrastScanPreset.java
+++ b/preprocess-worker/src/main/java/com/moonju/preprocess/worker/domain/preprocess/preset/LowContrastScanPreset.java
@@ -1,5 +1,7 @@
 package com.moonju.preprocess.worker.domain.preprocess.preset;
 
+import static java.util.Map.entry;
+
 import java.util.Map;
 import org.springframework.stereotype.Component;
 
@@ -13,11 +15,23 @@ public class LowContrastScanPreset implements PreprocessPresetDefinition {
             "Low contrast scan",
             "Low contrast document preset with stronger contrast normalization.",
             DocumentStepSequence.standard(),
-            Map.of(
-                "targetDpi", "300",
-                "binarizationMode", "adaptive",
-                "contrastClipLimit", "1.6",
-                "sharpen", "true"
+            Map.ofEntries(
+                entry("targetDpi", "300"),
+                entry("binarizationMode", "adaptive"),
+                entry("adaptiveBlockSize", "21"),
+                entry("adaptiveC", "5.0"),
+                entry("contrastClipLimit", "2.4"),
+                entry("contrastTileGridSize", "8"),
+                entry("denoiseMode", "median"),
+                entry("denoiseKernelSize", "3"),
+                entry("denoiseDiameter", "5"),
+                entry("denoiseSigmaColor", "25.0"),
+                entry("denoiseSigmaRange", "75.0"),
+                entry("morphologyMode", "open_close"),
+                entry("morphologyKernelSize", "2"),
+                entry("sharpen", "true"),
+                entry("sharpenAmount", "0.8"),
+                entry("sharpenSigma", "1.5")
             )
         );
     }

--- a/preprocess-worker/src/main/java/com/moonju/preprocess/worker/domain/preprocess/preset/NoisyScanPreset.java
+++ b/preprocess-worker/src/main/java/com/moonju/preprocess/worker/domain/preprocess/preset/NoisyScanPreset.java
@@ -1,5 +1,7 @@
 package com.moonju.preprocess.worker.domain.preprocess.preset;
 
+import static java.util.Map.entry;
+
 import java.util.Map;
 import org.springframework.stereotype.Component;
 
@@ -13,11 +15,23 @@ public class NoisyScanPreset implements PreprocessPresetDefinition {
             "Noisy scan",
             "Document preset reserved for strong background noise cases.",
             DocumentStepSequence.standard(),
-            Map.of(
-                "targetDpi", "300",
-                "binarizationMode", "adaptive",
-                "contrastClipLimit", "1.5",
-                "sharpen", "false"
+            Map.ofEntries(
+                entry("targetDpi", "300"),
+                entry("binarizationMode", "adaptive"),
+                entry("adaptiveBlockSize", "21"),
+                entry("adaptiveC", "5.0"),
+                entry("contrastClipLimit", "2.0"),
+                entry("contrastTileGridSize", "8"),
+                entry("denoiseMode", "bilateral"),
+                entry("denoiseKernelSize", "3"),
+                entry("denoiseDiameter", "5"),
+                entry("denoiseSigmaColor", "25.0"),
+                entry("denoiseSigmaRange", "75.0"),
+                entry("morphologyMode", "open_close"),
+                entry("morphologyKernelSize", "2"),
+                entry("sharpen", "false"),
+                entry("sharpenAmount", "0.8"),
+                entry("sharpenSigma", "1.5")
             )
         );
     }

--- a/preprocess-worker/src/main/java/com/moonju/preprocess/worker/domain/preprocess/preset/ReceiptPreset.java
+++ b/preprocess-worker/src/main/java/com/moonju/preprocess/worker/domain/preprocess/preset/ReceiptPreset.java
@@ -1,5 +1,7 @@
 package com.moonju.preprocess.worker.domain.preprocess.preset;
 
+import static java.util.Map.entry;
+
 import java.util.Map;
 import org.springframework.stereotype.Component;
 
@@ -13,11 +15,23 @@ public class ReceiptPreset implements PreprocessPresetDefinition {
             "Receipt",
             "Narrow receipt-like document preset.",
             DocumentStepSequence.standard(),
-            Map.of(
-                "targetDpi", "300",
-                "binarizationMode", "adaptive",
-                "contrastClipLimit", "1.4",
-                "sharpen", "true"
+            Map.ofEntries(
+                entry("targetDpi", "300"),
+                entry("binarizationMode", "adaptive"),
+                entry("adaptiveBlockSize", "21"),
+                entry("adaptiveC", "5.0"),
+                entry("contrastClipLimit", "2.2"),
+                entry("contrastTileGridSize", "8"),
+                entry("denoiseMode", "median"),
+                entry("denoiseKernelSize", "3"),
+                entry("denoiseDiameter", "5"),
+                entry("denoiseSigmaColor", "25.0"),
+                entry("denoiseSigmaRange", "75.0"),
+                entry("morphologyMode", "open_close"),
+                entry("morphologyKernelSize", "2"),
+                entry("sharpen", "true"),
+                entry("sharpenAmount", "0.8"),
+                entry("sharpenSigma", "1.5")
             )
         );
     }

--- a/preprocess-worker/src/main/java/com/moonju/preprocess/worker/domain/preprocess/step/BinarizationStep.java
+++ b/preprocess-worker/src/main/java/com/moonju/preprocess/worker/domain/preprocess/step/BinarizationStep.java
@@ -10,8 +10,8 @@ import org.springframework.stereotype.Component;
 @Component
 public class BinarizationStep implements PreprocessStep {
 
-    private static final int DEFAULT_ADAPTIVE_BLOCK_SIZE = 31;
-    private static final double DEFAULT_ADAPTIVE_C = 7.0;
+    private static final int DEFAULT_ADAPTIVE_BLOCK_SIZE = 21;
+    private static final double DEFAULT_ADAPTIVE_C = 5.0;
 
     @Override
     public PreprocessStepName name() {

--- a/preprocess-worker/src/main/java/com/moonju/preprocess/worker/domain/preprocess/step/ContrastNormalizeStep.java
+++ b/preprocess-worker/src/main/java/com/moonju/preprocess/worker/domain/preprocess/step/ContrastNormalizeStep.java
@@ -14,7 +14,7 @@ import org.springframework.stereotype.Component;
 @Component
 public class ContrastNormalizeStep implements PreprocessStep {
 
-    private static final double DEFAULT_CLIP_LIMIT = 1.2;
+    private static final double DEFAULT_CLIP_LIMIT = 2.0;
     private static final int DEFAULT_TILE_GRID_SIZE = 8;
 
     @Override

--- a/preprocess-worker/src/main/java/com/moonju/preprocess/worker/domain/preprocess/step/DenoiseStep.java
+++ b/preprocess-worker/src/main/java/com/moonju/preprocess/worker/domain/preprocess/step/DenoiseStep.java
@@ -11,6 +11,9 @@ import org.springframework.stereotype.Component;
 public class DenoiseStep implements PreprocessStep {
 
     private static final int DEFAULT_MEDIAN_KERNEL_SIZE = 3;
+    private static final int DEFAULT_BILATERAL_DIAMETER = 5;
+    private static final double DEFAULT_BILATERAL_SIGMA_COLOR = 25.0;
+    private static final double DEFAULT_BILATERAL_SIGMA_RANGE = 75.0;
 
     @Override
     public PreprocessStepName name() {
@@ -43,9 +46,27 @@ public class DenoiseStep implements PreprocessStep {
 
         Mat denoised = new Mat();
         if ("bilateral".equals(mode)) {
-            int diameter = positiveOddInt(context.parameters().get("denoiseDiameter"), 5);
-            Imgproc.bilateralFilter(holder.mat(), denoised, diameter, 75.0, 75.0);
-            replaceImage(context, holder, denoised, "Denoise applied: mode=bilateral, diameter=" + diameter);
+            int diameter = positiveOddInt(context.parameters().get("denoiseDiameter"), DEFAULT_BILATERAL_DIAMETER);
+            double sigmaColor = positiveDouble(
+                context.parameters().get("denoiseSigmaColor"),
+                DEFAULT_BILATERAL_SIGMA_COLOR
+            );
+            double sigmaRange = positiveDouble(
+                context.parameters().get("denoiseSigmaRange"),
+                DEFAULT_BILATERAL_SIGMA_RANGE
+            );
+            Imgproc.bilateralFilter(holder.mat(), denoised, diameter, sigmaColor, sigmaRange);
+            replaceImage(
+                context,
+                holder,
+                denoised,
+                "Denoise applied: mode=bilateral, diameter="
+                    + diameter
+                    + ", sigmaColor="
+                    + sigmaColor
+                    + ", sigmaRange="
+                    + sigmaRange
+            );
             return;
         }
 
@@ -70,5 +91,12 @@ public class DenoiseStep implements PreprocessStep {
         }
         int parsed = Math.max(3, Integer.parseInt(value));
         return parsed % 2 == 0 ? parsed + 1 : parsed;
+    }
+
+    private double positiveDouble(String value, double defaultValue) {
+        if (value == null || value.isBlank()) {
+            return defaultValue;
+        }
+        return Math.max(0.1, Double.parseDouble(value));
     }
 }

--- a/preprocess-worker/src/main/java/com/moonju/preprocess/worker/domain/preprocess/step/SharpenStep.java
+++ b/preprocess-worker/src/main/java/com/moonju/preprocess/worker/domain/preprocess/step/SharpenStep.java
@@ -11,8 +11,8 @@ import org.springframework.stereotype.Component;
 @Component
 public class SharpenStep implements PreprocessStep {
 
-    private static final double DEFAULT_SHARPEN_AMOUNT = 0.6;
-    private static final double DEFAULT_SHARPEN_SIGMA = 1.0;
+    private static final double DEFAULT_SHARPEN_AMOUNT = 0.8;
+    private static final double DEFAULT_SHARPEN_SIGMA = 1.5;
 
     @Override
     public PreprocessStepName name() {

--- a/preprocess-worker/src/test/java/com/moonju/preprocess/worker/domain/preprocess/preset/PreprocessPresetRegistryTests.java
+++ b/preprocess-worker/src/test/java/com/moonju/preprocess/worker/domain/preprocess/preset/PreprocessPresetRegistryTests.java
@@ -36,4 +36,32 @@ class PreprocessPresetRegistryTests {
         );
         assertThat(preset.steps()).hasSize(11);
     }
+
+    @Test
+    void builtInPresetsExposeQualityTuningParameters() {
+        assertThat(registry.findByName("A4_SCAN_300DPI").defaultParameters())
+            .containsEntry("contrastClipLimit", "2.0")
+            .containsEntry("adaptiveBlockSize", "21")
+            .containsEntry("adaptiveC", "5.0")
+            .containsEntry("denoiseMode", "median")
+            .containsEntry("denoiseSigmaColor", "25.0")
+            .containsEntry("morphologyMode", "open_close")
+            .containsEntry("sharpenAmount", "0.8")
+            .containsEntry("sharpenSigma", "1.5");
+
+        assertThat(registry.findByName("LOW_CONTRAST_SCAN").defaultParameters())
+            .containsEntry("contrastClipLimit", "2.4")
+            .containsEntry("denoiseMode", "median")
+            .containsEntry("sharpen", "true");
+
+        assertThat(registry.findByName("RECEIPT").defaultParameters())
+            .containsEntry("contrastClipLimit", "2.2")
+            .containsEntry("denoiseMode", "median")
+            .containsEntry("morphologyKernelSize", "2");
+
+        assertThat(registry.findByName("NOISY_SCAN").defaultParameters())
+            .containsEntry("contrastClipLimit", "2.0")
+            .containsEntry("denoiseMode", "bilateral")
+            .containsEntry("denoiseSigmaRange", "75.0");
+    }
 }

--- a/preprocess-worker/src/test/java/com/moonju/preprocess/worker/domain/preprocess/step/BinarizationStepTests.java
+++ b/preprocess-worker/src/test/java/com/moonju/preprocess/worker/domain/preprocess/step/BinarizationStepTests.java
@@ -63,6 +63,20 @@ class BinarizationStepTests {
     }
 
     @Test
+    void usesTunedAdaptiveDefaultsWhenParametersAreMissing() {
+        PreprocessContext context = context(Map.of("binarizationMode", "adaptive"));
+        ImageMatHolder sourceHolder = ImageMatHolder.decoded("originals/text.png", documentLikeImage());
+        context.storeDecodedImage(sourceHolder);
+
+        step.execute(context);
+
+        assertThat(context.consumeStepNote(PreprocessStepName.BINARIZATION))
+            .contains("blockSize=21")
+            .contains("c=5.0");
+        context.releaseDecodedImage();
+    }
+
+    @Test
     void fallsBackToOtsuWhenModeIsUnsupported() {
         PreprocessContext context = context(Map.of("binarizationMode", "unknown"));
         ImageMatHolder sourceHolder = ImageMatHolder.decoded("originals/text.png", documentLikeImage());

--- a/preprocess-worker/src/test/java/com/moonju/preprocess/worker/domain/preprocess/step/ContrastNormalizeStepTests.java
+++ b/preprocess-worker/src/test/java/com/moonju/preprocess/worker/domain/preprocess/step/ContrastNormalizeStepTests.java
@@ -58,6 +58,18 @@ class ContrastNormalizeStepTests {
     }
 
     @Test
+    void usesTunedDefaultClipLimitWhenParameterIsMissing() {
+        PreprocessContext context = context(Map.of());
+        ImageMatHolder sourceHolder = ImageMatHolder.decoded("originals/default.png", lowContrastBgrImage());
+        context.storeDecodedImage(sourceHolder);
+
+        step.execute(context);
+
+        assertThat(context.consumeStepNote(PreprocessStepName.CONTRAST_NORMALIZE)).contains("clipLimit=2.0");
+        context.releaseDecodedImage();
+    }
+
+    @Test
     void defersWhenDecodedImageIsMissing() {
         PreprocessContext context = context(Map.of());
 

--- a/preprocess-worker/src/test/java/com/moonju/preprocess/worker/domain/preprocess/step/DenoiseStepTests.java
+++ b/preprocess-worker/src/test/java/com/moonju/preprocess/worker/domain/preprocess/step/DenoiseStepTests.java
@@ -69,6 +69,42 @@ class DenoiseStepTests {
     }
 
     @Test
+    void appliesBilateralDenoiseWithTunedDefaultSigmas() {
+        PreprocessContext context = context(Map.of("denoiseMode", "bilateral"));
+        ImageMatHolder sourceHolder = ImageMatHolder.decoded("originals/noisy.png", noisyImage());
+        context.storeDecodedImage(sourceHolder);
+
+        step.execute(context);
+
+        assertThat(context.consumeStepNote(PreprocessStepName.DENOISE))
+            .contains("mode=bilateral")
+            .contains("sigmaColor=25.0")
+            .contains("sigmaRange=75.0");
+        context.releaseDecodedImage();
+    }
+
+    @Test
+    void appliesBilateralDenoiseWithConfiguredSigmas() {
+        PreprocessContext context = context(Map.of(
+            "denoiseMode",
+            "bilateral",
+            "denoiseSigmaColor",
+            "40.0",
+            "denoiseSigmaRange",
+            "60.0"
+        ));
+        ImageMatHolder sourceHolder = ImageMatHolder.decoded("originals/noisy.png", noisyImage());
+        context.storeDecodedImage(sourceHolder);
+
+        step.execute(context);
+
+        assertThat(context.consumeStepNote(PreprocessStepName.DENOISE))
+            .contains("sigmaColor=40.0")
+            .contains("sigmaRange=60.0");
+        context.releaseDecodedImage();
+    }
+
+    @Test
     void defersWhenDecodedImageIsMissing() {
         PreprocessContext context = context(Map.of());
 

--- a/preprocess-worker/src/test/java/com/moonju/preprocess/worker/domain/preprocess/step/SharpenStepTests.java
+++ b/preprocess-worker/src/test/java/com/moonju/preprocess/worker/domain/preprocess/step/SharpenStepTests.java
@@ -47,6 +47,20 @@ class SharpenStepTests {
     }
 
     @Test
+    void usesTunedSharpenDefaultsWhenParametersAreMissing() {
+        PreprocessContext context = context(Map.of("sharpen", "true"));
+        ImageMatHolder sourceHolder = ImageMatHolder.decoded("originals/processed.png", grayscaleImage());
+        context.storeDecodedImage(sourceHolder);
+
+        step.execute(context);
+
+        assertThat(context.consumeStepNote(PreprocessStepName.OPTIONAL_SHARPEN))
+            .contains("amount=0.8")
+            .contains("sigma=1.5");
+        context.releaseDecodedImage();
+    }
+
+    @Test
     void skipsWhenDisabledByParameter() {
         PreprocessContext context = context(Map.of("sharpen", "false"));
         ImageMatHolder sourceHolder = ImageMatHolder.decoded("originals/processed.png", grayscaleImage());


### PR DESCRIPTION
## #️⃣ 기능 설명

Worker 전처리 파이프라인의 품질 관련 기본값과 built-in preset 파라미터를 OCR 전처리 목적에 맞게 조정했습니다.

Closes #118

## 🛠️ 작업 상세 내용

- [x] `BinarizationStep` adaptive 기본값을 `blockSize=21`, `C=5.0`으로 변경
- [x] `ContrastNormalizeStep` CLAHE 기본 `clipLimit=2.0`으로 변경
- [x] `SharpenStep` 기본 `amount=0.8`, `sigma=1.5`로 변경
- [x] `DenoiseStep` bilateral `denoiseSigmaColor`, `denoiseSigmaRange` 파라미터 노출
- [x] `denoiseSigmaColor` 기본값을 `25.0`으로 낮춰 텍스트 경계 보존 방향으로 조정
- [x] A4, LowContrast, Receipt, Noisy preset에 denoise/morphology/sharpen 세부 파라미터 추가
- [x] backend-api preset validation contract에 동일 파라미터 추가
- [x] Worker/API 테스트와 문서 갱신

## 📁 변경 파일 요약

- `preprocess-worker/src/main/java/.../preprocess/step/*`
- `preprocess-worker/src/main/java/.../preprocess/preset/*`
- `backend-api/src/main/java/.../preprocess/service/PreprocessPresetRegistry.java`
- `preprocess-worker/src/test/java/...`
- `backend-api/src/test/java/...`
- `docs/worker/preset-spec.md`
- `docs/api/preprocess-preset-api.md`
- `docs/feature-specs/issue-118-worker-preprocess-quality-parameter-tuning.md`

## ✅ 검증 내용

- [x] `docker run --rm -v "${PWD}\\backend-api:/workspace" -w /workspace gradle:8.10-jdk21 gradle test --no-daemon`: 통과
- [x] `docker run --rm -v "${PWD}\\preprocess-worker:/workspace" -w /workspace gradle:8.12.1-jdk21 gradle test --no-daemon`: 통과
- [x] `docker run --rm -v "${PWD}\\backend-api:/workspace" -w /workspace gradle:8.10-jdk21 gradle build --no-daemon`: 통과
- [x] `docker run --rm -v "${PWD}\\preprocess-worker:/workspace" -w /workspace gradle:8.12.1-jdk21 gradle build --no-daemon`: 통과
- [x] `git diff --check`: 통과
- [x] Markdown 로컬 링크 검사: 통과

## 🔎 리뷰어가 확인해야 할 부분

- preset별 `contrastClipLimit` 상향값이 의도한 강도와 맞는지 확인해주세요.
- `denoiseSigmaRange` 이름을 OpenCV bilateralFilter의 sigmaSpace 의미로 사용하는 것이 괜찮은지 확인해주세요.
- API preset contract와 Worker preset default가 같은 방향으로 유지되는지 확인해주세요.

## 📸 스크린샷

문서/파라미터 변경 작업이라 생략합니다.

## 💬 기타 공유사항 to 리뷰어

로컬에 Gradle wrapper가 없어 Docker Gradle 이미지로 테스트/빌드를 수행했습니다.