### PR TITLE
👷 [Ci] Kubernetes 수동 배포 workflow 추가

### DIFF
--- a/.github/workflows/deploy-k8s.yml
+++ b/.github/workflows/deploy-k8s.yml
@@ -1,0 +1,382 @@
+name: Deploy Kubernetes
+
+on:
+  workflow_dispatch:
+    inputs:
+      image_tag:
+        description: "Image tag to deploy. Defaults to the short commit SHA."
+        required: false
+        type: string
+      image_namespace:
+        description: "Container image namespace."
+        required: false
+        default: "ghcr.io/som141/docprep-cloud"
+        type: string
+      domain:
+        description: "Production domain, for example docprep.example.com."
+        required: true
+        default: "YOUR_DOMAIN"
+        type: string
+      tls_secret:
+        description: "Existing Kubernetes TLS secret name."
+        required: true
+        default: "docprep-cloud-tls"
+        type: string
+      postgres_external_name:
+        description: "ExternalName target for PostgreSQL."
+        required: true
+        default: "postgres.example.internal"
+        type: string
+      rabbitmq_external_name:
+        description: "ExternalName target for RabbitMQ."
+        required: true
+        default: "rabbitmq.example.internal"
+        type: string
+      minio_external_name:
+        description: "ExternalName target for MinIO/S3."
+        required: true
+        default: "minio.example.internal"
+        type: string
+      otel_collector_external_name:
+        description: "ExternalName target for OpenTelemetry Collector."
+        required: true
+        default: "otel-collector.example.internal"
+        type: string
+      apply_mode:
+        description: "Use dry-run first. Select apply only for a real deployment."
+        required: true
+        default: "dry-run"
+        type: choice
+        options:
+          - dry-run
+          - apply
+      kube_context:
+        description: "Optional kubeconfig context name."
+        required: false
+        type: string
+      rollout_timeout:
+        description: "Rollout wait timeout for each deployment."
+        required: true
+        default: "180s"
+        type: string
+      configure_ghcr_pull_secret:
+        description: "Create/patch a GHCR imagePullSecret from production secrets."
+        required: true
+        default: false
+        type: boolean
+
+permissions:
+  contents: read
+
+concurrency:
+  group: deploy-k8s-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    name: Deploy Kubernetes manifests
+    runs-on: ubuntu-latest
+    environment: production
+    timeout-minutes: 30
+
+    env:
+      NAMESPACE: docprep-cloud
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up kubectl
+        uses: azure/setup-kubectl@v4
+        with:
+          version: v1.30.2
+
+      - name: Resolve deploy inputs
+        id: inputs
+        shell: bash
+        env:
+          RAW_IMAGE_TAG: ${{ inputs.image_tag }}
+          RAW_IMAGE_NAMESPACE: ${{ inputs.image_namespace }}
+          RAW_DOMAIN: ${{ inputs.domain }}
+          RAW_TLS_SECRET: ${{ inputs.tls_secret }}
+          RAW_POSTGRES_EXTERNAL_NAME: ${{ inputs.postgres_external_name }}
+          RAW_RABBITMQ_EXTERNAL_NAME: ${{ inputs.rabbitmq_external_name }}
+          RAW_MINIO_EXTERNAL_NAME: ${{ inputs.minio_external_name }}
+          RAW_OTEL_COLLECTOR_EXTERNAL_NAME: ${{ inputs.otel_collector_external_name }}
+          RAW_APPLY_MODE: ${{ inputs.apply_mode }}
+          RAW_KUBE_CONTEXT: ${{ inputs.kube_context }}
+          RAW_ROLLOUT_TIMEOUT: ${{ inputs.rollout_timeout }}
+          RAW_CONFIGURE_GHCR_PULL_SECRET: ${{ inputs.configure_ghcr_pull_secret }}
+        run: |
+          set -euo pipefail
+
+          if [ -n "$RAW_IMAGE_TAG" ]; then
+            IMAGE_TAG="$RAW_IMAGE_TAG"
+          else
+            IMAGE_TAG="${GITHUB_SHA::12}"
+          fi
+
+          IMAGE_NAMESPACE="${RAW_IMAGE_NAMESPACE:-ghcr.io/som141/docprep-cloud}"
+          DOMAIN="${RAW_DOMAIN:-YOUR_DOMAIN}"
+          TLS_SECRET="${RAW_TLS_SECRET:-docprep-cloud-tls}"
+          POSTGRES_EXTERNAL_NAME="${RAW_POSTGRES_EXTERNAL_NAME:-postgres.example.internal}"
+          RABBITMQ_EXTERNAL_NAME="${RAW_RABBITMQ_EXTERNAL_NAME:-rabbitmq.example.internal}"
+          MINIO_EXTERNAL_NAME="${RAW_MINIO_EXTERNAL_NAME:-minio.example.internal}"
+          OTEL_COLLECTOR_EXTERNAL_NAME="${RAW_OTEL_COLLECTOR_EXTERNAL_NAME:-otel-collector.example.internal}"
+          APPLY_MODE="${RAW_APPLY_MODE:-dry-run}"
+          KUBE_CONTEXT="${RAW_KUBE_CONTEXT:-}"
+          ROLLOUT_TIMEOUT="${RAW_ROLLOUT_TIMEOUT:-180s}"
+          CONFIGURE_GHCR_PULL_SECRET="${RAW_CONFIGURE_GHCR_PULL_SECRET:-false}"
+
+          if [ "$DOMAIN" = "YOUR_DOMAIN" ]; then
+            echo "::error::domain input must be a real domain, not YOUR_DOMAIN."
+            exit 1
+          fi
+
+          for pair in \
+            "postgres_external_name:$POSTGRES_EXTERNAL_NAME:postgres.example.internal" \
+            "rabbitmq_external_name:$RABBITMQ_EXTERNAL_NAME:rabbitmq.example.internal" \
+            "minio_external_name:$MINIO_EXTERNAL_NAME:minio.example.internal" \
+            "otel_collector_external_name:$OTEL_COLLECTOR_EXTERNAL_NAME:otel-collector.example.internal"; do
+            IFS=":" read -r name value placeholder <<< "$pair"
+            if [ "$value" = "$placeholder" ]; then
+              echo "::error::${name} input must be a real service DNS name, not ${placeholder}."
+              exit 1
+            fi
+          done
+
+          if [ "$APPLY_MODE" != "dry-run" ] && [ "$APPLY_MODE" != "apply" ]; then
+            echo "::error::apply_mode must be dry-run or apply."
+            exit 1
+          fi
+
+          {
+            echo "image_tag=$IMAGE_TAG"
+            echo "image_namespace=${IMAGE_NAMESPACE%/}"
+            echo "domain=$DOMAIN"
+            echo "tls_secret=$TLS_SECRET"
+            echo "postgres_external_name=$POSTGRES_EXTERNAL_NAME"
+            echo "rabbitmq_external_name=$RABBITMQ_EXTERNAL_NAME"
+            echo "minio_external_name=$MINIO_EXTERNAL_NAME"
+            echo "otel_collector_external_name=$OTEL_COLLECTOR_EXTERNAL_NAME"
+            echo "apply_mode=$APPLY_MODE"
+            echo "kube_context=$KUBE_CONTEXT"
+            echo "rollout_timeout=$ROLLOUT_TIMEOUT"
+            echo "configure_ghcr_pull_secret=$CONFIGURE_GHCR_PULL_SECRET"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Configure kubeconfig
+        shell: bash
+        env:
+          KUBE_CONFIG_B64: ${{ secrets.KUBE_CONFIG_B64 }}
+          KUBE_CONTEXT: ${{ steps.inputs.outputs.kube_context }}
+        run: |
+          set -euo pipefail
+
+          if [ -z "$KUBE_CONFIG_B64" ]; then
+            echo "::error::Missing GitHub production secret: KUBE_CONFIG_B64"
+            exit 1
+          fi
+
+          KUBECONFIG_PATH="$RUNNER_TEMP/kubeconfig"
+          printf '%s' "$KUBE_CONFIG_B64" | base64 --decode > "$KUBECONFIG_PATH"
+          chmod 600 "$KUBECONFIG_PATH"
+
+          export KUBECONFIG="$KUBECONFIG_PATH"
+          echo "KUBECONFIG=$KUBECONFIG_PATH" >> "$GITHUB_ENV"
+
+          if [ -n "$KUBE_CONTEXT" ]; then
+            kubectl config use-context "$KUBE_CONTEXT"
+          fi
+
+          kubectl config current-context
+
+      - name: Copy Kubernetes manifests
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p "$RUNNER_TEMP/deploy"
+          cp -R infra/k8s "$RUNNER_TEMP/deploy/k8s"
+
+      - name: Inject image tags and domain placeholders
+        shell: bash
+        env:
+          MANIFEST_ROOT: ${{ runner.temp }}/deploy/k8s
+          IMAGE_NAMESPACE: ${{ steps.inputs.outputs.image_namespace }}
+          IMAGE_TAG: ${{ steps.inputs.outputs.image_tag }}
+          DOMAIN: ${{ steps.inputs.outputs.domain }}
+          TLS_SECRET: ${{ steps.inputs.outputs.tls_secret }}
+          POSTGRES_EXTERNAL_NAME: ${{ steps.inputs.outputs.postgres_external_name }}
+          RABBITMQ_EXTERNAL_NAME: ${{ steps.inputs.outputs.rabbitmq_external_name }}
+          MINIO_EXTERNAL_NAME: ${{ steps.inputs.outputs.minio_external_name }}
+          OTEL_COLLECTOR_EXTERNAL_NAME: ${{ steps.inputs.outputs.otel_collector_external_name }}
+        run: |
+          set -euo pipefail
+
+          python - <<'PY'
+          import os
+          import pathlib
+
+          root = pathlib.Path(os.environ["MANIFEST_ROOT"])
+          image_namespace = os.environ["IMAGE_NAMESPACE"].rstrip("/")
+          image_tag = os.environ["IMAGE_TAG"]
+          domain = os.environ["DOMAIN"]
+          tls_secret = os.environ["TLS_SECRET"]
+          postgres_external_name = os.environ["POSTGRES_EXTERNAL_NAME"]
+          rabbitmq_external_name = os.environ["RABBITMQ_EXTERNAL_NAME"]
+          minio_external_name = os.environ["MINIO_EXTERNAL_NAME"]
+          otel_collector_external_name = os.environ["OTEL_COLLECTOR_EXTERNAL_NAME"]
+
+          replacements = {
+              "YOUR_REGISTRY/docprep-backend-api:CHANGE_ME": f"{image_namespace}/backend-api:{image_tag}",
+              "YOUR_REGISTRY/docprep-preprocess-worker:CHANGE_ME": f"{image_namespace}/preprocess-worker:{image_tag}",
+              "YOUR_REGISTRY/docprep-frontend:CHANGE_ME": f"{image_namespace}/frontend:{image_tag}",
+              "YOUR_DOMAIN": domain,
+              "docprep-cloud-tls": tls_secret,
+              "postgres.example.internal": postgres_external_name,
+              "rabbitmq.example.internal": rabbitmq_external_name,
+              "minio.example.internal": minio_external_name,
+              "otel-collector.example.internal": otel_collector_external_name,
+          }
+
+          for path in root.rglob("*.yml"):
+              text = path.read_text(encoding="utf-8")
+              for before, after in replacements.items():
+                  text = text.replace(before, after)
+              path.write_text(text, encoding="utf-8")
+          PY
+
+      - name: Render manifests
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p rendered
+          kubectl kustomize "$RUNNER_TEMP/deploy/k8s" > rendered/docprep-cloud-k8s.yml
+
+      - name: Validate rendered manifest placeholders
+        shell: bash
+        run: |
+          set -euo pipefail
+          if grep -q "YOUR_REGISTRY\\|CHANGE_ME\\|YOUR_DOMAIN\\|example.internal" rendered/docprep-cloud-k8s.yml; then
+            echo "::error::Rendered manifest still contains deployment placeholders."
+            exit 1
+          fi
+
+      - name: Validate cluster prerequisites
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          kubectl cluster-info
+          kubectl get crd scaledobjects.keda.sh
+          kubectl get crd triggerauthentications.keda.sh
+          kubectl get ingressclass nginx
+
+      - name: Validate namespace and application secrets
+        shell: bash
+        env:
+          APPLY_MODE: ${{ steps.inputs.outputs.apply_mode }}
+          TLS_SECRET: ${{ steps.inputs.outputs.tls_secret }}
+          MANIFEST_ROOT: ${{ runner.temp }}/deploy/k8s
+        run: |
+          set -euo pipefail
+
+          if ! kubectl get namespace "$NAMESPACE" >/dev/null 2>&1; then
+            if [ "$APPLY_MODE" = "apply" ]; then
+              kubectl apply -f "$MANIFEST_ROOT/namespace.yml"
+            else
+              echo "::error::Namespace $NAMESPACE does not exist. Create namespace and app secrets first, or use the render workflow only."
+              exit 1
+            fi
+          fi
+
+          kubectl -n "$NAMESPACE" get secret backend-api-secret
+          kubectl -n "$NAMESPACE" get secret preprocess-worker-secret
+          kubectl -n "$NAMESPACE" get secret "$TLS_SECRET"
+
+      - name: Configure GHCR image pull secret
+        shell: bash
+        env:
+          APPLY_MODE: ${{ steps.inputs.outputs.apply_mode }}
+          CONFIGURE_GHCR_PULL_SECRET: ${{ steps.inputs.outputs.configure_ghcr_pull_secret }}
+          GHCR_USERNAME: ${{ secrets.GHCR_USERNAME }}
+          GHCR_TOKEN: ${{ secrets.GHCR_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          if [ "$CONFIGURE_GHCR_PULL_SECRET" != "true" ]; then
+            echo "Skipping GHCR imagePullSecret configuration."
+            exit 0
+          fi
+
+          if [ -z "$GHCR_USERNAME" ] || [ -z "$GHCR_TOKEN" ]; then
+            echo "::error::GHCR_USERNAME and GHCR_TOKEN production secrets are required when configure_ghcr_pull_secret is true."
+            exit 1
+          fi
+
+          if [ "$APPLY_MODE" = "dry-run" ]; then
+            kubectl -n "$NAMESPACE" create secret docker-registry ghcr-pull-secret \
+              --docker-server=ghcr.io \
+              --docker-username="$GHCR_USERNAME" \
+              --docker-password="$GHCR_TOKEN" \
+              --dry-run=server \
+              -o yaml >/dev/null
+            echo "GHCR imagePullSecret server dry-run succeeded."
+            exit 0
+          fi
+
+          kubectl -n "$NAMESPACE" create secret docker-registry ghcr-pull-secret \
+            --docker-server=ghcr.io \
+            --docker-username="$GHCR_USERNAME" \
+            --docker-password="$GHCR_TOKEN" \
+            --dry-run=client \
+            -o yaml | kubectl apply -f -
+
+          kubectl -n "$NAMESPACE" patch serviceaccount default \
+            --type merge \
+            -p '{"imagePullSecrets":[{"name":"ghcr-pull-secret"}]}'
+
+      - name: Apply manifests
+        shell: bash
+        env:
+          APPLY_MODE: ${{ steps.inputs.outputs.apply_mode }}
+          ROLLOUT_TIMEOUT: ${{ steps.inputs.outputs.rollout_timeout }}
+        run: |
+          set -euo pipefail
+
+          if [ "$APPLY_MODE" = "dry-run" ]; then
+            kubectl apply --dry-run=server -f rendered/docprep-cloud-k8s.yml
+            exit 0
+          fi
+
+          kubectl apply -f rendered/docprep-cloud-k8s.yml
+          kubectl -n "$NAMESPACE" rollout status deployment/backend-api --timeout="$ROLLOUT_TIMEOUT"
+          kubectl -n "$NAMESPACE" rollout status deployment/frontend --timeout="$ROLLOUT_TIMEOUT"
+          kubectl -n "$NAMESPACE" rollout status deployment/nginx --timeout="$ROLLOUT_TIMEOUT"
+          kubectl -n "$NAMESPACE" get pods,svc,ingress,scaledobject
+
+      - name: Write deployment summary
+        shell: bash
+        run: |
+          {
+            echo "### Kubernetes deployment"
+            echo ""
+            echo "- mode: \`${{ steps.inputs.outputs.apply_mode }}\`"
+            echo "- backend-api: \`${{ steps.inputs.outputs.image_namespace }}/backend-api:${{ steps.inputs.outputs.image_tag }}\`"
+            echo "- preprocess-worker: \`${{ steps.inputs.outputs.image_namespace }}/preprocess-worker:${{ steps.inputs.outputs.image_tag }}\`"
+            echo "- frontend: \`${{ steps.inputs.outputs.image_namespace }}/frontend:${{ steps.inputs.outputs.image_tag }}\`"
+            echo "- domain: \`${{ steps.inputs.outputs.domain }}\`"
+            echo "- tls secret: \`${{ steps.inputs.outputs.tls_secret }}\`"
+            echo "- namespace: \`$NAMESPACE\`"
+            echo "- postgres external name: \`${{ steps.inputs.outputs.postgres_external_name }}\`"
+            echo "- rabbitmq external name: \`${{ steps.inputs.outputs.rabbitmq_external_name }}\`"
+            echo "- minio external name: \`${{ steps.inputs.outputs.minio_external_name }}\`"
+            echo "- otel collector external name: \`${{ steps.inputs.outputs.otel_collector_external_name }}\`"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload rendered manifests
+        uses: actions/upload-artifact@v4
+        with:
+          name: docprep-cloud-k8s-deploy-${{ steps.inputs.outputs.image_tag }}
+          path: rendered/docprep-cloud-k8s.yml
+          if-no-files-found: error

--- a/docs/README.md
+++ b/docs/README.md
@@ -49,6 +49,7 @@ AI/Codex 작업 규칙 문서는 로컬 전용 파일로 관리하고 원격 저
 | [GitHub Actions 배포](operation/github-actions-deployment.md) | production workflow 사용법 |
 | [GHCR 이미지 빌드/푸시](operation/ghcr-image-workflow.md) | Kubernetes 배포용 이미지 생성 |
 | [Kubernetes manifest 렌더링](operation/kubernetes-manifest-render-workflow.md) | 이미지 태그를 주입한 K8s YAML artifact 생성 |
+| [Kubernetes GitHub Actions 배포](operation/kubernetes-github-actions-deploy.md) | kubeconfig 기반 수동 dry-run/apply workflow |
 | [HTTPS/도메인 정책](operation/https-domain-policy.md) | 도메인, TLS, OAuth redirect 기준 |
 | [백업/복구](operation/backup-restore.md) | PostgreSQL과 Object Storage 백업 |
 | [최종 E2E 검증](operation/final-e2e-verification.md) | 운영 배포 후 검증 흐름 |

--- a/docs/feature-specs/issue-133-kubernetes-github-actions-deploy.md
+++ b/docs/feature-specs/issue-133-kubernetes-github-actions-deploy.md
@@ -1,0 +1,38 @@
+# 이슈 133. Kubernetes 수동 배포 workflow
+
+## 목적
+
+Kubernetes manifest 렌더링 단계 다음으로, GitHub Actions에서 실제 클러스터에 `dry-run` 또는 `apply`를 수행할 수 있는 수동 CD workflow를 추가합니다.
+
+## 작업 범위
+
+1. `Deploy Kubernetes` workflow 추가
+2. GHCR 이미지 태그와 namespace 주입
+3. 운영 도메인과 TLS secret 주입
+4. PostgreSQL, RabbitMQ, MinIO, OTel Collector ExternalName 주입
+5. `KUBE_CONFIG_B64` 기반 kubeconfig 설정
+6. KEDA CRD, IngressClass, namespace, application secret 사전 확인
+7. `dry-run`과 실제 `apply` 모드 분리
+8. GHCR private image pull secret 선택 생성
+9. 운영 문서 갱신
+
+## 사용자에게 값을 요구하는 시점
+
+이번 작업은 workflow와 문서 추가이므로 사용자의 실제 운영 값이 필요하지 않습니다.
+
+실제 GitHub Actions에서 `Deploy Kubernetes`를 실행하기 직전에는 아래 값이 필요합니다.
+
+1. `KUBE_CONFIG_B64`
+2. 운영 도메인
+3. TLS secret 이름
+4. PostgreSQL, RabbitMQ, MinIO, OTel Collector DNS 이름
+5. `backend-api-secret`
+6. `preprocess-worker-secret`
+7. GHCR private image를 사용할 경우 `GHCR_USERNAME`, `GHCR_TOKEN`
+
+## 완료 기준
+
+- `.github/workflows/deploy-k8s.yml`이 추가됩니다.
+- `kubectl kustomize infra/k8s`가 통과합니다.
+- 렌더링 결과에 `YOUR_REGISTRY`, `CHANGE_ME`, `YOUR_DOMAIN`, `example.internal`이 남지 않는지 로컬 검증합니다.
+- 운영 문서에 실행 순서와 필수 준비값이 기록됩니다.

--- a/docs/operation/README.md
+++ b/docs/operation/README.md
@@ -10,12 +10,13 @@
 3. [GitHub Actions 배포](github-actions-deployment.md)
 4. [GHCR 이미지 빌드/푸시](ghcr-image-workflow.md)
 5. [Kubernetes manifest 렌더링](kubernetes-manifest-render-workflow.md)
-6. [HTTPS와 도메인 정책](https-domain-policy.md)
-7. [관측성 로컬 실행](observability.md)
-8. [Kubernetes/KEDA 배포](kubernetes-deployment.md)
-9. [배포 체크리스트](deployment-checklist.md)
-10. [최종 E2E 검증](final-e2e-verification.md)
-11. [백업/복구](backup-restore.md)
+6. [Kubernetes GitHub Actions 배포](kubernetes-github-actions-deploy.md)
+7. [HTTPS와 도메인 정책](https-domain-policy.md)
+8. [관측성 로컬 실행](observability.md)
+9. [Kubernetes/KEDA 배포](kubernetes-deployment.md)
+10. [배포 체크리스트](deployment-checklist.md)
+11. [최종 E2E 검증](final-e2e-verification.md)
+12. [백업/복구](backup-restore.md)
 
 ## 로컬 실행 문서
 
@@ -36,6 +37,7 @@
 | [GitHub Actions 배포](github-actions-deployment.md) | `Deploy Production` workflow 사용 |
 | [GHCR 이미지 빌드/푸시](ghcr-image-workflow.md) | Kubernetes 배포용 이미지 생성 |
 | [Kubernetes manifest 렌더링](kubernetes-manifest-render-workflow.md) | 이미지 태그를 주입한 K8s YAML artifact 생성 |
+| [Kubernetes GitHub Actions 배포](kubernetes-github-actions-deploy.md) | kubeconfig 기반 수동 dry-run/apply workflow |
 | [HTTPS/도메인 정책](https-domain-policy.md) | TLS 종료, OAuth redirect, cookie 정책 |
 | [관측성 로컬 실행](observability.md) | 배포 전 metric과 trace 검증 |
 | [Kubernetes/KEDA 배포](kubernetes-deployment.md) | Kubernetes skeleton 적용과 Worker autoscaling |

--- a/docs/operation/kubernetes-deployment.md
+++ b/docs/operation/kubernetes-deployment.md
@@ -65,6 +65,7 @@ infra/k8s/**/*.local.yml
 
 GHCR 이미지는 [GHCR 이미지 빌드/푸시 workflow](ghcr-image-workflow.md)로 생성한다.
 이미지 태그를 넣은 최종 Kubernetes YAML은 [Kubernetes manifest 렌더링 workflow](kubernetes-manifest-render-workflow.md)로 먼저 검토한다.
+실제 클러스터 적용은 [Kubernetes GitHub Actions 배포](kubernetes-github-actions-deploy.md)의 수동 `dry-run` 후 `apply` 순서로 진행한다.
 
 아래 파일의 placeholder를 실제 값으로 교체한다.
 

--- a/docs/operation/kubernetes-github-actions-deploy.md
+++ b/docs/operation/kubernetes-github-actions-deploy.md
@@ -1,0 +1,166 @@
+# Kubernetes GitHub Actions 배포
+
+이 문서는 GitHub Actions에서 Kubernetes manifest를 렌더링한 뒤 실제 클러스터에 `dry-run` 또는 `apply` 하는 수동 CD workflow를 설명합니다.
+
+## 목적
+
+기존 `Render Kubernetes Manifests` workflow는 YAML artifact만 만들고 클러스터에는 적용하지 않습니다.
+
+`Deploy Kubernetes` workflow는 다음 단계입니다.
+
+1. GHCR 이미지 태그를 Kubernetes manifest에 주입합니다.
+2. 운영 도메인과 TLS secret 이름을 주입합니다.
+3. GitHub production secret의 kubeconfig로 클러스터에 접속합니다.
+4. KEDA, IngressClass, namespace, application secret을 사전 확인합니다.
+5. `dry-run`으로 서버 검증하거나 `apply`로 실제 배포합니다.
+
+## Workflow 파일
+
+```text
+.github/workflows/deploy-k8s.yml
+```
+
+## 실행 조건
+
+수동 실행만 지원합니다.
+
+```text
+Actions -> Deploy Kubernetes -> Run workflow
+```
+
+`main` push 자동 배포는 아직 사용하지 않습니다. 실제 클러스터, 도메인, TLS, secret, 백업 정책이 안정화되기 전에는 수동 배포가 안전합니다.
+
+## GitHub production secrets
+
+GitHub repository의 `production` Environment에 아래 값을 등록합니다.
+
+| Secret | 필수 | 설명 |
+| --- | --- | --- |
+| `KUBE_CONFIG_B64` | O | kubeconfig 파일을 base64로 인코딩한 값 |
+| `GHCR_USERNAME` | 선택 | GHCR private image pull secret을 workflow에서 만들 때 사용 |
+| `GHCR_TOKEN` | 선택 | GHCR package read 권한이 있는 token |
+
+`KUBE_CONFIG_B64` 생성 예시:
+
+```bash
+base64 -w 0 ~/.kube/config
+```
+
+PowerShell 예시:
+
+```powershell
+[Convert]::ToBase64String([System.IO.File]::ReadAllBytes("$HOME\.kube\config"))
+```
+
+## Workflow 입력값
+
+| 입력값 | 기본값 | 설명 |
+| --- | --- | --- |
+| `image_tag` | commit SHA 앞 12자리 | 배포할 이미지 태그 |
+| `image_namespace` | `ghcr.io/som141/docprep-cloud` | 이미지 namespace |
+| `domain` | `YOUR_DOMAIN` | 운영 도메인. 실제 배포에서는 반드시 교체 |
+| `tls_secret` | `docprep-cloud-tls` | 클러스터에 이미 존재해야 하는 TLS secret |
+| `postgres_external_name` | `postgres.example.internal` | PostgreSQL로 연결되는 실제 DNS 이름 |
+| `rabbitmq_external_name` | `rabbitmq.example.internal` | RabbitMQ로 연결되는 실제 DNS 이름 |
+| `minio_external_name` | `minio.example.internal` | MinIO/S3 API로 연결되는 실제 DNS 이름 |
+| `otel_collector_external_name` | `otel-collector.example.internal` | OpenTelemetry Collector로 연결되는 실제 DNS 이름 |
+| `apply_mode` | `dry-run` | `dry-run` 또는 `apply` |
+| `kube_context` | 빈 값 | kubeconfig 안의 특정 context를 선택할 때 사용 |
+| `rollout_timeout` | `180s` | deployment rollout 대기 시간 |
+| `configure_ghcr_pull_secret` | `false` | GHCR pull secret을 workflow가 만들고 default service account에 연결할지 여부 |
+
+`domain`, `postgres_external_name`, `rabbitmq_external_name`, `minio_external_name`, `otel_collector_external_name`에 기본 placeholder가 남아 있으면 workflow는 배포를 중단합니다.
+
+## 클러스터 사전 조건
+
+실행 전에 아래 항목이 준비되어야 합니다.
+
+| 항목 | 확인 명령 |
+| --- | --- |
+| 대상 namespace | `kubectl get namespace docprep-cloud` |
+| KEDA CRD | `kubectl get crd scaledobjects.keda.sh` |
+| KEDA TriggerAuthentication CRD | `kubectl get crd triggerauthentications.keda.sh` |
+| NGINX IngressClass | `kubectl get ingressclass nginx` |
+| backend-api secret | `kubectl -n docprep-cloud get secret backend-api-secret` |
+| preprocess-worker secret | `kubectl -n docprep-cloud get secret preprocess-worker-secret` |
+| TLS secret | `kubectl -n docprep-cloud get secret docprep-cloud-tls` |
+
+`apply_mode=apply`일 때 namespace가 없으면 workflow가 `infra/k8s/namespace.yml`을 먼저 적용합니다.  
+하지만 application secret과 TLS secret은 실제 운영 값을 담기 때문에 workflow가 자동 생성하지 않습니다.
+
+## 실행 순서
+
+권장 순서는 아래와 같습니다.
+
+1. `Build GHCR Images` workflow로 이미지 생성
+2. `Render Kubernetes Manifests` workflow로 YAML artifact 검토
+3. 클러스터에 namespace와 secret 준비
+4. DB, RabbitMQ, MinIO, OTel Collector의 실제 DNS 이름을 입력해 `Deploy Kubernetes` workflow를 `apply_mode=dry-run`으로 실행
+5. dry-run 성공 후 `apply_mode=apply`로 실행
+6. 운영 도메인 접속과 E2E 검증 수행
+
+## GHCR private image 처리
+
+GHCR package가 public이면 별도 image pull secret이 필요하지 않습니다.
+
+GHCR package가 private이면 아래 중 하나를 선택합니다.
+
+1. GHCR package visibility를 public으로 변경합니다.
+2. `GHCR_USERNAME`, `GHCR_TOKEN`을 production secret에 등록하고 `configure_ghcr_pull_secret=true`로 실행합니다.
+
+두 번째 방식을 사용하면 workflow가 아래 작업을 수행합니다.
+
+1. `ghcr-pull-secret` docker-registry secret 생성 또는 갱신
+2. `default` service account에 `imagePullSecrets` 연결
+
+## 배포 후 확인
+
+workflow가 `apply` 모드로 실행되면 아래 rollout을 기다립니다.
+
+```text
+deployment/backend-api
+deployment/frontend
+deployment/nginx
+```
+
+`preprocess-worker`는 KEDA scale-to-zero 구조라 queue가 비어 있으면 replica `0`이 정상입니다.
+
+수동 확인 명령:
+
+```bash
+kubectl -n docprep-cloud get pods
+kubectl -n docprep-cloud get svc
+kubectl -n docprep-cloud get ingress
+kubectl -n docprep-cloud get scaledobject
+```
+
+브라우저 검증:
+
+1. 운영 도메인 접속
+2. Google 로그인
+3. 프로젝트 생성
+4. 이미지 또는 ZIP 업로드
+5. 전처리 Job 생성
+6. 처리된 이미지 또는 ZIP 다운로드
+
+## 사용자가 값을 줘야 하는 시점
+
+이번 workflow 작성 단계에서는 실제 값을 줄 필요가 없습니다.
+
+실제 `Deploy Kubernetes` workflow를 실행하기 직전에는 아래 값을 받아야 합니다.
+
+1. 운영 클러스터 kubeconfig 또는 배포 전용 service account kubeconfig
+2. 운영 도메인
+3. TLS secret 이름과 생성 방식
+4. PostgreSQL, RabbitMQ, MinIO, OTel Collector의 Kubernetes 접근 DNS 이름
+5. backend-api, preprocess-worker Kubernetes secret의 실제 값
+6. GHCR package가 private일 경우 GHCR read token
+7. Google OAuth 운영 Client ID/Secret과 redirect URI
+
+## 현재 한계
+
+1. PostgreSQL, RabbitMQ, MinIO는 아직 placeholder service 기준입니다.
+2. TLS secret 자동 발급은 포함하지 않습니다.
+3. DB migration 전용 Job은 아직 없습니다.
+4. Prometheus Operator용 ServiceMonitor는 아직 없습니다.
+5. 실제 운영 환경에서는 첫 apply 전에 네트워크, DNS, storage endpoint를 별도로 점검해야 합니다.

--- a/docs/operation/kubernetes-manifest-render-workflow.md
+++ b/docs/operation/kubernetes-manifest-render-workflow.md
@@ -79,5 +79,5 @@ docprep-cloud-k8s-{image_tag}
 
 1. GHCR 이미지 push workflow와 연결
 2. image tag를 자동으로 render workflow에 전달
-3. kubeconfig 기반 `kubectl apply` CD 추가
+3. [Kubernetes GitHub Actions 배포](kubernetes-github-actions-deploy.md)로 kubeconfig 기반 `dry-run` 또는 `apply` 수행
 4. 배포 후 health check와 smoke test 추가


### PR DESCRIPTION
## #️⃣ 기능 설명

GitHub Actions에서 Kubernetes manifest를 렌더링한 뒤 kubeconfig 기반으로 `dry-run` 또는 실제 `apply`를 수행하는 수동 CD workflow를 추가합니다.

## 🛠️ 작업 상세 내용

- [x] `Deploy Kubernetes` workflow 추가
- [x] 이미지 태그, 이미지 namespace, 운영 도메인, TLS secret 주입
- [x] PostgreSQL/RabbitMQ/MinIO/OTel Collector ExternalName 주입
- [x] `KUBE_CONFIG_B64` 기반 kubeconfig 설정
- [x] KEDA CRD, IngressClass, namespace, application secret preflight 검사
- [x] `dry-run`/`apply` 모드 분리
- [x] GHCR private image pull secret 선택 생성 지원
- [x] 운영 문서와 feature spec 추가

## 📁 변경 파일 요약

- `.github/workflows/deploy-k8s.yml`
- `docs/operation/kubernetes-github-actions-deploy.md`
- `docs/feature-specs/issue-133-kubernetes-github-actions-deploy.md`
- `docs/operation/README.md`
- `docs/README.md`
- `docs/operation/kubernetes-deployment.md`
- `docs/operation/kubernetes-manifest-render-workflow.md`

## ✅ 검증 내용

- [x] `kubectl kustomize infra/k8s`: 통과
- [x] 로컬 렌더링 후 `YOUR_REGISTRY`, `CHANGE_ME`, `YOUR_DOMAIN`, `example.internal` placeholder 미잔존 확인: 통과
- [x] `git diff --check`: 통과
- [x] `docker run --rm ... rhysd/actionlint:latest .github/workflows/deploy-k8s.yml`: 통과
- [ ] 실제 `Deploy Kubernetes` workflow 실행: `KUBE_CONFIG_B64`와 클러스터 secret이 아직 없어 미수행

## 🔎 리뷰어가 확인해야 할 부분

- 실제 배포 전 필요한 값은 `KUBE_CONFIG_B64`, 운영 도메인, TLS secret, backend/worker Kubernetes secret, PostgreSQL/RabbitMQ/MinIO/OTel DNS 이름입니다.
- GHCR package가 private이면 `GHCR_USERNAME`, `GHCR_TOKEN`도 production secret에 추가하고 `configure_ghcr_pull_secret=true`로 실행해야 합니다.

Closes #133