### PR TITLE
🔨 [Fix] Kubernetes 공개 라우팅 프록시 수정

### DIFF
--- a/docs/feature-specs/issue-143-kubernetes-minio-presigned-route.md
+++ b/docs/feature-specs/issue-143-kubernetes-minio-presigned-route.md
@@ -1,0 +1,53 @@
+# Issue 143. Kubernetes MinIO presigned URL 업로드 405 수정
+
+## 문제
+
+Kubernetes 배포 환경에서 업로드 화면으로 이미지를 선택한 뒤 전처리 작업을 실행하면 원본 업로드 단계에서 `HTTP 405`가 발생했다.
+
+```text
+Upload originals to object storage failed. MinIO upload failed ... HTTP 405.
+```
+
+## 원인
+
+`backend-api`는 브라우저가 접근 가능한 presigned URL을 만들기 위해 `MINIO_PUBLIC_ENDPOINT`를 사용한다.
+
+운영형 Kubernetes 환경에서는 이 값이 공개 도메인이다.
+
+```text
+MINIO_PUBLIC_ENDPOINT=https://{공개 도메인}
+```
+
+따라서 업로드 URL은 아래처럼 생성된다.
+
+```text
+https://{공개 도메인}/image-preprocess-prod/{objectKey}?X-Amz-...
+```
+
+하지만 Kubernetes NGINX ConfigMap에는 `/image-preprocess-prod/` bucket path를 `minio:9000`으로 보내는 라우트가 없었다. 그 결과 `PUT` 요청이 프론트엔드 NGINX로 전달되어 정적 파일 서버가 `405 Method Not Allowed`를 반환했다.
+
+## 수정 내용
+
+Kubernetes NGINX ConfigMap에 bucket path 라우트를 추가했다.
+
+```nginx
+location ~ ^/(image-preprocess-local|image-preprocess-prod)/ {
+    proxy_set_header Host $host;
+    proxy_request_buffering off;
+    proxy_buffering off;
+    proxy_pass http://minio:9000;
+}
+```
+
+## 중요한 점
+
+presigned URL은 서명에 요청 host와 path가 포함된다. 그래서 NGINX가 MinIO로 넘길 때 `Host`를 내부 서비스명 `minio:9000`으로 바꾸면 서명이 맞지 않을 수 있다.
+
+이 설정은 공개 도메인의 `Host` 값을 그대로 유지한다.
+
+## 검증 기준
+
+- 외부 URL에서 `PUT /image-preprocess-prod/{objectKey}` 요청이 더 이상 프론트의 405를 반환하지 않는다.
+- 서명 없는 테스트 요청은 MinIO의 XML 오류를 반환한다.
+- 실제 프론트 업로드는 presigned URL을 사용하므로 원본 업로드 단계가 통과해야 한다.
+

--- a/infra/k8s/nginx/configmap.yml
+++ b/infra/k8s/nginx/configmap.yml
@@ -59,6 +59,18 @@ data:
                 proxy_pass http://frontend:80;
             }
 
+            location ~ ^/(image-preprocess-local|image-preprocess-prod)/ {
+                proxy_http_version 1.1;
+                proxy_set_header Host $host;
+                proxy_set_header X-Real-IP $remote_addr;
+                proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+                proxy_set_header X-Forwarded-Proto $proxy_x_forwarded_proto;
+                proxy_request_buffering off;
+                proxy_buffering off;
+                proxy_read_timeout 1h;
+                proxy_pass http://minio:9000;
+            }
+
             location /oauth2/ {
                 proxy_http_version 1.1;
                 proxy_set_header Host $host;


### PR DESCRIPTION
## #️⃣ 기능 설명

Closes #143
Closes #145

Kubernetes 배포 환경에서 공개 도메인으로 들어오는 특수 경로가 잘못 프록시되거나 301 리다이렉트되어 프론트에서 `HTTP 0 non-JSON response`로 보이던 문제를 수정했습니다.

## 🛠️ 작업 상세 내용

- [x] `/image-preprocess-local/`, `/image-preprocess-prod/` bucket path를 MinIO API로 프록시
- [x] presigned URL 서명 검증을 위해 bucket path 프록시에서 공개 `Host` 헤더 유지
- [x] 대용량 업로드를 위해 `proxy_request_buffering off`, `proxy_buffering off`, `proxy_read_timeout 1h` 적용
- [x] `/api/v1/jobs` exact route를 추가해 NGINX trailing slash 301 방지
- [x] 원인과 검증 기준을 기능 명세 문서로 기록
- [x] 실제 클러스터 ConfigMap 적용 및 NGINX 롤아웃 검증

## 📁 변경 파일 요약

- `infra/k8s/nginx/configmap.yml`
- `docs/feature-specs/issue-143-kubernetes-minio-presigned-route.md`
- `docs/feature-specs/issue-145-kubernetes-job-api-trailing-slash.md`

## ✅ 검증 내용

- [x] `kubectl kustomize infra/k8s`: 통과
- [x] `git diff --check`: 통과
- [x] `kubectl -n docprep-cloud apply -f infra/k8s/nginx/configmap.yml`: 적용 완료
- [x] `kubectl -n docprep-cloud rollout restart deployment/nginx`: 완료
- [x] `PUT /image-preprocess-prod/__route_probe__.png`: 프론트 `405`가 아니라 MinIO `403 AccessDenied XML` 확인
- [x] `GET /oauth2/success?login=success`: `200 text/html` 유지 확인
- [x] `POST /api/v1/jobs`: 301이 아니라 JSON `401` 확인
- [x] `GET /api/v1/jobs?size=5`: 301이 아니라 JSON `401` 확인

## 🔎 리뷰어가 확인해야 할 부분

- bucket path 라우트가 presigned upload/download URL을 MinIO로 전달하면서 `Host` 헤더를 유지하는지 확인해주세요.
- `/api/v1/jobs` exact route가 `/api/v1/jobs/` prefix route의 자동 301을 막는지 확인해주세요.
- 기존 OAuth, API, frontend 라우팅과 충돌하지 않는지 확인해주세요.

## 📸 스크린샷

생략

## 💬 기타 공유사항 to 리뷰어

실제 클러스터에는 이미 동일 설정을 적용했습니다. 업로드 원본 PUT은 200으로 통과했고, Job 생성 API는 더 이상 NGINX 301로 빠지지 않습니다.