### PR TITLE
🔨 [Fix] Kubernetes 공개 라우팅 프록시 수정

### DIFF
--- a/docs/feature-specs/issue-141-kubernetes-oauth-success-route.md
+++ b/docs/feature-specs/issue-141-kubernetes-oauth-success-route.md
@@ -1,0 +1,40 @@
+# Issue 141. Kubernetes OAuth 성공 라우팅 수정
+
+## 문제
+
+Kubernetes 배포 환경에서 Google OAuth 로그인 성공 후 `/oauth2/success?login=success`로 이동하면 프론트엔드 SPA가 아니라 `backend-api`로 프록시되어 `common500` 응답이 표시되었다.
+
+## 원인
+
+프론트엔드는 `/oauth2/success` 경로에서 OAuth 성공 후 세션을 확인하도록 구현되어 있다. 하지만 Kubernetes NGINX ConfigMap에는 `/oauth2/` 전체를 `backend-api:8080`으로 보내는 prefix 라우트만 있었고, `/oauth2/success`를 프론트로 보내는 exact 라우트가 없었다.
+
+로컬 NGINX 설정에는 이미 아래 정책이 있었지만 Kubernetes 설정에는 누락되어 있었다.
+
+```text
+/oauth2/success -> frontend
+/oauth2/*       -> backend-api
+```
+
+## 수정 내용
+
+`infra/k8s/nginx/configmap.yml`에 exact match 라우트를 추가했다.
+
+```nginx
+location = /oauth2/success {
+    proxy_pass http://frontend:80;
+}
+```
+
+OAuth 시작과 콜백 경로는 기존처럼 백엔드로 유지한다.
+
+```text
+/oauth2/authorization/google -> backend-api
+/login/oauth2/code/google    -> backend-api
+```
+
+## 검증 기준
+
+- `https://{도메인}/oauth2/success?login=success`가 200 HTML을 반환한다.
+- `https://{도메인}/oauth2/authorization/google`은 Google OAuth로 302 리다이렉트된다.
+- `https://{도메인}/v3/api-docs`는 기존처럼 backend-api에서 200을 반환한다.
+

--- a/infra/k8s/nginx/configmap.yml
+++ b/infra/k8s/nginx/configmap.yml
@@ -50,6 +50,15 @@ data:
                 proxy_pass http://backend-api:8080;
             }
 
+            location = /oauth2/success {
+                proxy_http_version 1.1;
+                proxy_set_header Host $host;
+                proxy_set_header X-Real-IP $remote_addr;
+                proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+                proxy_set_header X-Forwarded-Proto $proxy_x_forwarded_proto;
+                proxy_pass http://frontend:80;
+            }
+
             location /oauth2/ {
                 proxy_http_version 1.1;
                 proxy_set_header Host $host;


### PR DESCRIPTION
## #️⃣ 기능 설명

Closes #141
Closes #143

Kubernetes 배포 환경에서 공개 도메인으로 들어오는 특수 경로가 잘못 프록시되던 문제를 수정했습니다.

- OAuth 성공 화면 `/oauth2/success`가 backend-api로 들어가 `common500`을 반환하던 문제 수정
- MinIO presigned URL bucket path `/image-preprocess-prod/...`가 frontend로 들어가 `HTTP 405`를 반환하던 문제 수정

## 🛠️ 작업 상세 내용

- [x] Kubernetes NGINX ConfigMap에 `location = /oauth2/success` exact 라우트 추가
- [x] `/oauth2/success`는 frontend로 전달하고 `/oauth2/authorization/google`, `/login/oauth2/code/google`은 backend-api로 유지
- [x] `/image-preprocess-local/`, `/image-preprocess-prod/` bucket path를 MinIO API로 프록시
- [x] presigned URL 서명 검증을 위해 bucket path 프록시에서 공개 `Host` 헤더 유지
- [x] 원인과 검증 기준을 기능 명세 문서로 기록
- [x] 실제 클러스터 ConfigMap 적용 및 NGINX 롤아웃 검증

## 📁 변경 파일 요약

- `infra/k8s/nginx/configmap.yml`
- `docs/feature-specs/issue-141-kubernetes-oauth-success-route.md`
- `docs/feature-specs/issue-143-kubernetes-minio-presigned-route.md`

## ✅ 검증 내용

- [x] `kubectl kustomize infra/k8s`: 통과
- [x] `git diff --check`: 통과
- [x] `kubectl -n docprep-cloud apply -f infra/k8s/nginx/configmap.yml`: 적용 완료
- [x] `kubectl -n docprep-cloud rollout restart deployment/nginx`: 완료
- [x] `GET /oauth2/success?login=success`: `200 text/html` 확인
- [x] `GET /oauth2/authorization/google`: Google OAuth `302` 확인
- [x] `PUT /image-preprocess-prod/__route_probe__.png`: 프론트 `405`가 아니라 MinIO `403 AccessDenied XML` 확인

## 🔎 리뷰어가 확인해야 할 부분

- `/oauth2/success` exact route가 `/oauth2/` prefix route보다 우선되어 프론트 SPA로 전달되는지 확인해주세요.
- OAuth 시작/콜백 라우팅이 backend-api로 유지되는지 확인해주세요.
- bucket path 라우트가 presigned upload/download URL을 MinIO로 전달하면서 `Host` 헤더를 유지하는지 확인해주세요.

## 📸 스크린샷

생략

## 💬 기타 공유사항 to 리뷰어

실제 클러스터에는 이미 동일 설정을 적용했습니다. 업로드 405 원인은 NGINX가 bucket path를 프론트로 보내던 것이며, 현재 외부 URL에서 bucket path PUT 요청은 MinIO까지 도달합니다.