### PR TITLE
🔨 [Fix] Kubernetes OAuth redirect URI HTTPS 보정

### DIFF
--- a/infra/k8s/nginx/configmap.yml
+++ b/infra/k8s/nginx/configmap.yml
@@ -1,4 +1,4 @@
-apiVersion: v1
+﻿apiVersion: v1
 kind: ConfigMap
 metadata:
   name: nginx-config
@@ -18,6 +18,11 @@ data:
         include /etc/nginx/mime.types;
         default_type application/octet-stream;
 
+        map $http_x_forwarded_proto $proxy_x_forwarded_proto {
+            default $http_x_forwarded_proto;
+            "" $scheme;
+        }
+
         sendfile on;
         keepalive_timeout 65;
         client_max_body_size 2g;
@@ -30,7 +35,7 @@ data:
                 proxy_set_header Host $host;
                 proxy_set_header X-Real-IP $remote_addr;
                 proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-                proxy_set_header X-Forwarded-Proto $scheme;
+                proxy_set_header X-Forwarded-Proto $proxy_x_forwarded_proto;
                 proxy_buffering off;
                 proxy_read_timeout 1h;
                 proxy_pass http://backend-api:8080;
@@ -41,7 +46,7 @@ data:
                 proxy_set_header Host $host;
                 proxy_set_header X-Real-IP $remote_addr;
                 proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-                proxy_set_header X-Forwarded-Proto $scheme;
+                proxy_set_header X-Forwarded-Proto $proxy_x_forwarded_proto;
                 proxy_pass http://backend-api:8080;
             }
 
@@ -50,7 +55,7 @@ data:
                 proxy_set_header Host $host;
                 proxy_set_header X-Real-IP $remote_addr;
                 proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-                proxy_set_header X-Forwarded-Proto $scheme;
+                proxy_set_header X-Forwarded-Proto $proxy_x_forwarded_proto;
                 proxy_pass http://backend-api:8080;
             }
 
@@ -59,7 +64,7 @@ data:
                 proxy_set_header Host $host;
                 proxy_set_header X-Real-IP $remote_addr;
                 proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-                proxy_set_header X-Forwarded-Proto $scheme;
+                proxy_set_header X-Forwarded-Proto $proxy_x_forwarded_proto;
                 proxy_pass http://backend-api:8080;
             }
 
@@ -68,7 +73,7 @@ data:
                 proxy_set_header Host $host;
                 proxy_set_header X-Real-IP $remote_addr;
                 proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-                proxy_set_header X-Forwarded-Proto $scheme;
+                proxy_set_header X-Forwarded-Proto $proxy_x_forwarded_proto;
                 proxy_pass http://backend-api:8080;
             }
 
@@ -77,7 +82,7 @@ data:
                 proxy_set_header Host $host;
                 proxy_set_header X-Real-IP $remote_addr;
                 proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-                proxy_set_header X-Forwarded-Proto $scheme;
+                proxy_set_header X-Forwarded-Proto $proxy_x_forwarded_proto;
                 proxy_pass http://backend-api:8080;
             }
 
@@ -86,7 +91,7 @@ data:
                 proxy_set_header Host $host;
                 proxy_set_header X-Real-IP $remote_addr;
                 proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-                proxy_set_header X-Forwarded-Proto $scheme;
+                proxy_set_header X-Forwarded-Proto $proxy_x_forwarded_proto;
                 proxy_pass http://backend-api:8080;
             }
 
@@ -95,7 +100,7 @@ data:
                 proxy_set_header Host $host;
                 proxy_set_header X-Real-IP $remote_addr;
                 proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-                proxy_set_header X-Forwarded-Proto $scheme;
+                proxy_set_header X-Forwarded-Proto $proxy_x_forwarded_proto;
                 proxy_pass http://frontend:80;
             }
         }


### PR DESCRIPTION
## #️⃣ 기능 설명

Kubernetes 배포에서 Google OAuth redirect_uri가 `http://...`로 생성되는 문제를 수정했습니다.

Closes #139

## 🛠️ 작업 상세 내용

- [x] NGINX 내부 proxy가 Ingress의 `X-Forwarded-Proto` 값을 보존하도록 `map` 추가
- [x] backend-api, OAuth2, Swagger, API, frontend proxy 경로 모두 동일하게 forwarded proto 전달
- [x] ngrok HTTPS 접속 시 Google authorization URL의 `redirect_uri`가 HTTPS로 생성되는지 확인

## 📁 변경 파일 요약

- `infra/k8s/nginx/configmap.yml`

## ✅ 검증 내용

- [x] `kubectl kustomize infra/k8s`: 통과
- [x] `git diff --check HEAD~1 HEAD`: 통과
- [x] 클러스터에 NGINX configmap 적용 및 nginx rollout 완료
- [x] 공개 URL `/` 200 확인
- [x] 공개 URL `/v3/api-docs` 200 확인
- [x] `/oauth2/authorization/google` 302 Location 확인
- [x] `redirect_uri=https://ardella-unmarketable-jacob.ngrok-free.dev/login/oauth2/code/google` 확인

## 🔎 리뷰어가 확인해야 할 부분

- Ingress 뒤 내부 NGINX가 `X-Forwarded-Proto`를 보존하는 방식이 배포 환경에 맞는지 확인해주세요.

## 📸 스크린샷

없음

## 💬 기타 공유사항 to 리뷰어

- 이 수정은 PR #138 merge 직후 발견된 OAuth HTTPS redirect 보정입니다.