### PR TITLE
👷 [Ci] GHCR 이미지 빌드/푸시 workflow skeleton 추가

### DIFF
--- a/.github/workflows/build-ghcr-images.yml
+++ b/.github/workflows/build-ghcr-images.yml
@@ -1,0 +1,108 @@
+name: Build GHCR Images
+
+on:
+  workflow_dispatch:
+    inputs:
+      image_tag:
+        description: "Optional image tag. Defaults to the short commit SHA."
+        required: false
+        type: string
+  push:
+    branches:
+      - main
+    tags:
+      - "v*.*.*"
+
+permissions:
+  contents: read
+  packages: write
+
+concurrency:
+  group: ghcr-images-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAMESPACE: ${{ github.repository_owner }}/docprep-cloud
+
+jobs:
+  build-and-push:
+    name: Build and push ${{ matrix.service.image_name }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    strategy:
+      fail-fast: false
+      matrix:
+        service:
+          - name: backend-api
+            context: backend-api
+            dockerfile: backend-api/Dockerfile
+            image_name: backend-api
+          - name: preprocess-worker
+            context: preprocess-worker
+            dockerfile: preprocess-worker/Dockerfile
+            image_name: preprocess-worker
+          - name: frontend
+            context: frontend
+            dockerfile: frontend/Dockerfile
+            image_name: frontend
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Resolve image metadata
+        id: meta
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if [ -n "${{ inputs.image_tag || '' }}" ]; then
+            IMAGE_TAG="${{ inputs.image_tag }}"
+          elif [[ "${GITHUB_REF_TYPE}" == "tag" ]]; then
+            IMAGE_TAG="${GITHUB_REF_NAME}"
+          else
+            IMAGE_TAG="${GITHUB_SHA::12}"
+          fi
+
+          IMAGE="ghcr.io/${IMAGE_NAMESPACE}/${{ matrix.service.image_name }}"
+          IMAGE="$(echo "$IMAGE" | tr '[:upper:]' '[:lower:]')"
+
+          echo "image=$IMAGE" >> "$GITHUB_OUTPUT"
+          echo "tag=$IMAGE_TAG" >> "$GITHUB_OUTPUT"
+          echo "full_image=$IMAGE:$IMAGE_TAG" >> "$GITHUB_OUTPUT"
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push image
+        uses: docker/build-push-action@v6
+        with:
+          context: ${{ matrix.service.context }}
+          file: ${{ matrix.service.dockerfile }}
+          push: true
+          tags: |
+            ${{ steps.meta.outputs.full_image }}
+            ${{ steps.meta.outputs.image }}:latest
+          labels: |
+            org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.title=${{ matrix.service.name }}
+          cache-from: type=gha,scope=${{ matrix.service.name }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.service.name }}
+
+      - name: Write image summary
+        run: |
+          {
+            echo "### ${{ matrix.service.name }}"
+            echo ""
+            echo "- Image: \`${{ steps.meta.outputs.full_image }}\`"
+            echo "- Latest: \`${{ steps.meta.outputs.image }}:latest\`"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ localStorage.getItem('doc-pipeline.access-token')
 | [Kubernetes/KEDA 배포](docs/operation/kubernetes-deployment.md) | Kubernetes skeleton 적용 절차 |
 | [운영 배포](docs/operation/production-deployment-guide.md) | 운영 배포 전체 순서 |
 | [GitHub Actions 배포](docs/operation/github-actions-deployment.md) | CI/CD 배포 workflow |
+| [GHCR 이미지 빌드/푸시](docs/operation/ghcr-image-workflow.md) | Kubernetes 배포용 이미지 생성 |
 | [환경변수와 Secrets](docs/operation/production-env.md) | 운영 secret 주입 방식 |
 | [배포 체크리스트](docs/operation/deployment-checklist.md) | 공개 전 점검 항목 |
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -47,6 +47,7 @@ AI/Codex 작업 규칙 문서는 로컬 전용 파일로 관리하고 원격 저
 | [Kubernetes/KEDA 배포](operation/kubernetes-deployment.md) | Kubernetes skeleton 적용 절차 |
 | [운영 환경변수](operation/production-env.md) | `.env.prod`와 secret 주입 방식 |
 | [GitHub Actions 배포](operation/github-actions-deployment.md) | production workflow 사용법 |
+| [GHCR 이미지 빌드/푸시](operation/ghcr-image-workflow.md) | Kubernetes 배포용 이미지 생성 |
 | [HTTPS/도메인 정책](operation/https-domain-policy.md) | 도메인, TLS, OAuth redirect 기준 |
 | [백업/복구](operation/backup-restore.md) | PostgreSQL과 Object Storage 백업 |
 | [최종 E2E 검증](operation/final-e2e-verification.md) | 운영 배포 후 검증 흐름 |

--- a/docs/feature-specs/issue-126-ghcr-image-workflow.md
+++ b/docs/feature-specs/issue-126-ghcr-image-workflow.md
@@ -1,0 +1,47 @@
+# Issue 126. GHCR 이미지 빌드/푸시 workflow skeleton
+
+## 목적
+
+GitHub Actions에서 backend-api, preprocess-worker, frontend 이미지를 GHCR로 빌드하고 푸시하는 workflow skeleton을 추가한다.
+
+## 작업 범위
+
+1. GHCR build/push workflow 추가
+2. 세 서비스 이미지 matrix 구성
+3. `GITHUB_TOKEN` 기반 GHCR login
+4. commit SHA, Git tag, 수동 입력 tag 규칙 정의
+5. workflow summary에 이미지 주소 출력
+6. 운영 문서와 체크리스트 연결
+
+## 제외 범위
+
+1. Kubernetes cluster apply
+2. kubeconfig secret 등록
+3. SSH 기반 VM 배포
+4. GHCR pull secret 생성
+5. image tag 자동 patch 후 배포
+
+## 이미지 이름
+
+```text
+ghcr.io/som141/docprep-cloud/backend-api:<tag>
+ghcr.io/som141/docprep-cloud/preprocess-worker:<tag>
+ghcr.io/som141/docprep-cloud/frontend:<tag>
+```
+
+## 사용자에게 나중에 받을 값
+
+이번 작업에는 필요 없지만 실제 Kubernetes 배포 단계에서는 아래 값이 필요하다.
+
+1. kubeconfig 또는 cluster 접근 방식
+2. GHCR private image pull token
+3. 실제 운영 도메인
+4. TLS secret
+5. 운영 secret
+
+## 검증 기준
+
+1. workflow YAML 문법이 유효해야 한다.
+2. `packages: write` 권한이 있어야 한다.
+3. 실제 secret 값이 workflow에 없어야 한다.
+4. 문서에 GHCR 권한 설정과 이미지 이름 규칙이 적혀 있어야 한다.

--- a/docs/operation/README.md
+++ b/docs/operation/README.md
@@ -8,12 +8,13 @@
 1. [운영 배포 가이드](production-deployment-guide.md)
 2. [운영 환경변수와 Secret 주입](production-env.md)
 3. [GitHub Actions 배포](github-actions-deployment.md)
-4. [HTTPS와 도메인 정책](https-domain-policy.md)
-5. [관측성 로컬 실행](observability.md)
-6. [Kubernetes/KEDA 배포](kubernetes-deployment.md)
-7. [배포 체크리스트](deployment-checklist.md)
-8. [최종 E2E 검증](final-e2e-verification.md)
-9. [백업/복구](backup-restore.md)
+4. [GHCR 이미지 빌드/푸시](ghcr-image-workflow.md)
+5. [HTTPS와 도메인 정책](https-domain-policy.md)
+6. [관측성 로컬 실행](observability.md)
+7. [Kubernetes/KEDA 배포](kubernetes-deployment.md)
+8. [배포 체크리스트](deployment-checklist.md)
+9. [최종 E2E 검증](final-e2e-verification.md)
+10. [백업/복구](backup-restore.md)
 
 ## 로컬 실행 문서
 
@@ -32,6 +33,7 @@
 | [운영 배포 가이드](production-deployment-guide.md) | 서버 준비부터 post-deploy까지 전체 흐름 |
 | [운영 환경변수](production-env.md) | `.env.prod` 작성과 secret 관리 |
 | [GitHub Actions 배포](github-actions-deployment.md) | `Deploy Production` workflow 사용 |
+| [GHCR 이미지 빌드/푸시](ghcr-image-workflow.md) | Kubernetes 배포용 이미지 생성 |
 | [HTTPS/도메인 정책](https-domain-policy.md) | TLS 종료, OAuth redirect, cookie 정책 |
 | [관측성 로컬 실행](observability.md) | 배포 전 metric과 trace 검증 |
 | [Kubernetes/KEDA 배포](kubernetes-deployment.md) | Kubernetes skeleton 적용과 Worker autoscaling |

--- a/docs/operation/deployment-checklist.md
+++ b/docs/operation/deployment-checklist.md
@@ -39,12 +39,22 @@ OAUTH2_SUCCESS_REDIRECT_URI=https://YOUR_DOMAIN/oauth2/success
 ## 4. GitHub Actions
 
 - [ ] GitHub `production` Environment가 있다.
+- [ ] Actions workflow permission이 `Read and write permissions`로 설정되어 있다.
 - [ ] `DEPLOY_HOST`가 등록되어 있다.
 - [ ] `DEPLOY_USER`가 등록되어 있다.
 - [ ] `DEPLOY_SSH_PRIVATE_KEY`가 등록되어 있다.
 - [ ] `DEPLOY_PATH`가 등록되어 있다.
 - [ ] `PROD_BASE_URL`이 등록되어 있다.
 - [ ] 첫 배포는 수동 `workflow_dispatch`로 실행한다.
+
+## 4.1 GHCR 이미지
+
+- [ ] `Build GHCR Images` workflow가 성공했다.
+- [ ] backend-api 이미지가 GHCR에 올라갔다.
+- [ ] preprocess-worker 이미지가 GHCR에 올라갔다.
+- [ ] frontend 이미지가 GHCR에 올라갔다.
+- [ ] Kubernetes manifest 또는 overlay에 실제 image tag가 반영되어 있다.
+- [ ] GHCR package가 private이면 cluster에 `imagePullSecret`이 준비되어 있다.
 
 ## 5. Compose 설정 검증
 

--- a/docs/operation/ghcr-image-workflow.md
+++ b/docs/operation/ghcr-image-workflow.md
@@ -1,0 +1,119 @@
+# GHCR 이미지 빌드/푸시 workflow
+
+이 문서는 GitHub Actions에서 backend-api, preprocess-worker, frontend 이미지를 GHCR로 빌드하고 푸시하는 방법을 정리한다.
+
+## 목적
+
+Kubernetes 배포에서는 컨테이너 이미지가 먼저 registry에 올라가 있어야 한다. 이 프로젝트는 별도 Docker Hub 가입 없이 GitHub Container Registry를 기본 이미지 저장소로 사용한다.
+
+## Workflow 파일
+
+```text
+.github/workflows/build-ghcr-images.yml
+```
+
+## 실행 조건
+
+| 조건 | 동작 |
+| --- | --- |
+| `push` to `main` | 세 서비스 이미지를 commit SHA tag와 `latest`로 푸시 |
+| `push` tag `v*.*.*` | 세 서비스 이미지를 Git tag와 `latest`로 푸시 |
+| `workflow_dispatch` | 수동 실행. 선택적으로 `image_tag` 입력 가능 |
+
+## 이미지 이름 규칙
+
+기본 이미지 이름은 아래와 같다.
+
+```text
+ghcr.io/som141/docprep-cloud/backend-api:<tag>
+ghcr.io/som141/docprep-cloud/preprocess-worker:<tag>
+ghcr.io/som141/docprep-cloud/frontend:<tag>
+```
+
+`tag` 결정 규칙:
+
+1. 수동 실행에서 `image_tag`를 넣으면 그 값을 사용한다.
+2. Git tag로 실행되면 Git tag 이름을 사용한다.
+3. 그 외에는 commit SHA 앞 12자리를 사용한다.
+
+모든 실행은 같은 이미지에 `latest` tag도 함께 푸시한다.
+
+## 권한 설정
+
+Workflow는 아래 권한을 사용한다.
+
+```yaml
+permissions:
+  contents: read
+  packages: write
+```
+
+GitHub repository 설정에서 Actions 권한이 읽기/쓰기 가능해야 한다.
+
+```text
+Settings -> Actions -> General -> Workflow permissions -> Read and write permissions
+```
+
+별도 가입은 필요 없다. GHCR은 GitHub 계정과 repository에 연결된 Container Registry다.
+
+## Kubernetes manifest에 반영하는 방법
+
+이미지가 푸시된 뒤에는 Kubernetes manifest의 image placeholder를 실제 값으로 교체한다.
+
+| 파일 | 교체 대상 |
+| --- | --- |
+| `infra/k8s/backend-api/deployment.yml` | `YOUR_REGISTRY/docprep-backend-api:CHANGE_ME` |
+| `infra/k8s/preprocess-worker/deployment.yml` | `YOUR_REGISTRY/docprep-preprocess-worker:CHANGE_ME` |
+| `infra/k8s/frontend/deployment.yml` | `YOUR_REGISTRY/docprep-frontend:CHANGE_ME` |
+
+예시:
+
+```text
+YOUR_REGISTRY/docprep-backend-api:CHANGE_ME
+-> ghcr.io/som141/docprep-cloud/backend-api:abc123def456
+```
+
+향후 자동 배포 단계에서는 GitHub Actions가 이 값을 `kustomize set image` 또는 manifest patch로 주입하도록 확장한다.
+
+## Private package pull
+
+GHCR package가 private이면 Kubernetes cluster에서 이미지를 pull할 때 `imagePullSecret`이 필요할 수 있다.
+
+그 단계에서 사용자에게 필요한 값:
+
+1. GHCR pull 권한이 있는 GitHub PAT 또는 배포 전용 token
+2. registry username
+3. cluster namespace
+
+현재 workflow skeleton 작업에는 이 값들이 필요 없다.
+
+## 수동 실행 절차
+
+1. GitHub repository의 `Actions` 탭으로 이동한다.
+2. `Build GHCR Images` workflow를 선택한다.
+3. `Run workflow`를 누른다.
+4. 필요하면 `image_tag`를 입력한다.
+5. 실행 완료 후 workflow summary에서 이미지 주소를 확인한다.
+
+## 검증 방법
+
+GitHub Packages 또는 GHCR에서 이미지가 보이는지 확인한다.
+
+```text
+https://github.com/som141?tab=packages
+```
+
+로컬 Docker가 사용 가능하면 아래처럼 pull 테스트를 할 수 있다.
+
+```bash
+docker pull ghcr.io/som141/docprep-cloud/backend-api:<tag>
+docker pull ghcr.io/som141/docprep-cloud/preprocess-worker:<tag>
+docker pull ghcr.io/som141/docprep-cloud/frontend:<tag>
+```
+
+## 다음 단계
+
+1. K8s manifest image placeholder 자동 치환
+2. `kubectl apply` 또는 GitOps 기반 배포 workflow
+3. GHCR private image pull secret 생성
+4. 운영 cluster smoke test 자동화

--- a/docs/operation/kubernetes-deployment.md
+++ b/docs/operation/kubernetes-deployment.md
@@ -63,6 +63,8 @@ infra/k8s/**/*.local.yml
 
 ## 4. 이미지와 도메인 교체
 
+GHCR 이미지는 [GHCR 이미지 빌드/푸시 workflow](ghcr-image-workflow.md)로 생성한다.
+
 아래 파일의 placeholder를 실제 값으로 교체한다.
 
 | 파일 | 교체 값 |

--- a/docs/tasks/25-final-docs-tests.md
+++ b/docs/tasks/25-final-docs-tests.md
@@ -49,6 +49,8 @@
 25. backend-api CI workflow를 작성한다.
 26. preprocess-worker CI workflow를 작성한다.
 27. frontend CI workflow를 작성한다.
+28. GHCR 이미지 build/push workflow를 작성한다.
+29. Kubernetes manifest image tag 주입 방식을 문서화한다.
 
 ## 산출물
 


### PR DESCRIPTION
## #️⃣ 기능 설명

backend-api, preprocess-worker, frontend 이미지를 GHCR로 빌드/푸시하는 GitHub Actions workflow skeleton을 추가했습니다.

Refs #126

> 이 PR은 #125(`feat/som/124`) 위에 쌓인 stacked PR입니다. #125가 main에 머지된 뒤 이 PR을 main으로 retarget하거나 순서대로 머지하면 됩니다.

## 🛠️ 작업 상세 내용

- [x] `Build GHCR Images` workflow 추가
- [x] `backend-api`, `preprocess-worker`, `frontend` matrix build 구성
- [x] `GITHUB_TOKEN` 기반 GHCR login 구성
- [x] `packages: write` 권한 선언
- [x] commit SHA, Git tag, manual input tag 규칙 정의
- [x] workflow summary에 이미지 주소 출력
- [x] GHCR 이미지 이름과 K8s manifest 반영 문서 추가
- [x] 배포 체크리스트에 GHCR 항목 추가

## 📁 변경 파일 요약

- `.github/workflows/build-ghcr-images.yml`
- `docs/operation/ghcr-image-workflow.md`
- `docs/feature-specs/issue-126-ghcr-image-workflow.md`
- `docs/operation/deployment-checklist.md`
- `docs/operation/kubernetes-deployment.md`
- `README.md`, `docs/README.md`, `docs/operation/README.md`

## ✅ 검증 내용

- [x] `git diff --check`: 통과
- [x] secret 패턴 검색: 실제 secret 노출 없음. 기존 문서의 placeholder만 검색됨
- [x] GHCR image path를 `ghcr.io/som141/docprep-cloud/{service}:<tag>` 형식으로 정리
- [ ] workflow YAML 정식 파싱: 미실행. 로컬에 `actionlint`, Ruby, PyYAML, Node yaml module이 없습니다.
- [ ] 실제 workflow 실행: 미실행. PR 머지 후 GitHub Actions에서 검증 필요

## 🔎 리뷰어가 확인해야 할 부분

- GHCR image namespace를 `som141/docprep-cloud`로 둔 것이 적절한지 확인해주세요.
- `latest` tag를 함께 푸시하는 정책이 괜찮은지 확인해주세요.
- #125가 먼저 머지된 뒤 이 PR을 main으로 retarget할지, stacked PR로 순서대로 머지할지 확인해주세요.

## 📸 스크린샷

없음. GitHub Actions workflow skeleton 작업입니다.

## 💬 기타 공유사항 to 리뷰어

별도 GHCR 가입은 필요 없고, repository Actions 권한에서 `Read and write permissions`만 허용하면 `GITHUB_TOKEN`으로 package push가 가능합니다.