### PR TITLE
👷 [Ci] Kubernetes manifest 렌더링 workflow 추가

### DIFF
--- a/.github/workflows/render-k8s-manifests.yml
+++ b/.github/workflows/render-k8s-manifests.yml
@@ -1,0 +1,146 @@
+name: Render Kubernetes Manifests
+
+on:
+  workflow_dispatch:
+    inputs:
+      image_tag:
+        description: "Image tag to inject. Defaults to the short commit SHA."
+        required: false
+        type: string
+      image_namespace:
+        description: "Container image namespace."
+        required: false
+        default: "ghcr.io/som141/docprep-cloud"
+        type: string
+      domain:
+        description: "Ingress domain. Leave as YOUR_DOMAIN for template rendering."
+        required: false
+        default: "YOUR_DOMAIN"
+        type: string
+      tls_secret:
+        description: "Ingress TLS secret name."
+        required: false
+        default: "docprep-cloud-tls"
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: render-k8s-manifests-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  render:
+    name: Render Kubernetes manifests
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up kubectl
+        uses: azure/setup-kubectl@v4
+        with:
+          version: v1.30.2
+
+      - name: Resolve render inputs
+        id: inputs
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if [ -n "${{ inputs.image_tag || '' }}" ]; then
+            IMAGE_TAG="${{ inputs.image_tag }}"
+          else
+            IMAGE_TAG="${GITHUB_SHA::12}"
+          fi
+
+          IMAGE_NAMESPACE="${{ inputs.image_namespace || 'ghcr.io/som141/docprep-cloud' }}"
+          DOMAIN="${{ inputs.domain || 'YOUR_DOMAIN' }}"
+          TLS_SECRET="${{ inputs.tls_secret || 'docprep-cloud-tls' }}"
+
+          echo "image_tag=$IMAGE_TAG" >> "$GITHUB_OUTPUT"
+          echo "image_namespace=$IMAGE_NAMESPACE" >> "$GITHUB_OUTPUT"
+          echo "domain=$DOMAIN" >> "$GITHUB_OUTPUT"
+          echo "tls_secret=$TLS_SECRET" >> "$GITHUB_OUTPUT"
+
+      - name: Copy Kubernetes manifests
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p "$RUNNER_TEMP/render"
+          cp -R infra/k8s "$RUNNER_TEMP/render/k8s"
+
+      - name: Inject image tags and domain placeholders
+        shell: bash
+        env:
+          MANIFEST_ROOT: ${{ runner.temp }}/render/k8s
+          IMAGE_NAMESPACE: ${{ steps.inputs.outputs.image_namespace }}
+          IMAGE_TAG: ${{ steps.inputs.outputs.image_tag }}
+          DOMAIN: ${{ steps.inputs.outputs.domain }}
+          TLS_SECRET: ${{ steps.inputs.outputs.tls_secret }}
+        run: |
+          set -euo pipefail
+
+          python - <<'PY'
+          import os
+          import pathlib
+
+          root = pathlib.Path(os.environ["MANIFEST_ROOT"])
+          image_namespace = os.environ["IMAGE_NAMESPACE"].rstrip("/")
+          image_tag = os.environ["IMAGE_TAG"]
+          domain = os.environ["DOMAIN"]
+          tls_secret = os.environ["TLS_SECRET"]
+
+          replacements = {
+              "YOUR_REGISTRY/docprep-backend-api:CHANGE_ME": f"{image_namespace}/backend-api:{image_tag}",
+              "YOUR_REGISTRY/docprep-preprocess-worker:CHANGE_ME": f"{image_namespace}/preprocess-worker:{image_tag}",
+              "YOUR_REGISTRY/docprep-frontend:CHANGE_ME": f"{image_namespace}/frontend:{image_tag}",
+              "YOUR_DOMAIN": domain,
+              "docprep-cloud-tls": tls_secret,
+          }
+
+          for path in root.rglob("*.yml"):
+              text = path.read_text(encoding="utf-8")
+              for before, after in replacements.items():
+                  text = text.replace(before, after)
+              path.write_text(text, encoding="utf-8")
+          PY
+
+      - name: Render manifests
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p rendered
+          kubectl kustomize "$RUNNER_TEMP/render/k8s" > rendered/docprep-cloud-k8s.yml
+
+      - name: Validate rendered manifest placeholders
+        shell: bash
+        run: |
+          set -euo pipefail
+          if grep -q "YOUR_REGISTRY\\|CHANGE_ME" rendered/docprep-cloud-k8s.yml; then
+            echo "Rendered manifest still contains image placeholders."
+            exit 1
+          fi
+
+      - name: Write render summary
+        shell: bash
+        run: |
+          {
+            echo "### Rendered Kubernetes manifests"
+            echo ""
+            echo "- backend-api: \`${{ steps.inputs.outputs.image_namespace }}/backend-api:${{ steps.inputs.outputs.image_tag }}\`"
+            echo "- preprocess-worker: \`${{ steps.inputs.outputs.image_namespace }}/preprocess-worker:${{ steps.inputs.outputs.image_tag }}\`"
+            echo "- frontend: \`${{ steps.inputs.outputs.image_namespace }}/frontend:${{ steps.inputs.outputs.image_tag }}\`"
+            echo "- domain: \`${{ steps.inputs.outputs.domain }}\`"
+            echo "- tls secret: \`${{ steps.inputs.outputs.tls_secret }}\`"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload rendered manifests
+        uses: actions/upload-artifact@v4
+        with:
+          name: docprep-cloud-k8s-${{ steps.inputs.outputs.image_tag }}
+          path: rendered/docprep-cloud-k8s.yml
+          if-no-files-found: error

--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ localStorage.getItem('doc-pipeline.access-token')
 | [운영 배포](docs/operation/production-deployment-guide.md) | 운영 배포 전체 순서 |
 | [GitHub Actions 배포](docs/operation/github-actions-deployment.md) | CI/CD 배포 workflow |
 | [GHCR 이미지 빌드/푸시](docs/operation/ghcr-image-workflow.md) | Kubernetes 배포용 이미지 생성 |
+| [Kubernetes manifest 렌더링](docs/operation/kubernetes-manifest-render-workflow.md) | 이미지 태그를 주입한 K8s YAML artifact 생성 |
 | [환경변수와 Secrets](docs/operation/production-env.md) | 운영 secret 주입 방식 |
 | [배포 체크리스트](docs/operation/deployment-checklist.md) | 공개 전 점검 항목 |
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -48,6 +48,7 @@ AI/Codex 작업 규칙 문서는 로컬 전용 파일로 관리하고 원격 저
 | [운영 환경변수](operation/production-env.md) | `.env.prod`와 secret 주입 방식 |
 | [GitHub Actions 배포](operation/github-actions-deployment.md) | production workflow 사용법 |
 | [GHCR 이미지 빌드/푸시](operation/ghcr-image-workflow.md) | Kubernetes 배포용 이미지 생성 |
+| [Kubernetes manifest 렌더링](operation/kubernetes-manifest-render-workflow.md) | 이미지 태그를 주입한 K8s YAML artifact 생성 |
 | [HTTPS/도메인 정책](operation/https-domain-policy.md) | 도메인, TLS, OAuth redirect 기준 |
 | [백업/복구](operation/backup-restore.md) | PostgreSQL과 Object Storage 백업 |
 | [최종 E2E 검증](operation/final-e2e-verification.md) | 운영 배포 후 검증 흐름 |

--- a/docs/feature-specs/issue-129-kubernetes-manifest-render-workflow.md
+++ b/docs/feature-specs/issue-129-kubernetes-manifest-render-workflow.md
@@ -1,0 +1,43 @@
+# Issue 129. Kubernetes manifest 렌더링 workflow
+
+## 목적
+
+GHCR 이미지 태그를 Kubernetes manifest에 주입하고, `kubectl kustomize` 결과를 artifact로 남기는 GitHub Actions workflow를 추가한다.
+
+## 작업 범위
+
+1. `Render Kubernetes Manifests` workflow 추가
+2. `image_tag`, `image_namespace`, `domain`, `tls_secret` 입력값 정의
+3. `infra/k8s` manifest를 임시 디렉터리로 복사
+4. image/domain/TLS placeholder 치환
+5. `kubectl kustomize` 결과 생성
+6. 렌더링 결과 artifact 업로드
+7. 운영 문서와 체크리스트 연결
+
+## 제외 범위
+
+1. 실제 Kubernetes cluster apply
+2. kubeconfig secret
+3. SSH key
+4. 운영 secret 생성
+5. GHCR image pull secret 생성
+
+## 사용자에게 나중에 받을 값
+
+실제 Kubernetes CD 단계로 넘어갈 때 아래 값이 필요하다.
+
+1. kubeconfig 또는 cluster 접근 방식
+2. 운영 namespace
+3. 실제 domain
+4. TLS secret
+5. GHCR image pull token 또는 public package 정책
+6. 운영 secret 주입 방식
+
+이번 렌더링 workflow에는 위 값이 없어도 된다.
+
+## 완료 기준
+
+1. `kubectl kustomize`를 사용해 최종 YAML을 만든다.
+2. 이미지 placeholder가 렌더링 결과에 남지 않는다.
+3. workflow artifact로 `docprep-cloud-k8s.yml`을 업로드한다.
+4. 실제 `kubectl apply`는 수행하지 않는다.

--- a/docs/operation/README.md
+++ b/docs/operation/README.md
@@ -9,12 +9,13 @@
 2. [운영 환경변수와 Secret 주입](production-env.md)
 3. [GitHub Actions 배포](github-actions-deployment.md)
 4. [GHCR 이미지 빌드/푸시](ghcr-image-workflow.md)
-5. [HTTPS와 도메인 정책](https-domain-policy.md)
-6. [관측성 로컬 실행](observability.md)
-7. [Kubernetes/KEDA 배포](kubernetes-deployment.md)
-8. [배포 체크리스트](deployment-checklist.md)
-9. [최종 E2E 검증](final-e2e-verification.md)
-10. [백업/복구](backup-restore.md)
+5. [Kubernetes manifest 렌더링](kubernetes-manifest-render-workflow.md)
+6. [HTTPS와 도메인 정책](https-domain-policy.md)
+7. [관측성 로컬 실행](observability.md)
+8. [Kubernetes/KEDA 배포](kubernetes-deployment.md)
+9. [배포 체크리스트](deployment-checklist.md)
+10. [최종 E2E 검증](final-e2e-verification.md)
+11. [백업/복구](backup-restore.md)
 
 ## 로컬 실행 문서
 
@@ -34,6 +35,7 @@
 | [운영 환경변수](production-env.md) | `.env.prod` 작성과 secret 관리 |
 | [GitHub Actions 배포](github-actions-deployment.md) | `Deploy Production` workflow 사용 |
 | [GHCR 이미지 빌드/푸시](ghcr-image-workflow.md) | Kubernetes 배포용 이미지 생성 |
+| [Kubernetes manifest 렌더링](kubernetes-manifest-render-workflow.md) | 이미지 태그를 주입한 K8s YAML artifact 생성 |
 | [HTTPS/도메인 정책](https-domain-policy.md) | TLS 종료, OAuth redirect, cookie 정책 |
 | [관측성 로컬 실행](observability.md) | 배포 전 metric과 trace 검증 |
 | [Kubernetes/KEDA 배포](kubernetes-deployment.md) | Kubernetes skeleton 적용과 Worker autoscaling |

--- a/docs/operation/deployment-checklist.md
+++ b/docs/operation/deployment-checklist.md
@@ -53,6 +53,8 @@ OAUTH2_SUCCESS_REDIRECT_URI=https://YOUR_DOMAIN/oauth2/success
 - [ ] backend-api 이미지가 GHCR에 올라갔다.
 - [ ] preprocess-worker 이미지가 GHCR에 올라갔다.
 - [ ] frontend 이미지가 GHCR에 올라갔다.
+- [ ] `Render Kubernetes Manifests` workflow가 성공했다.
+- [ ] 렌더링 artifact에 `YOUR_REGISTRY` 또는 `CHANGE_ME`가 남아 있지 않다.
 - [ ] Kubernetes manifest 또는 overlay에 실제 image tag가 반영되어 있다.
 - [ ] GHCR package가 private이면 cluster에 `imagePullSecret`이 준비되어 있다.
 

--- a/docs/operation/kubernetes-deployment.md
+++ b/docs/operation/kubernetes-deployment.md
@@ -64,6 +64,7 @@ infra/k8s/**/*.local.yml
 ## 4. 이미지와 도메인 교체
 
 GHCR 이미지는 [GHCR 이미지 빌드/푸시 workflow](ghcr-image-workflow.md)로 생성한다.
+이미지 태그를 넣은 최종 Kubernetes YAML은 [Kubernetes manifest 렌더링 workflow](kubernetes-manifest-render-workflow.md)로 먼저 검토한다.
 
 아래 파일의 placeholder를 실제 값으로 교체한다.
 

--- a/docs/operation/kubernetes-manifest-render-workflow.md
+++ b/docs/operation/kubernetes-manifest-render-workflow.md
@@ -1,0 +1,83 @@
+# Kubernetes manifest 렌더링 workflow
+
+이 문서는 GHCR 이미지 태그를 Kubernetes manifest에 주입하고, 최종 YAML을 artifact로 남기는 GitHub Actions workflow를 설명한다.
+
+## 목적
+
+실제 클러스터에 배포하기 전에 아래 항목을 확인한다.
+
+1. backend-api, preprocess-worker, frontend 이미지 태그가 올바르게 들어가는지
+2. Ingress domain과 TLS secret 이름이 원하는 값으로 들어가는지
+3. `kubectl kustomize infra/k8s` 결과가 하나의 배포 YAML로 생성되는지
+4. 실제 `kubectl apply` 없이 배포 파일을 리뷰할 수 있는지
+
+## Workflow 파일
+
+```text
+.github/workflows/render-k8s-manifests.yml
+```
+
+## 실행 조건
+
+현재는 수동 실행만 지원한다.
+
+```text
+Actions -> Render Kubernetes Manifests -> Run workflow
+```
+
+## 입력값
+
+| 입력값 | 기본값 | 설명 |
+| --- | --- | --- |
+| `image_tag` | commit SHA 앞 12자리 | 세 서비스에 공통으로 주입할 이미지 태그 |
+| `image_namespace` | `ghcr.io/som141/docprep-cloud` | GHCR image namespace |
+| `domain` | `YOUR_DOMAIN` | Ingress host와 backend config의 public domain |
+| `tls_secret` | `docprep-cloud-tls` | Ingress TLS secret 이름 |
+
+## 이미지 주입 규칙
+
+렌더링 workflow는 아래 placeholder를 실제 이미지로 바꾼다.
+
+| 기존 placeholder | 렌더링 결과 예시 |
+| --- | --- |
+| `YOUR_REGISTRY/docprep-backend-api:CHANGE_ME` | `ghcr.io/som141/docprep-cloud/backend-api:abc123def456` |
+| `YOUR_REGISTRY/docprep-preprocess-worker:CHANGE_ME` | `ghcr.io/som141/docprep-cloud/preprocess-worker:abc123def456` |
+| `YOUR_REGISTRY/docprep-frontend:CHANGE_ME` | `ghcr.io/som141/docprep-cloud/frontend:abc123def456` |
+
+## 결과물
+
+Workflow는 아래 artifact를 생성한다.
+
+```text
+docprep-cloud-k8s-{image_tag}
+└── docprep-cloud-k8s.yml
+```
+
+이 파일은 리뷰용 렌더링 결과다. 실제 클러스터 적용은 하지 않는다.
+
+## 실제 배포와의 차이
+
+이 workflow는 다음을 하지 않는다.
+
+1. kubeconfig를 사용하지 않는다.
+2. SSH key를 사용하지 않는다.
+3. 운영 secret을 만들지 않는다.
+4. `kubectl apply`를 실행하지 않는다.
+5. GHCR private image pull secret을 만들지 않는다.
+
+위 작업은 실제 Kubernetes CD 단계에서 별도 workflow로 추가한다.
+
+## 검증 기준
+
+1. workflow가 성공한다.
+2. artifact에 `docprep-cloud-k8s.yml`이 있다.
+3. 렌더링 결과에 `YOUR_REGISTRY`, `CHANGE_ME`가 남아 있지 않다.
+4. `YOUR_DOMAIN`은 입력값을 넣은 경우 실제 domain으로 바뀐다.
+5. secret 값은 artifact에 포함되지 않는다.
+
+## 다음 단계
+
+1. GHCR 이미지 push workflow와 연결
+2. image tag를 자동으로 render workflow에 전달
+3. kubeconfig 기반 `kubectl apply` CD 추가
+4. 배포 후 health check와 smoke test 추가

--- a/docs/tasks/25-final-docs-tests.md
+++ b/docs/tasks/25-final-docs-tests.md
@@ -51,6 +51,7 @@
 27. frontend CI workflow를 작성한다.
 28. GHCR 이미지 build/push workflow를 작성한다.
 29. Kubernetes manifest image tag 주입 방식을 문서화한다.
+30. Kubernetes manifest render artifact workflow를 작성한다.
 
 ## 산출물
 


### PR DESCRIPTION
## #️⃣ 기능 설명

GHCR 이미지 태그와 도메인 입력값을 Kubernetes manifest에 주입하고, `kubectl kustomize` 결과를 artifact로 남기는 workflow를 추가했습니다.

Closes #129

> 이 PR은 #128(`ci/som/126`) 위에 쌓인 stacked PR입니다. merge 순서는 #128 -> #130입니다.

## 🛠️ 작업 상세 내용

- [x] `Render Kubernetes Manifests` workflow 추가
- [x] `image_tag`, `image_namespace`, `domain`, `tls_secret` 입력값 추가
- [x] `infra/k8s` manifest를 임시 디렉터리로 복사 후 placeholder 치환
- [x] `kubectl kustomize` 결과를 `docprep-cloud-k8s.yml`로 생성
- [x] 렌더링 artifact 업로드
- [x] `YOUR_REGISTRY`, `CHANGE_ME` 잔존 검증 추가
- [x] 운영 문서와 체크리스트 연결

## 📁 변경 파일 요약

- `.github/workflows/render-k8s-manifests.yml`
- `docs/operation/kubernetes-manifest-render-workflow.md`
- `docs/feature-specs/issue-129-kubernetes-manifest-render-workflow.md`
- `docs/operation/deployment-checklist.md`
- `docs/operation/kubernetes-deployment.md`
- `README.md`, `docs/README.md`, `docs/operation/README.md`

## ✅ 검증 내용

- [x] 로컬 시뮬레이션: `infra/k8s` 복사 -> image/domain placeholder 치환 -> `kubectl kustomize` 렌더링 통과
- [x] 렌더링 결과에서 `YOUR_REGISTRY`, `CHANGE_ME` 미검출
- [x] `git diff --check`: 통과
- [x] secret 패턴 검색: 실제 secret 노출 없음. 기존 placeholder 문서만 검색됨
- [ ] workflow 실제 실행: PR 머지 후 GitHub Actions에서 검증 필요

## 🔎 리뷰어가 확인해야 할 부분

- 실제 `kubectl apply`를 하지 않고 artifact만 생성하는 범위가 적절한지 확인해주세요.
- `domain` 기본값을 `YOUR_DOMAIN`으로 둔 정책이 괜찮은지 확인해주세요.
- #128이 먼저 main에 반영된 뒤 이 PR을 main으로 retarget해야 합니다.

## 📸 스크린샷

없음. Workflow와 문서 작업입니다.

## 💬 기타 공유사항 to 리뷰어

이 workflow는 kubeconfig, SSH key, 운영 secret 없이 실행됩니다. 실제 클러스터 배포 workflow는 이후 별도 이슈에서 진행합니다.