### PR TITLE
🔨 [Fix] Kubernetes Job API trailing slash redirect 수정

### DIFF
--- a/docs/feature-specs/issue-145-kubernetes-job-api-trailing-slash.md
+++ b/docs/feature-specs/issue-145-kubernetes-job-api-trailing-slash.md
@@ -1,0 +1,51 @@
+# Issue 145. Kubernetes Job API trailing slash 301 수정
+
+## 문제
+
+Kubernetes 배포 환경에서 프론트가 전처리 작업을 생성할 때 `POST /api/v1/jobs`를 호출하면 `HTTP 0 non-JSON response` 오류가 표시되었다.
+
+```text
+Create preprocessing job failed. API returned non-JSON response with HTTP 0
+```
+
+대시보드에서도 일부 Job 관련 API 호출이 같은 방식으로 실패할 수 있다.
+
+## 원인
+
+Kubernetes NGINX ConfigMap에는 SSE와 Job detail 계열 경로를 위해 아래 prefix location이 있었다.
+
+```nginx
+location /api/v1/jobs/ {
+    proxy_pass http://backend-api:8080;
+}
+```
+
+NGINX는 slash로 끝나는 proxy prefix location이 있을 때 slash 없는 exact path 요청을 slash path로 301 리다이렉트할 수 있다.
+
+실제 로그는 다음과 같았다.
+
+```text
+POST /api/v1/jobs HTTP/1.1 301
+```
+
+프론트 API client는 보안상 `redirect: manual`을 사용한다. 이 경우 브라우저 fetch는 수동 리다이렉트 응답을 opaque redirect로 처리할 수 있고, 프론트에서는 status가 `0`인 non-JSON 응답처럼 보인다.
+
+## 수정 내용
+
+`/api/v1/jobs` exact route를 추가해 slash 없는 Job collection API가 리다이렉트 없이 backend-api로 전달되게 했다.
+
+```nginx
+location = /api/v1/jobs {
+    proxy_pass http://backend-api:8080;
+}
+```
+
+기존 `/api/v1/jobs/` prefix route는 SSE와 하위 Job 경로를 위해 유지한다.
+
+## 검증 기준
+
+- `POST /api/v1/jobs`가 301을 반환하지 않는다.
+- 인증이 없으면 JSON `401`이 반환된다.
+- 인증이 있으면 Job 생성 API가 JSON 응답을 반환한다.
+- 업로드 화면에서 원본 업로드 완료 후 Job 생성 단계로 넘어간다.
+

--- a/infra/k8s/nginx/configmap.yml
+++ b/infra/k8s/nginx/configmap.yml
@@ -30,6 +30,15 @@ data:
         server {
             listen 80;
 
+            location = /api/v1/jobs {
+                proxy_http_version 1.1;
+                proxy_set_header Host $host;
+                proxy_set_header X-Real-IP $remote_addr;
+                proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+                proxy_set_header X-Forwarded-Proto $proxy_x_forwarded_proto;
+                proxy_pass http://backend-api:8080;
+            }
+
             location /api/v1/jobs/ {
                 proxy_http_version 1.1;
                 proxy_set_header Host $host;


### PR DESCRIPTION
## #️⃣ 기능 설명

Closes #145

Kubernetes NGINX에서 `POST /api/v1/jobs`가 `/api/v1/jobs/`로 301 리다이렉트되어 프론트에서 `HTTP 0 non-JSON response`로 보이던 문제를 수정했습니다.

## 🛠️ 작업 상세 내용

- [x] `/api/v1/jobs` exact route 추가
- [x] `/api/v1/jobs/` prefix route는 SSE와 하위 Job 경로용으로 유지
- [x] NGINX trailing slash 301 원인 문서화
- [x] 실제 클러스터 ConfigMap 적용 및 NGINX 롤아웃 검증

## 📁 변경 파일 요약

- `infra/k8s/nginx/configmap.yml`
- `docs/feature-specs/issue-145-kubernetes-job-api-trailing-slash.md`

## ✅ 검증 내용

- [x] `kubectl kustomize infra/k8s`: 통과
- [x] `git diff --check`: 통과
- [x] `kubectl -n docprep-cloud apply -f infra/k8s/nginx/configmap.yml`: 적용 완료
- [x] `kubectl -n docprep-cloud rollout restart deployment/nginx`: 완료
- [x] `POST /api/v1/jobs`: 301이 아니라 JSON `401` 확인
- [x] `GET /api/v1/jobs?size=5`: 301이 아니라 JSON `401` 확인

## 🔎 리뷰어가 확인해야 할 부분

- `/api/v1/jobs` exact route가 `/api/v1/jobs/` prefix route의 자동 301을 막는지 확인해주세요.
- 기존 `/api/v1/jobs/{jobId}` 및 SSE 경로와 충돌하지 않는지 확인해주세요.

## 📸 스크린샷

생략

## 💬 기타 공유사항 to 리뷰어

실제 클러스터에는 이미 동일 설정을 적용했습니다. 업로드 원본 PUT은 이미 200으로 통과했고, Job 생성 API는 더 이상 NGINX 301로 빠지지 않습니다.