### PR TITLE
🧹 [Chore] Kubernetes secret 준비와 preflight 스크립트 추가

### DIFF
--- a/docs/feature-specs/issue-135-kubernetes-secret-preflight-scripts.md
+++ b/docs/feature-specs/issue-135-kubernetes-secret-preflight-scripts.md
@@ -1,0 +1,42 @@
+# 이슈 135. Kubernetes secret 준비와 preflight 스크립트
+
+## 목적
+
+Kubernetes 실제 배포 전에 사용자가 직접 준비해야 하는 application secret과 cluster 사전 조건을 명확히 확인할 수 있도록 로컬 스크립트와 문서를 추가합니다.
+
+## 작업 범위
+
+1. 환경변수 기반 Kubernetes Secret manifest 생성 스크립트 추가
+2. 생성 결과를 gitignore된 `infra/k8s/**/secret.yml`에 저장
+3. 현재 kubectl context의 namespace, secret, KEDA CRD, IngressClass 확인 스크립트 추가
+4. 필요한 환경변수 목록과 실행 순서 문서화
+
+## 추가 스크립트
+
+| 스크립트 | 역할 |
+| --- | --- |
+| `scripts/k8s-generate-secrets.ps1` | 운영 값을 환경변수로 받아 `backend-api-secret`, `preprocess-worker-secret` manifest 생성 |
+| `scripts/k8s-preflight.ps1` | 실제 cluster에 배포 전 필수 리소스 존재 여부 확인 |
+
+## 완료 기준
+
+- PowerShell parser 기준 문법 오류가 없습니다.
+- dummy 환경변수로 secret manifest 생성이 가능합니다.
+- 생성된 secret manifest 경로가 `.gitignore` 대상입니다.
+- 실제 secret 값은 저장소에 포함하지 않습니다.
+- 운영 문서에 실행 순서가 남아 있습니다.
+
+## 사용자에게 값을 요구하는 시점
+
+이번 작업은 스크립트와 문서 추가라 실제 운영 값이 필요하지 않습니다.
+
+실제 배포 직전에는 아래 값을 받아야 합니다.
+
+1. DB 계정과 비밀번호
+2. RabbitMQ 계정, 비밀번호, AMQP URI
+3. Google OAuth 운영 Client ID/Secret
+4. JWT secret
+5. MinIO/S3 access key와 secret key
+6. Worker internal token
+7. TLS secret 이름과 생성 방식
+8. Kubernetes context 또는 kubeconfig

--- a/docs/operation/kubernetes-secret-preflight.md
+++ b/docs/operation/kubernetes-secret-preflight.md
@@ -1,0 +1,143 @@
+# Kubernetes Secret 준비와 Preflight
+
+이 문서는 Kubernetes 배포 직전에 필요한 application secret manifest를 로컬에서 생성하고, 클러스터 사전 조건을 확인하는 방법을 정리합니다.
+
+실제 secret 값은 Git에 커밋하지 않습니다. 생성되는 파일은 `.gitignore` 대상입니다.
+
+## 사용하는 스크립트
+
+| 스크립트 | 용도 |
+| --- | --- |
+| `scripts/k8s-generate-secrets.ps1` | 환경변수에서 값을 읽어 `backend-api-secret`, `preprocess-worker-secret` manifest 생성 |
+| `scripts/k8s-preflight.ps1` | 현재 `kubectl` context의 namespace, secret, KEDA, IngressClass 존재 여부 확인 |
+
+## 생성되는 파일
+
+```text
+infra/k8s/backend-api/secret.yml
+infra/k8s/preprocess-worker/secret.yml
+```
+
+두 파일은 `.gitignore`에 포함되어 있으므로 원격 저장소에 올라가지 않습니다.
+
+## 필요한 환경변수
+
+`k8s-generate-secrets.ps1` 실행 전 아래 값을 현재 shell 환경변수로 넣습니다.
+
+| 환경변수 | 사용처 |
+| --- | --- |
+| `DB_USERNAME` | backend-api DB 접속 계정 |
+| `DB_PASSWORD` | backend-api DB 접속 비밀번호 |
+| `SPRING_RABBITMQ_USERNAME` | API/Worker RabbitMQ 계정 |
+| `SPRING_RABBITMQ_PASSWORD` | API/Worker RabbitMQ 비밀번호 |
+| `RABBITMQ_AMQP_URI` | KEDA와 Worker가 사용할 AMQP URI |
+| `GOOGLE_CLIENT_ID` | Google OAuth 운영 Client ID |
+| `GOOGLE_CLIENT_SECRET` | Google OAuth 운영 Client Secret |
+| `JWT_SECRET` | Access Token 서명 secret. 32자 이상 |
+| `MINIO_ACCESS_KEY` | S3/MinIO access key |
+| `MINIO_SECRET_KEY` | S3/MinIO secret key |
+| `WORKER_INTERNAL_TOKEN` | backend-api와 worker 내부 통신 토큰 |
+
+예시:
+
+```powershell
+$env:DB_USERNAME = "CHANGE_THIS_IN_LOCAL_SHELL"
+$env:DB_PASSWORD = "CHANGE_THIS_IN_LOCAL_SHELL"
+$env:SPRING_RABBITMQ_USERNAME = "CHANGE_THIS_IN_LOCAL_SHELL"
+$env:SPRING_RABBITMQ_PASSWORD = "CHANGE_THIS_IN_LOCAL_SHELL"
+$env:RABBITMQ_AMQP_URI = "amqp://USER:PASSWORD@rabbitmq:5672/%2F"
+$env:GOOGLE_CLIENT_ID = "CHANGE_THIS_IN_LOCAL_SHELL"
+$env:GOOGLE_CLIENT_SECRET = "CHANGE_THIS_IN_LOCAL_SHELL"
+$env:JWT_SECRET = "CHANGE_THIS_TO_AT_LEAST_32_CHARACTERS"
+$env:MINIO_ACCESS_KEY = "CHANGE_THIS_IN_LOCAL_SHELL"
+$env:MINIO_SECRET_KEY = "CHANGE_THIS_IN_LOCAL_SHELL"
+$env:WORKER_INTERNAL_TOKEN = "CHANGE_THIS_TO_A_LONG_RANDOM_VALUE"
+```
+
+위 예시는 형식만 보여줍니다. 실제 값은 문서나 PR에 적지 않습니다.
+
+## Secret manifest 생성
+
+레포지토리 루트에서 실행합니다.
+
+```powershell
+.\scripts\k8s-generate-secrets.ps1
+```
+
+이미 파일이 있으면 덮어쓰지 않습니다. 다시 생성하려면 `-Force`를 붙입니다.
+
+```powershell
+.\scripts\k8s-generate-secrets.ps1 -Force
+```
+
+현재 `kubectl` context에 바로 적용하려면 `-Apply`를 붙입니다.
+
+```powershell
+.\scripts\k8s-generate-secrets.ps1 -Force -Apply
+```
+
+`-Apply`는 현재 `kubectl` context에 secret을 적용합니다. 실행 전에 반드시 아래 명령으로 대상 cluster를 확인합니다.
+
+```powershell
+kubectl config current-context
+```
+
+## 클러스터 preflight
+
+Kubernetes 사전 조건을 확인합니다.
+
+```powershell
+.\scripts\k8s-preflight.ps1
+```
+
+특정 context를 선택하려면 다음처럼 실행합니다.
+
+```powershell
+.\scripts\k8s-preflight.ps1 -KubeContext "YOUR_CONTEXT"
+```
+
+GHCR package가 private이고 image pull secret을 직접 준비했다면 다음 옵션을 추가합니다.
+
+```powershell
+.\scripts\k8s-preflight.ps1 -RequireGhcrPullSecret
+```
+
+## 확인하는 항목
+
+`k8s-preflight.ps1`은 읽기 전용으로 아래 항목을 확인합니다.
+
+| 항목 | 확인 명령 |
+| --- | --- |
+| kubectl 설치 | `kubectl` command |
+| 현재 context | `kubectl config current-context` |
+| cluster 연결 | `kubectl cluster-info` |
+| namespace | `kubectl get namespace docprep-cloud` |
+| backend secret | `kubectl -n docprep-cloud get secret backend-api-secret` |
+| worker secret | `kubectl -n docprep-cloud get secret preprocess-worker-secret` |
+| TLS secret | `kubectl -n docprep-cloud get secret docprep-cloud-tls` |
+| KEDA CRD | `kubectl get crd scaledobjects.keda.sh` |
+| KEDA auth CRD | `kubectl get crd triggerauthentications.keda.sh` |
+| IngressClass | `kubectl get ingressclass nginx` |
+
+## 실제 배포 전 순서
+
+권장 순서는 아래와 같습니다.
+
+1. 운영 secret 값을 로컬 shell 환경변수로만 설정합니다.
+2. `k8s-generate-secrets.ps1 -Force`로 secret manifest를 만듭니다.
+3. `kubectl config current-context`로 대상 cluster를 확인합니다.
+4. namespace가 없으면 먼저 생성합니다.
+5. `kubectl apply -f infra/k8s/backend-api/secret.yml`을 실행합니다.
+6. `kubectl apply -f infra/k8s/preprocess-worker/secret.yml`을 실행합니다.
+7. TLS secret을 생성하거나 기존 secret 이름을 확인합니다.
+8. `k8s-preflight.ps1`을 통과시킵니다.
+9. `Render Kubernetes Manifests` workflow로 YAML을 검토합니다.
+10. `Deploy Kubernetes` workflow를 `dry-run`으로 실행합니다.
+11. 문제가 없으면 `Deploy Kubernetes` workflow를 `apply`로 실행합니다.
+
+## 주의사항
+
+- `secret.yml` 파일은 로컬에 남기지 않아도 됩니다. 필요할 때 다시 생성하면 됩니다.
+- 생성된 secret 값을 PR, 문서, 이슈에 붙여넣지 않습니다.
+- `RABBITMQ_AMQP_URI`에 비밀번호가 들어가므로 터미널 공유 시 주의합니다.
+- 운영 cluster에 적용하기 전 `kubectl config current-context`를 반드시 확인합니다.

--- a/infra/k8s/README.md
+++ b/infra/k8s/README.md
@@ -42,6 +42,20 @@ kubectl apply -f infra/k8s/preprocess-worker/secret.yml
 kubectl apply -k infra/k8s
 ```
 
+Secret 파일은 환경변수 기반으로 생성할 수 있다.
+
+```powershell
+.\scripts\k8s-generate-secrets.ps1 -Force
+```
+
+클러스터에 실제 배포하기 전에는 preflight를 먼저 실행한다.
+
+```powershell
+.\scripts\k8s-preflight.ps1
+```
+
+자세한 순서는 [Kubernetes Secret 준비와 Preflight](../../docs/operation/kubernetes-secret-preflight.md)를 따른다.
+
 ## 주의사항
 
 - `postgres`, `rabbitmq`, `minio`, `otel-collector`는 현재 `ExternalName` placeholder다.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,36 +1,37 @@
 # scripts
 
-This directory contains local development and operation helper scripts.
+이 디렉터리는 로컬 개발, 검증, 운영 준비용 보조 스크립트를 둡니다.
 
-## Current Scripts
+## 현재 스크립트
 
-- `local-e2e-smoke.ps1`: Runs the Docker Compose local MVP flow through HTTP APIs. It creates synthetic document
-  images, simulates ZIP expansion, uploads through presigned URLs, creates a preprocessing Job, waits for Worker
-  completion, and downloads processed outputs.
-- `docker-compose-preflight.ps1`: Checks Docker Compose config, container states, NGINX routing, backend health,
-  Swagger/OpenAPI, MinIO health, and RabbitMQ queue topology before running browser or E2E tests.
+- `local-e2e-smoke.ps1`: Docker Compose local MVP 흐름을 HTTP API로 검증합니다. 테스트 문서 이미지를 만들고, ZIP 확장 동작을 흉내 낸 뒤, presigned URL 업로드, 전처리 Job 생성, Worker 처리 완료 대기, 처리 결과 다운로드까지 확인합니다.
+- `docker-compose-preflight.ps1`: 브라우저 테스트나 E2E 테스트 전에 Docker Compose 설정, 컨테이너 상태, NGINX 라우팅, backend health, Swagger/OpenAPI, MinIO health, RabbitMQ queue topology를 확인합니다.
+- `k8s-generate-secrets.ps1`: 환경변수에서 운영 값을 읽어 gitignore된 Kubernetes Secret manifest를 생성합니다.
+- `k8s-preflight.ps1`: 실제 Kubernetes 배포 전 현재 `kubectl` context의 namespace, secret, KEDA CRD, IngressClass를 확인합니다.
 
-Run from the repository root:
+레포지토리 루트에서 실행합니다.
 
 ```powershell
 .\scripts\docker-compose-preflight.ps1
 ```
 
-Then run the authenticated E2E smoke flow:
+인증이 필요한 E2E smoke flow는 다음처럼 실행합니다.
 
 ```powershell
 .\scripts\local-e2e-smoke.ps1 -AccessToken "<access-token>"
 ```
 
-To get the token, sign in through `http://localhost/login` and read this value in browser DevTools:
+토큰은 `http://localhost/login`으로 로그인한 뒤 브라우저 DevTools에서 아래 값을 확인합니다.
 
 ```javascript
 localStorage.getItem('doc-pipeline.access-token')
 ```
 
-## Planned Scripts
+Kubernetes secret 준비는 실제 운영 값을 shell 환경변수에 넣은 뒤 실행합니다.
 
-- `local-up.sh`
-- `local-down.sh`
-- `seed-dev-data.sh`
-- `clean-object-storage.sh`
+```powershell
+.\scripts\k8s-generate-secrets.ps1 -Force
+.\scripts\k8s-preflight.ps1
+```
+
+자세한 내용은 [Kubernetes Secret 준비와 Preflight](../docs/operation/kubernetes-secret-preflight.md)를 확인합니다.

--- a/scripts/k8s-generate-secrets.ps1
+++ b/scripts/k8s-generate-secrets.ps1
@@ -1,0 +1,166 @@
+<#
+.SYNOPSIS
+Generates local Kubernetes Secret manifests from environment variables.
+
+.DESCRIPTION
+This script reads production-like values from environment variables and writes only gitignored Kubernetes Secret
+manifests under infra/k8s. It never prints secret values. Use -Apply only after checking the target kubectl context.
+#>
+[CmdletBinding()]
+param(
+    [string]$Namespace = "docprep-cloud",
+    [string]$BackendSecretPath = "infra/k8s/backend-api/secret.yml",
+    [string]$WorkerSecretPath = "infra/k8s/preprocess-worker/secret.yml",
+    [switch]$Force,
+    [switch]$Apply
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+function Resolve-RepoPath {
+    param([string]$Path)
+
+    if ([System.IO.Path]::IsPathRooted($Path)) {
+        return $Path
+    }
+
+    $repoRoot = Split-Path -Parent $PSScriptRoot
+    return Join-Path $repoRoot $Path
+}
+
+function Get-RequiredEnv {
+    param([string]$Name)
+
+    $value = [Environment]::GetEnvironmentVariable($Name)
+    if ([string]::IsNullOrWhiteSpace($value)) {
+        throw "Required environment variable is missing: $Name"
+    }
+    if ($value -match "CHANGE_ME") {
+        throw "Environment variable still contains placeholder text: $Name"
+    }
+    if ($value -match "[`r`n]") {
+        throw "Multiline values are not supported for Kubernetes stringData in this script: $Name"
+    }
+    return $value
+}
+
+function ConvertTo-YamlSingleQuoted {
+    param([string]$Value)
+
+    return "'" + $Value.Replace("'", "''") + "'"
+}
+
+function New-SecretManifest {
+    param(
+        [string]$Name,
+        [string]$Namespace,
+        [string]$AppName,
+        [hashtable]$Values
+    )
+
+    $lines = New-Object System.Collections.Generic.List[string]
+    $lines.Add("apiVersion: v1")
+    $lines.Add("kind: Secret")
+    $lines.Add("metadata:")
+    $lines.Add("  name: $Name")
+    $lines.Add("  namespace: $Namespace")
+    $lines.Add("  labels:")
+    $lines.Add("    app.kubernetes.io/name: $AppName")
+    $lines.Add("    app.kubernetes.io/part-of: docprep-cloud")
+    $lines.Add("type: Opaque")
+    $lines.Add("stringData:")
+
+    foreach ($key in ($Values.Keys | Sort-Object)) {
+        $lines.Add("  ${key}: $(ConvertTo-YamlSingleQuoted $Values[$key])")
+    }
+
+    return ($lines -join [Environment]::NewLine) + [Environment]::NewLine
+}
+
+function Write-SecretFile {
+    param(
+        [string]$Path,
+        [string]$Content
+    )
+
+    $resolvedPath = Resolve-RepoPath $Path
+    $directory = Split-Path -Parent $resolvedPath
+    if (-not (Test-Path -LiteralPath $directory)) {
+        New-Item -ItemType Directory -Path $directory -Force | Out-Null
+    }
+
+    if ((Test-Path -LiteralPath $resolvedPath) -and -not $Force) {
+        throw "Secret file already exists: $resolvedPath. Re-run with -Force to overwrite."
+    }
+
+    Set-Content -LiteralPath $resolvedPath -Value $Content -Encoding UTF8
+    Write-Host "Wrote secret manifest: $Path"
+}
+
+function Invoke-KubectlApply {
+    param([string]$Path)
+
+    if ($null -eq (Get-Command kubectl -ErrorAction SilentlyContinue)) {
+        throw "kubectl command is not available."
+    }
+
+    $resolvedPath = Resolve-RepoPath $Path
+    & kubectl apply -f $resolvedPath
+    if ($LASTEXITCODE -ne 0) {
+        throw "kubectl apply failed: $Path"
+    }
+}
+
+$backendValues = @{
+    DB_USERNAME = Get-RequiredEnv "DB_USERNAME"
+    DB_PASSWORD = Get-RequiredEnv "DB_PASSWORD"
+    SPRING_RABBITMQ_USERNAME = Get-RequiredEnv "SPRING_RABBITMQ_USERNAME"
+    SPRING_RABBITMQ_PASSWORD = Get-RequiredEnv "SPRING_RABBITMQ_PASSWORD"
+    GOOGLE_CLIENT_ID = Get-RequiredEnv "GOOGLE_CLIENT_ID"
+    GOOGLE_CLIENT_SECRET = Get-RequiredEnv "GOOGLE_CLIENT_SECRET"
+    JWT_SECRET = Get-RequiredEnv "JWT_SECRET"
+    MINIO_ACCESS_KEY = Get-RequiredEnv "MINIO_ACCESS_KEY"
+    MINIO_SECRET_KEY = Get-RequiredEnv "MINIO_SECRET_KEY"
+    WORKER_INTERNAL_TOKEN = Get-RequiredEnv "WORKER_INTERNAL_TOKEN"
+}
+
+$workerValues = @{
+    SPRING_RABBITMQ_USERNAME = Get-RequiredEnv "SPRING_RABBITMQ_USERNAME"
+    SPRING_RABBITMQ_PASSWORD = Get-RequiredEnv "SPRING_RABBITMQ_PASSWORD"
+    RABBITMQ_AMQP_URI = Get-RequiredEnv "RABBITMQ_AMQP_URI"
+    MINIO_ACCESS_KEY = Get-RequiredEnv "MINIO_ACCESS_KEY"
+    MINIO_SECRET_KEY = Get-RequiredEnv "MINIO_SECRET_KEY"
+    WORKER_INTERNAL_TOKEN = Get-RequiredEnv "WORKER_INTERNAL_TOKEN"
+}
+
+if ($backendValues.JWT_SECRET.Length -lt 32) {
+    throw "JWT_SECRET must be at least 32 characters."
+}
+
+if ($backendValues.WORKER_INTERNAL_TOKEN.Length -lt 16) {
+    throw "WORKER_INTERNAL_TOKEN must be at least 16 characters."
+}
+
+$backendManifest = New-SecretManifest `
+    -Name "backend-api-secret" `
+    -Namespace $Namespace `
+    -AppName "backend-api" `
+    -Values $backendValues
+
+$workerManifest = New-SecretManifest `
+    -Name "preprocess-worker-secret" `
+    -Namespace $Namespace `
+    -AppName "preprocess-worker" `
+    -Values $workerValues
+
+Write-SecretFile -Path $BackendSecretPath -Content $backendManifest
+Write-SecretFile -Path $WorkerSecretPath -Content $workerManifest
+
+if ($Apply) {
+    Write-Host "Applying generated secrets to the current kubectl context."
+    Invoke-KubectlApply -Path $BackendSecretPath
+    Invoke-KubectlApply -Path $WorkerSecretPath
+}
+
+Write-Host "Secret generation completed. Generated files are gitignored and must not be committed."

--- a/scripts/k8s-preflight.ps1
+++ b/scripts/k8s-preflight.ps1
@@ -1,0 +1,125 @@
+<#
+.SYNOPSIS
+Checks Kubernetes prerequisites before running the Deploy Kubernetes workflow.
+
+.DESCRIPTION
+This script performs read-only checks against the current kubectl context. It does not create or update resources.
+#>
+[CmdletBinding()]
+param(
+    [string]$Namespace = "docprep-cloud",
+    [string]$TlsSecretName = "docprep-cloud-tls",
+    [string]$IngressClassName = "nginx",
+    [string]$KubeContext = "",
+    [switch]$SkipKeda,
+    [switch]$SkipTls,
+    [switch]$SkipApplicationSecrets,
+    [switch]$RequireGhcrPullSecret
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+$script:Failures = New-Object System.Collections.Generic.List[string]
+
+function Invoke-PreflightCheck {
+    param(
+        [string]$Name,
+        [scriptblock]$Action
+    )
+
+    Write-Host "[check] $Name"
+    try {
+        & $Action
+        Write-Host "[ ok ] $Name"
+    } catch {
+        $message = "$Name failed: $($_.Exception.Message)"
+        $script:Failures.Add($message)
+        Write-Warning $message
+    }
+}
+
+function Invoke-Kubectl {
+    param([string[]]$Arguments)
+
+    $output = & kubectl @Arguments 2>&1
+    if ($LASTEXITCODE -ne 0) {
+        throw ($output -join [Environment]::NewLine)
+    }
+    return $output
+}
+
+Write-Host "Kubernetes preflight"
+Write-Host "Namespace: $Namespace"
+Write-Host "TLS secret: $TlsSecretName"
+Write-Host "IngressClass: $IngressClassName"
+
+Invoke-PreflightCheck "kubectl command" {
+    if ($null -eq (Get-Command kubectl -ErrorAction SilentlyContinue)) {
+        throw "kubectl command is not available."
+    }
+}
+
+if (-not [string]::IsNullOrWhiteSpace($KubeContext)) {
+    Invoke-PreflightCheck "select kubectl context" {
+        Invoke-Kubectl @("config", "use-context", $KubeContext) | Out-Null
+    }
+}
+
+Invoke-PreflightCheck "current kubectl context" {
+    Invoke-Kubectl @("config", "current-context") | Out-Host
+}
+
+Invoke-PreflightCheck "cluster reachable" {
+    Invoke-Kubectl @("cluster-info") | Out-Null
+}
+
+Invoke-PreflightCheck "namespace exists" {
+    Invoke-Kubectl @("get", "namespace", $Namespace) | Out-Null
+}
+
+if (-not $SkipApplicationSecrets) {
+    Invoke-PreflightCheck "backend-api-secret exists" {
+        Invoke-Kubectl @("-n", $Namespace, "get", "secret", "backend-api-secret") | Out-Null
+    }
+
+    Invoke-PreflightCheck "preprocess-worker-secret exists" {
+        Invoke-Kubectl @("-n", $Namespace, "get", "secret", "preprocess-worker-secret") | Out-Null
+    }
+}
+
+if (-not $SkipTls) {
+    Invoke-PreflightCheck "TLS secret exists" {
+        Invoke-Kubectl @("-n", $Namespace, "get", "secret", $TlsSecretName) | Out-Null
+    }
+}
+
+if (-not $SkipKeda) {
+    Invoke-PreflightCheck "KEDA ScaledObject CRD exists" {
+        Invoke-Kubectl @("get", "crd", "scaledobjects.keda.sh") | Out-Null
+    }
+
+    Invoke-PreflightCheck "KEDA TriggerAuthentication CRD exists" {
+        Invoke-Kubectl @("get", "crd", "triggerauthentications.keda.sh") | Out-Null
+    }
+}
+
+Invoke-PreflightCheck "IngressClass exists" {
+    Invoke-Kubectl @("get", "ingressclass", $IngressClassName) | Out-Null
+}
+
+if ($RequireGhcrPullSecret) {
+    Invoke-PreflightCheck "GHCR image pull secret exists" {
+        Invoke-Kubectl @("-n", $Namespace, "get", "secret", "ghcr-pull-secret") | Out-Null
+    }
+}
+
+if ($script:Failures.Count -gt 0) {
+    Write-Host ""
+    Write-Host "Kubernetes preflight failed:"
+    $script:Failures | ForEach-Object { Write-Host "- $_" }
+    exit 1
+}
+
+Write-Host ""
+Write-Host "Kubernetes preflight passed. The cluster is ready for manifest dry-run or apply."


### PR DESCRIPTION
## #️⃣ 기능 설명

Kubernetes 실제 배포 전에 필요한 application secret manifest를 환경변수 기반으로 생성하고, 클러스터 사전 조건을 확인하는 로컬 스크립트를 추가합니다.

## 🛠️ 작업 상세 내용

- [x] `scripts/k8s-generate-secrets.ps1` 추가
- [x] `scripts/k8s-preflight.ps1` 추가
- [x] 생성 결과를 gitignore된 `infra/k8s/**/secret.yml`에 저장하도록 구성
- [x] dummy 환경변수 기반 secret manifest 생성 검증
- [x] Kubernetes secret/preflight 운영 문서 추가
- [x] scripts와 infra/k8s README 갱신

## 📁 변경 파일 요약

- `scripts/k8s-generate-secrets.ps1`
- `scripts/k8s-preflight.ps1`
- `docs/operation/kubernetes-secret-preflight.md`
- `docs/feature-specs/issue-135-kubernetes-secret-preflight-scripts.md`
- `infra/k8s/README.md`
- `scripts/README.md`

## ✅ 검증 내용

- [x] PowerShell parser check: 통과
- [x] dummy 환경변수로 secret manifest 생성: 통과
- [x] 생성 manifest 구조 확인: 통과
- [x] 생성 대상 `infra/k8s/**/secret.yml` gitignore 확인: 통과
- [x] `git diff --check`: 통과
- [ ] 실제 cluster preflight: Kubernetes cluster 접근값이 아직 없어 미수행

## 🔎 리뷰어가 확인해야 할 부분

- 실제 운영 secret 값은 저장소에 포함하지 않았습니다.
- 실제 Kubernetes 배포 직전에는 DB/RabbitMQ/Google OAuth/JWT/MinIO/Worker token 값을 환경변수로 넣고 `k8s-generate-secrets.ps1`을 실행해야 합니다.

Closes #135