### PR TITLE
👷 [Ci] Kubernetes 배포 workflow self-hosted runner 전환

### DIFF
--- a/.github/workflows/deploy-k8s.yml
+++ b/.github/workflows/deploy-k8s.yml
@@ -213,7 +213,7 @@ jobs:
         run: |
           set -euo pipefail
 
-          python - <<'PY'
+          python3 - <<'PY'
           import os
           import pathlib
 

--- a/.github/workflows/deploy-k8s.yml
+++ b/.github/workflows/deploy-k8s.yml
@@ -75,7 +75,7 @@ concurrency:
 jobs:
   deploy:
     name: Deploy Kubernetes manifests
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64, docprep-k8s]
     environment: production
     timeout-minutes: 30
 

--- a/docs/feature-specs/issue-149-kubernetes-self-hosted-runner.md
+++ b/docs/feature-specs/issue-149-kubernetes-self-hosted-runner.md
@@ -1,0 +1,47 @@
+# Issue 149. Kubernetes 배포 workflow self-hosted runner 전환
+
+## 목적
+
+GitHub hosted runner는 사설망 Kubernetes API에 접근할 수 없다.
+
+```text
+Kubernetes API: 10.0.1.6:6443
+```
+
+따라서 Kubernetes cluster 내부에 self-hosted runner를 설치하고, `Deploy Kubernetes` workflow가 해당 runner에서 실행되도록 변경한다.
+
+## 작업 내용
+
+1. `github-actions` namespace에 `docprep-k8s-runner` Deployment를 설치한다.
+2. GitHub repository runner 등록 상태를 확인한다.
+3. `Deploy Kubernetes` workflow의 `runs-on`을 self-hosted runner 라벨로 변경한다.
+4. Kubernetes GitHub Actions 배포 문서를 한글로 갱신한다.
+
+## runner 라벨
+
+```text
+self-hosted
+Linux
+X64
+docprep-k8s
+k8s
+deploy
+```
+
+workflow는 아래 라벨을 사용한다.
+
+```yaml
+runs-on: [self-hosted, Linux, X64, docprep-k8s]
+```
+
+## 완료 조건
+
+- GitHub runner 목록에서 `docprep-k8s` runner가 `online` 상태다.
+- `Deploy Kubernetes` workflow가 GitHub hosted runner가 아닌 self-hosted runner에서 실행된다.
+- 관련 운영 문서가 갱신된다.
+
+## 운영 주의사항
+
+현재 runner는 registration token 기반으로 등록된다. Pod 재시작 시 token이 만료되어 있으면 재등록에 실패할 수 있다.
+
+장기 운영에서는 Actions Runner Controller 또는 GitHub App/PAT 기반 token refresh 구조로 전환한다.

--- a/docs/operation/kubernetes-github-actions-deploy.md
+++ b/docs/operation/kubernetes-github-actions-deploy.md
@@ -1,121 +1,109 @@
 # Kubernetes GitHub Actions 배포
 
-이 문서는 GitHub Actions에서 Kubernetes manifest를 렌더링한 뒤 실제 클러스터에 `dry-run` 또는 `apply` 하는 수동 CD workflow를 설명합니다.
+이 문서는 GitHub Actions에서 Kubernetes manifest를 렌더링하고 실제 cluster에 배포하는 방법을 정리한다.
 
-## 목적
+## 현재 방식
 
-기존 `Render Kubernetes Manifests` workflow는 YAML artifact만 만들고 클러스터에는 적용하지 않습니다.
+`Deploy Kubernetes` workflow는 GitHub hosted runner가 아니라 cluster 내부 self-hosted runner에서 실행한다.
 
-`Deploy Kubernetes` workflow는 다음 단계입니다.
+```text
+runs-on: [self-hosted, Linux, X64, docprep-k8s]
+```
 
-1. GHCR 이미지 태그를 Kubernetes manifest에 주입합니다.
-2. 운영 도메인과 TLS secret 이름을 주입합니다.
-3. GitHub production secret의 kubeconfig로 클러스터에 접속합니다.
-4. KEDA, IngressClass, namespace, application secret을 사전 확인합니다.
-5. `dry-run`으로 서버 검증하거나 `apply`로 실제 배포합니다.
+이유는 배포 대상 Kubernetes API가 사설망 주소이기 때문이다.
 
-## Workflow 파일
+```text
+Kubernetes API: 10.0.1.6:6443
+```
+
+GitHub hosted runner는 이 주소에 접근할 수 없다. 따라서 `github-actions` namespace에 올라간 `docprep-k8s-runner` Pod가 배포 job을 수행한다.
+
+## 배포 workflow 파일
 
 ```text
 .github/workflows/deploy-k8s.yml
 ```
 
-## 실행 조건
+## 실행 방법
 
-수동 실행만 지원합니다.
+GitHub에서 아래 순서로 실행한다.
 
 ```text
 Actions -> Deploy Kubernetes -> Run workflow
 ```
 
-`main` push 자동 배포는 아직 사용하지 않습니다. 실제 클러스터, 도메인, TLS, secret, 백업 정책이 안정화되기 전에는 수동 배포가 안전합니다.
+현재 수동 배포 입력값 예시는 다음과 같다.
 
-## GitHub production secrets
+| 입력값 | 값 |
+| --- | --- |
+| `image_tag` | 배포할 GHCR 이미지 태그 |
+| `image_namespace` | `ghcr.io/som141/docprep-cloud` |
+| `domain` | 현재 ngrok 도메인 |
+| `tls_secret` | `docprep-cloud-tls` |
+| `postgres_external_name` | `postgres` |
+| `rabbitmq_external_name` | `rabbitmq` |
+| `minio_external_name` | `minio` |
+| `otel_collector_external_name` | `otel-collector` |
+| `apply_mode` | `apply` |
+| `kube_context` | 비워둠 |
+| `rollout_timeout` | `180s` |
+| `configure_ghcr_pull_secret` | GHCR package가 public이면 `false` |
 
-GitHub repository의 `production` Environment에 아래 값을 등록합니다.
+## 필요한 GitHub secret
+
+`production` environment에 아래 secret이 필요하다.
 
 | Secret | 필수 | 설명 |
 | --- | --- | --- |
-| `KUBE_CONFIG_B64` | O | kubeconfig 파일을 base64로 인코딩한 값 |
-| `GHCR_USERNAME` | 선택 | GHCR private image pull secret을 workflow에서 만들 때 사용 |
-| `GHCR_TOKEN` | 선택 | GHCR package read 권한이 있는 token |
+| `KUBE_CONFIG_B64` | O | kubeconfig 파일을 Base64로 인코딩한 값 |
+| `GHCR_USERNAME` | 선택 | GHCR private image pull secret 생성 시 사용 |
+| `GHCR_TOKEN` | 선택 | GHCR private package read 권한 token |
 
-`KUBE_CONFIG_B64` 생성 예시:
-
-```bash
-base64 -w 0 ~/.kube/config
-```
-
-PowerShell 예시:
+PowerShell에서 `KUBE_CONFIG_B64`를 만들려면 다음 명령을 사용한다.
 
 ```powershell
-[Convert]::ToBase64String([System.IO.File]::ReadAllBytes("$HOME\.kube\config"))
+[Convert]::ToBase64String([IO.File]::ReadAllBytes("$env:USERPROFILE\Downloads\kube (1).conf"))
 ```
 
-## Workflow 입력값
+## self-hosted runner 상태 확인
 
-| 입력값 | 기본값 | 설명 |
-| --- | --- | --- |
-| `image_tag` | commit SHA 앞 12자리 | 배포할 이미지 태그 |
-| `image_namespace` | `ghcr.io/som141/docprep-cloud` | 이미지 namespace |
-| `domain` | `YOUR_DOMAIN` | 운영 도메인. 실제 배포에서는 반드시 교체 |
-| `tls_secret` | `docprep-cloud-tls` | 클러스터에 이미 존재해야 하는 TLS secret |
-| `postgres_external_name` | `postgres.example.internal` | PostgreSQL로 연결되는 실제 DNS 이름 |
-| `rabbitmq_external_name` | `rabbitmq.example.internal` | RabbitMQ로 연결되는 실제 DNS 이름 |
-| `minio_external_name` | `minio.example.internal` | MinIO/S3 API로 연결되는 실제 DNS 이름 |
-| `otel_collector_external_name` | `otel-collector.example.internal` | OpenTelemetry Collector로 연결되는 실제 DNS 이름 |
-| `apply_mode` | `dry-run` | `dry-run` 또는 `apply` |
-| `kube_context` | 빈 값 | kubeconfig 안의 특정 context를 선택할 때 사용 |
-| `rollout_timeout` | `180s` | deployment rollout 대기 시간 |
-| `configure_ghcr_pull_secret` | `false` | GHCR pull secret을 workflow가 만들고 default service account에 연결할지 여부 |
+runner는 Kubernetes 안에 설치한다.
 
-`domain`, `postgres_external_name`, `rabbitmq_external_name`, `minio_external_name`, `otel_collector_external_name`에 기본 placeholder가 남아 있으면 workflow는 배포를 중단합니다.
+```bash
+kubectl -n github-actions get pods
+kubectl -n github-actions logs deployment/docprep-k8s-runner --tail=100
+```
 
-## 클러스터 사전 조건
+GitHub에서는 아래 위치에서 확인한다.
 
-실행 전에 아래 항목이 준비되어야 합니다.
+```text
+Repository -> Settings -> Actions -> Runners
+```
+
+정상 상태는 다음과 같다.
+
+```text
+status: online
+labels: self-hosted, Linux, X64, docprep-k8s, k8s, deploy
+```
+
+## 배포 전제조건
+
+workflow는 배포 전에 아래 항목을 확인한다.
 
 | 항목 | 확인 명령 |
 | --- | --- |
-| 대상 namespace | `kubectl get namespace docprep-cloud` |
-| KEDA CRD | `kubectl get crd scaledobjects.keda.sh` |
+| namespace | `kubectl get namespace docprep-cloud` |
+| KEDA ScaledObject CRD | `kubectl get crd scaledobjects.keda.sh` |
 | KEDA TriggerAuthentication CRD | `kubectl get crd triggerauthentications.keda.sh` |
 | NGINX IngressClass | `kubectl get ingressclass nginx` |
-| backend-api secret | `kubectl -n docprep-cloud get secret backend-api-secret` |
-| preprocess-worker secret | `kubectl -n docprep-cloud get secret preprocess-worker-secret` |
+| backend secret | `kubectl -n docprep-cloud get secret backend-api-secret` |
+| worker secret | `kubectl -n docprep-cloud get secret preprocess-worker-secret` |
 | TLS secret | `kubectl -n docprep-cloud get secret docprep-cloud-tls` |
-
-`apply_mode=apply`일 때 namespace가 없으면 workflow가 `infra/k8s/namespace.yml`을 먼저 적용합니다.  
-하지만 application secret과 TLS secret은 실제 운영 값을 담기 때문에 workflow가 자동 생성하지 않습니다.
-
-## 실행 순서
-
-권장 순서는 아래와 같습니다.
-
-1. `Build GHCR Images` workflow로 이미지 생성
-2. `Render Kubernetes Manifests` workflow로 YAML artifact 검토
-3. 클러스터에 namespace와 secret 준비
-4. DB, RabbitMQ, MinIO, OTel Collector의 실제 DNS 이름을 입력해 `Deploy Kubernetes` workflow를 `apply_mode=dry-run`으로 실행
-5. dry-run 성공 후 `apply_mode=apply`로 실행
-6. 운영 도메인 접속과 E2E 검증 수행
-
-## GHCR private image 처리
-
-GHCR package가 public이면 별도 image pull secret이 필요하지 않습니다.
-
-GHCR package가 private이면 아래 중 하나를 선택합니다.
-
-1. GHCR package visibility를 public으로 변경합니다.
-2. `GHCR_USERNAME`, `GHCR_TOKEN`을 production secret에 등록하고 `configure_ghcr_pull_secret=true`로 실행합니다.
-
-두 번째 방식을 사용하면 workflow가 아래 작업을 수행합니다.
-
-1. `ghcr-pull-secret` docker-registry secret 생성 또는 갱신
-2. `default` service account에 `imagePullSecrets` 연결
 
 ## 배포 후 확인
 
-workflow가 `apply` 모드로 실행되면 아래 rollout을 기다립니다.
+배포가 성공하면 workflow가 아래 rollout을 기다린다.
 
 ```text
 deployment/backend-api
@@ -123,9 +111,9 @@ deployment/frontend
 deployment/nginx
 ```
 
-`preprocess-worker`는 KEDA scale-to-zero 구조라 queue가 비어 있으면 replica `0`이 정상입니다.
+`preprocess-worker`는 KEDA scale-to-zero 구조라서 queue가 비어 있으면 replica가 `0`일 수 있다.
 
-수동 확인 명령:
+수동 확인 명령은 다음과 같다.
 
 ```bash
 kubectl -n docprep-cloud get pods
@@ -134,33 +122,27 @@ kubectl -n docprep-cloud get ingress
 kubectl -n docprep-cloud get scaledobject
 ```
 
-브라우저 검증:
+## 자동 CI/CD로 확장할 때
 
-1. 운영 도메인 접속
-2. Google 로그인
-3. 프로젝트 생성
-4. 이미지 또는 ZIP 업로드
-5. 전처리 Job 생성
-6. 처리된 이미지 또는 ZIP 다운로드
+완전 자동 배포를 하려면 `Deploy Kubernetes` workflow에 `workflow_run` 또는 `push` trigger를 추가한다.
 
-## 사용자가 값을 줘야 하는 시점
+권장 흐름은 다음과 같다.
 
-이번 workflow 작성 단계에서는 실제 값을 줄 필요가 없습니다.
+```text
+main merge
+-> Build GHCR Images 성공
+-> Deploy Kubernetes 자동 실행
+-> rollout 확인
+```
 
-실제 `Deploy Kubernetes` workflow를 실행하기 직전에는 아래 값을 받아야 합니다.
+운영 안정성을 위해 처음에는 `production` environment approval을 유지하는 것이 좋다.
 
-1. 운영 클러스터 kubeconfig 또는 배포 전용 service account kubeconfig
-2. 운영 도메인
-3. TLS secret 이름과 생성 방식
-4. PostgreSQL, RabbitMQ, MinIO, OTel Collector의 Kubernetes 접근 DNS 이름
-5. backend-api, preprocess-worker Kubernetes secret의 실제 값
-6. GHCR package가 private일 경우 GHCR read token
-7. Google OAuth 운영 Client ID/Secret과 redirect URI
+## 현재 제약
 
-## 현재 한계
+현재 self-hosted runner는 registration token 기반 Deployment다. Pod가 재시작된 뒤 registration token이 만료되어 있으면 재등록에 실패할 수 있다.
 
-1. PostgreSQL, RabbitMQ, MinIO는 아직 placeholder service 기준입니다.
-2. TLS secret 자동 발급은 포함하지 않습니다.
-3. DB migration 전용 Job은 아직 없습니다.
-4. Prometheus Operator용 ServiceMonitor는 아직 없습니다.
-5. 실제 운영 환경에서는 첫 apply 전에 네트워크, DNS, storage endpoint를 별도로 점검해야 합니다.
+장기 운영에서는 아래 중 하나로 전환한다.
+
+1. Actions Runner Controller를 설치한다.
+2. GitHub App 또는 PAT 기반으로 runner registration token을 Pod 시작 시 자동 발급한다.
+3. 마스터 노드 OS에 runner systemd service를 직접 설치한다.


### PR DESCRIPTION
## #️⃣ 기능 설명

Kubernetes API가 사설망에 있어 GitHub hosted runner에서 배포하지 못하는 문제를 해결하기 위해 `Deploy Kubernetes` workflow를 cluster 내부 self-hosted runner 라벨로 전환합니다.

## 🛠️ 작업 상세 내용

- [x] `Deploy Kubernetes` workflow `runs-on`을 `[self-hosted, Linux, X64, docprep-k8s]`로 변경
- [x] Kubernetes GitHub Actions 배포 문서를 한글로 재작성
- [x] Issue 149 기능 명세 문서 추가
- [x] `github-actions` namespace에 `docprep-k8s-runner` Deployment 설치
- [x] runner Pod에 배포 workflow용 `python3` 설치 반영

## 📁 변경 파일 요약

- `.github/workflows/deploy-k8s.yml`
- `docs/operation/kubernetes-github-actions-deploy.md`
- `docs/feature-specs/issue-149-kubernetes-self-hosted-runner.md`

## ✅ 검증 내용

- [x] `git diff --check` 통과
- [x] Kubernetes runner Deployment `1/1 Running` 확인
- [x] GitHub runner `online` 확인
- [x] `Deploy Kubernetes` workflow가 self-hosted runner에서 성공
- [x] `docprep-cloud` namespace pods/service/ingress/scaledobject 상태 확인

검증 workflow: https://github.com/som141/opensource-cloud-/actions/runs/26741179205

## 🔎 리뷰어가 확인해야 할 부분

- GitHub hosted runner 대신 `docprep-k8s` self-hosted runner를 사용하는 것이 의도와 맞는지 확인해주세요.
- 장기 운영 시 registration token 만료 문제를 ARC 또는 GitHub App/PAT 방식으로 개선해야 합니다.

Closes #149