### PR TITLE
🔨 [Fix] 운영 배포 workflow 자동 실행 비활성화

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -2,9 +2,6 @@ name: Deploy Production
 
 on:
   workflow_dispatch:
-  push:
-    branches:
-      - main
 
 concurrency:
   group: production-deploy
@@ -20,6 +17,23 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - name: Validate deployment secrets
+        env:
+          DEPLOY_HOST: ${{ secrets.DEPLOY_HOST }}
+          DEPLOY_USER: ${{ secrets.DEPLOY_USER }}
+          DEPLOY_SSH_PRIVATE_KEY: ${{ secrets.DEPLOY_SSH_PRIVATE_KEY }}
+          DEPLOY_PATH: ${{ secrets.DEPLOY_PATH }}
+          PROD_BASE_URL: ${{ secrets.PROD_BASE_URL }}
+        run: |
+          missing=0
+          for name in DEPLOY_HOST DEPLOY_USER DEPLOY_SSH_PRIVATE_KEY DEPLOY_PATH PROD_BASE_URL; do
+            if [ -z "${!name}" ]; then
+              echo "::error::Missing GitHub production secret: ${name}"
+              missing=1
+            fi
+          done
+          exit "$missing"
 
       - name: Validate production compose template
         run: |

--- a/docs/feature-specs/issue-131-production-deploy-manual-trigger.md
+++ b/docs/feature-specs/issue-131-production-deploy-manual-trigger.md
@@ -1,0 +1,43 @@
+# 이슈 131. 운영 배포 workflow 수동 실행 전용 전환
+
+## 목적
+
+`Deploy Production` workflow가 `main` push마다 자동 실행되어 운영 서버 시크릿이 준비되지 않은 상태에서도 실패 체크를 만드는 문제를 막습니다.
+
+## 변경 사항
+
+1. `.github/workflows/deploy-production.yml`에서 `push` 트리거를 제거합니다.
+2. 운영 배포는 `workflow_dispatch` 수동 실행으로만 수행합니다.
+3. 수동 실행 시 필요한 GitHub Environment secret을 먼저 검사합니다.
+4. 누락된 secret이 있으면 SSH 접속 전에 명확한 에러 메시지로 실패합니다.
+5. 운영 배포 문서에 수동 실행 정책과 필수 secret 검증 방식을 반영합니다.
+
+## 필수 GitHub production secrets
+
+| Secret | 설명 |
+| --- | --- |
+| `DEPLOY_HOST` | 운영 서버 IP 또는 host |
+| `DEPLOY_USER` | SSH 배포 유저 |
+| `DEPLOY_SSH_PRIVATE_KEY` | 배포 유저 private key |
+| `DEPLOY_PATH` | 서버 배포 경로 |
+| `PROD_BASE_URL` | 배포 후 health/API docs 확인용 base URL |
+| `DEPLOY_SSH_PORT` | SSH 포트. 선택값이며 없으면 `22` 사용 |
+
+## 사용자가 값을 제공해야 하는 시점
+
+아직은 코드와 문서 작업만 가능하므로 실제 서버 값이 없어도 됩니다.
+
+운영 배포를 실제로 실행하기 직전에는 아래 값이 필요합니다.
+
+1. 운영 서버 접속 정보: host, SSH port, deploy user
+2. 배포용 SSH private key
+3. 서버 배포 경로
+4. 운영 도메인과 `PROD_BASE_URL`
+5. 서버의 `/opt/image-preprocess/shared/.env.prod`
+6. Google OAuth 운영 Client ID/Secret과 redirect URI
+
+## 완료 조건
+
+- `Deploy Production`이 `main` push로 자동 실행되지 않습니다.
+- 수동 실행 시 누락된 secret을 명확히 알려줍니다.
+- 운영 배포 문서가 현재 정책과 일치합니다.

--- a/docs/operation/github-actions-deployment.md
+++ b/docs/operation/github-actions-deployment.md
@@ -10,12 +10,19 @@ Workflow 파일:
 
 ## 실행 조건
 
-Workflow는 아래 경우 실행됩니다.
+Workflow는 아래 경우에만 실행됩니다.
 
 - `workflow_dispatch`: GitHub UI에서 수동 실행
-- `push` to `main`: main 반영 후 자동 실행
 
-첫 운영 배포는 반드시 수동 실행으로 검증하는 것을 권장합니다. 서버가 안정화된 뒤 main 자동 배포를 유지할지 결정합니다.
+현재 운영 배포 workflow는 `main` push 자동 실행을 하지 않습니다.
+서버 SSH 정보와 운영 `.env.prod`가 준비되지 않은 상태에서 자동 배포가 실패 체크를 만들지 않게 하기 위한 의도적인 설정입니다.
+
+자동 배포가 필요해지는 시점은 운영 서버, 도메인, HTTPS, Google OAuth 운영 redirect URI, 백업 정책까지 안정화된 뒤입니다.
+그 전까지는 아래 경로에서 명시적으로 수동 실행합니다.
+
+```text
+Actions -> Deploy Production -> Run workflow
+```
 
 ## GitHub Environment
 
@@ -35,6 +42,9 @@ production
 | `DEPLOY_SSH_PORT` | `22` | SSH 포트. 비워두면 22 |
 | `DEPLOY_PATH` | `/opt/image-preprocess` | 서버 배포 경로 |
 | `PROD_BASE_URL` | `https://YOUR_DOMAIN` | 배포 후 health check 기준 URL |
+
+Workflow는 수동 실행 직후 위 필수 secret이 비어 있는지 먼저 검사합니다.
+누락 값이 있으면 SSH 접속 전에 실패하며, Actions 로그에 `Missing GitHub production secret: ...` 형식으로 표시됩니다.
 
 주의:
 

--- a/docs/operation/production-deployment-guide.md
+++ b/docs/operation/production-deployment-guide.md
@@ -106,6 +106,9 @@ GitHub Actions에서 아래 workflow를 수동 실행합니다.
 Actions -> Deploy Production -> Run workflow
 ```
 
+`Deploy Production` workflow는 `main` push 때 자동으로 실행되지 않습니다.
+운영 서버 SSH 정보와 서버 `.env.prod`가 준비된 이후에만 수동으로 실행하는 것을 기본 정책으로 둡니다.
+
 workflow는 repository를 압축해 서버에 업로드하고, 서버의 shared `.env.prod`를 사용해 production compose stack을 실행합니다.
 
 사용되는 compose 명령:


### PR DESCRIPTION
## #️⃣ 기능 설명

운영 서버/SSH 시크릿이 준비되지 않은 상태에서 `main` push마다 `Deploy Production` workflow가 자동 실패하는 문제를 막습니다.

## 🛠️ 작업 상세 내용

- [x] `Deploy Production` workflow의 `push` 트리거 제거
- [x] 수동 실행 시 필수 production secret preflight 검사 추가
- [x] GitHub Actions 운영 배포 문서 갱신
- [x] 이슈별 기능 명세 문서 추가

## 📁 변경 파일 요약

- `.github/workflows/deploy-production.yml`
- `docs/operation/github-actions-deployment.md`
- `docs/operation/production-deployment-guide.md`
- `docs/feature-specs/issue-131-production-deploy-manual-trigger.md`

## ✅ 검증 내용

- [x] `git diff --check`: 통과
- [x] `docker compose -f infra/docker-compose/docker-compose.local.yml -f infra/docker-compose/docker-compose.prod.yml --env-file infra/docker-compose/.env.prod.example config`: 통과
- [ ] `actionlint`: 로컬 미설치로 미수행

## 🔎 리뷰어가 확인해야 할 부분

- 운영 배포를 `workflow_dispatch` 수동 실행 전용으로 두는 정책이 현재 배포 준비 단계와 맞는지 확인해주세요.
- 실제 운영 배포 직전 필요한 값은 `DEPLOY_HOST`, `DEPLOY_USER`, `DEPLOY_SSH_PRIVATE_KEY`, `DEPLOY_PATH`, `PROD_BASE_URL`입니다.

Closes #131