### PR TITLE
🔨 [Fix] Worker 처리 안정화와 A4 프리셋 복원

### DIFF
--- a/backend-api/src/main/java/com/moonju/preprocess/api/domain/preprocess/service/PreprocessPresetRegistry.java
+++ b/backend-api/src/main/java/com/moonju/preprocess/api/domain/preprocess/service/PreprocessPresetRegistry.java
@@ -63,7 +63,7 @@ public class PreprocessPresetRegistry {
             "General A4 document scan preset for OCR preprocessing.",
             true,
             DOCUMENT_PIPELINE_STEPS,
-            commonParameters(300, "otsu", 2.0, "median", false)
+            commonParameters(300, "otsu", false, 2.5, "median", "open", false, 8.27, 11.69, 300)
         ));
         register(new PreprocessPreset(
             PreprocessPresetName.LOW_CONTRAST_SCAN,
@@ -72,7 +72,7 @@ public class PreprocessPresetRegistry {
             "Improves low contrast scans using stronger contrast normalization before binarization.",
             true,
             DOCUMENT_PIPELINE_STEPS,
-            commonParameters(300, "adaptive", 2.4, "median", true)
+            commonParameters(300, "adaptive", true, 2.5, "median", "close", true, 8.27, 11.69, 300)
         ));
         register(new PreprocessPreset(
             PreprocessPresetName.RECEIPT,
@@ -81,7 +81,7 @@ public class PreprocessPresetRegistry {
             "Narrow receipt-like document preset with adaptive thresholding and light morphology cleanup.",
             true,
             DOCUMENT_PIPELINE_STEPS,
-            commonParameters(300, "adaptive", 2.2, "median", true)
+            commonParameters(300, "adaptive", true, 2.5, "median", "close", true, 3.15, 8.0, 300)
         ));
         register(new PreprocessPreset(
             PreprocessPresetName.NOISY_SCAN,
@@ -90,7 +90,7 @@ public class PreprocessPresetRegistry {
             "Preset for scans with strong background noise and more aggressive denoise settings.",
             true,
             DOCUMENT_PIPELINE_STEPS,
-            commonParameters(300, "adaptive", 2.0, "bilateral", false)
+            commonParameters(300, "adaptive", false, 2.5, "bilateral", "open", false, 8.27, 11.69, 300)
         ));
         register(new PreprocessPreset(
             PreprocessPresetName.AUTO,
@@ -114,17 +114,51 @@ public class PreprocessPresetRegistry {
     private List<PresetParameterDefinition> commonParameters(
         int targetDpi,
         String binarizationMode,
+        boolean contrastNormalize,
         double contrastClipLimit,
         String denoiseMode,
-        boolean sharpen
+        String morphologyMode,
+        boolean sharpen,
+        double referenceWidthInches,
+        double referenceHeightInches,
+        int fallbackSourceDpi
     ) {
         return List.of(
+            PresetParameterDefinition.bool(
+                "grayscale",
+                "Whether color normalization should convert input images to grayscale.",
+                true
+            ),
             PresetParameterDefinition.integer(
                 "targetDpi",
                 "Target DPI for OCR-oriented DPI normalization.",
                 true,
                 targetDpi,
                 150,
+                600
+            ),
+            PresetParameterDefinition.decimal(
+                "referenceWidthInches",
+                "Reference document width used to estimate source DPI when metadata is missing.",
+                false,
+                referenceWidthInches,
+                1.0,
+                30.0
+            ),
+            PresetParameterDefinition.decimal(
+                "referenceHeightInches",
+                "Reference document height used to estimate source DPI when metadata is missing.",
+                false,
+                referenceHeightInches,
+                1.0,
+                50.0
+            ),
+            PresetParameterDefinition.integer(
+                "fallbackSourceDpi",
+                "Fallback source DPI used when metadata and reference-size estimation are unavailable.",
+                false,
+                fallbackSourceDpi,
+                72,
                 600
             ),
             PresetParameterDefinition.decimal(
@@ -146,7 +180,7 @@ public class PreprocessPresetRegistry {
                 "adaptiveBlockSize",
                 "Odd block size for adaptive thresholding.",
                 true,
-                21,
+                31,
                 3,
                 99
             ),
@@ -154,9 +188,14 @@ public class PreprocessPresetRegistry {
                 "adaptiveC",
                 "Constant subtracted from the adaptive threshold mean.",
                 true,
-                5.0,
+                15.0,
                 -20.0,
                 20.0
+            ),
+            PresetParameterDefinition.bool(
+                "contrastNormalize",
+                "Whether contrast normalization should run before binarization.",
+                contrastNormalize
             ),
             PresetParameterDefinition.decimal(
                 "contrastClipLimit",
@@ -193,7 +232,7 @@ public class PreprocessPresetRegistry {
                 "denoiseDiameter",
                 "Bilateral filter neighborhood diameter.",
                 true,
-                5,
+                7,
                 3,
                 15
             ),
@@ -201,7 +240,7 @@ public class PreprocessPresetRegistry {
                 "denoiseSigmaColor",
                 "Bilateral filter color sigma. Lower values preserve text edges.",
                 true,
-                25.0,
+                50.0,
                 0.1,
                 200.0
             ),
@@ -209,7 +248,7 @@ public class PreprocessPresetRegistry {
                 "denoiseSigmaRange",
                 "Bilateral filter spatial sigma range.",
                 true,
-                75.0,
+                50.0,
                 0.1,
                 200.0
             ),
@@ -217,7 +256,7 @@ public class PreprocessPresetRegistry {
                 "morphologyMode",
                 "Morphology cleanup strategy.",
                 true,
-                "open_close",
+                morphologyMode,
                 Set.of("open", "close", "open_close", "none", "off", "false")
             ),
             PresetParameterDefinition.integer(
@@ -237,7 +276,7 @@ public class PreprocessPresetRegistry {
                 "sharpenAmount",
                 "Unsharp mask weight for optional sharpen.",
                 true,
-                0.8,
+                0.25,
                 0.1,
                 3.0
             ),
@@ -245,7 +284,7 @@ public class PreprocessPresetRegistry {
                 "sharpenSigma",
                 "Gaussian blur sigma for optional sharpen.",
                 true,
-                1.5,
+                1.2,
                 0.1,
                 10.0
             ),

--- a/backend-api/src/test/java/com/moonju/preprocess/api/domain/preprocess/service/PreprocessParameterValidatorTests.java
+++ b/backend-api/src/test/java/com/moonju/preprocess/api/domain/preprocess/service/PreprocessParameterValidatorTests.java
@@ -20,18 +20,24 @@ class PreprocessParameterValidatorTests {
 
         assertThat(response.valid()).isTrue();
         assertThat(response.resolvedParameters())
+            .containsEntry("grayscale", "true")
             .containsEntry("targetDpi", "300")
+            .containsEntry("referenceWidthInches", "8.27")
+            .containsEntry("referenceHeightInches", "11.69")
+            .containsEntry("fallbackSourceDpi", "300")
             .containsEntry("binarizationMode", "otsu")
-            .containsEntry("adaptiveBlockSize", "21")
-            .containsEntry("adaptiveC", "5.0")
-            .containsEntry("contrastClipLimit", "2.0")
+            .containsEntry("adaptiveBlockSize", "31")
+            .containsEntry("adaptiveC", "15.0")
+            .containsEntry("contrastNormalize", "false")
+            .containsEntry("contrastClipLimit", "2.5")
             .containsEntry("denoiseMode", "median")
-            .containsEntry("denoiseSigmaColor", "25.0")
-            .containsEntry("denoiseSigmaRange", "75.0")
-            .containsEntry("morphologyMode", "open_close")
+            .containsEntry("denoiseDiameter", "7")
+            .containsEntry("denoiseSigmaColor", "50.0")
+            .containsEntry("denoiseSigmaRange", "50.0")
+            .containsEntry("morphologyMode", "open")
             .containsEntry("morphologyKernelSize", "2")
-            .containsEntry("sharpenAmount", "0.8")
-            .containsEntry("sharpenSigma", "1.5")
+            .containsEntry("sharpenAmount", "0.25")
+            .containsEntry("sharpenSigma", "1.2")
             .containsEntry("debugArtifacts", "false");
     }
 

--- a/docs/api/preprocess-preset-api.md
+++ b/docs/api/preprocess-preset-api.md
@@ -2,23 +2,24 @@
 
 ## 목적
 
-Preprocess Preset API는 backend-api, Job 생성 흐름, Worker가 공유하는 전처리 파라미터 계약을 제공합니다.
-API 서버는 프리셋 이름과 파라미터 범위를 검증하지만 OpenCV 이미지 전처리를 직접 수행하지 않습니다.
+Preprocess Preset API는 Job 생성 전에 사용할 수 있는 전처리 프리셋과 파라미터 범위를 제공한다.
+API 서버는 파라미터 이름과 범위를 검증하지만 OpenCV 이미지 전처리는 직접 수행하지 않는다.
+실제 처리는 RabbitMQ 메시지를 받은 Worker가 수행한다.
 
 ## 규칙
 
-- built-in preset 이름은 Worker preset 이름과 정확히 일치해야 합니다.
-- API 서버는 Job 생성 전에 파라미터 형태와 범위를 검증합니다.
-- API 서버는 문서 이미지 전처리를 직접 수행하지 않습니다.
-- 프리셋은 단순 썸네일 resize가 아니라 OCR용 문서 전처리 파이프라인을 설명합니다.
-- custom preset은 built-in preset에서 파생되는 사용자 소유 skeleton record입니다.
+- built-in preset 이름은 Worker preset 이름과 일치해야 한다.
+- Job 생성 시 API 서버는 프리셋 파라미터를 검증하고 기본값을 채운다.
+- 검증된 파라미터는 Job에 저장되고 RabbitMQ 메시지로 Worker에 전달된다.
+- API 서버는 문서 이미지 전처리를 직접 수행하지 않는다.
+- 이 API는 단순 resize가 아니라 OCR 전 문서 이미지 전처리 파이프라인의 계약을 설명한다.
 
-## Built-in preset
+## Built-in Preset
 
 | 이름 | 용도 |
 | --- | --- |
-| `A4_SCAN_300DPI` | 일반 A4 문서 스캔 |
-| `LOW_CONTRAST_SCAN` | 저대비 문서 |
+| `A4_SCAN_300DPI` | 일반 A4 300 DPI 스캔 문서 |
+| `LOW_CONTRAST_SCAN` | 저대비 스캔 문서 |
 | `RECEIPT` | 영수증처럼 폭이 좁은 문서 |
 | `NOISY_SCAN` | 배경 노이즈가 강한 문서 |
 | `AUTO` | Worker가 이미지 특성에 따라 프리셋 선택 |
@@ -27,37 +28,14 @@ API 서버는 프리셋 이름과 파라미터 범위를 검증하지만 OpenCV 
 
 | Method | Path | 설명 |
 | --- | --- | --- |
-| `GET` | `/api/v1/preprocess/presets` | built-in preset 목록 |
-| `GET` | `/api/v1/preprocess/presets/{presetName}` | built-in preset 상세 |
+| `GET` | `/api/v1/preprocess/presets` | built-in preset 목록 조회 |
+| `GET` | `/api/v1/preprocess/presets/{presetName}` | built-in preset 상세 조회 |
 | `POST` | `/api/v1/preprocess/presets/validate` | preset 파라미터 검증 |
 | `POST` | `/api/v1/preprocess/presets/custom` | custom preset 생성 |
-| `GET` | `/api/v1/preprocess/presets/custom` | 내 custom preset 목록 |
+| `GET` | `/api/v1/preprocess/presets/custom` | 내 custom preset 목록 조회 |
 | `DELETE` | `/api/v1/preprocess/presets/custom/{presetId}` | custom preset 삭제 |
 
-## built-in preset 목록
-
-Response:
-
-```json
-{
-  "isSuccess": true,
-  "code": "common200",
-  "message": "Request succeeded.",
-  "result": [
-    {
-      "name": "A4_SCAN_300DPI",
-      "type": "BUILT_IN",
-      "displayName": "A4 300 DPI scan",
-      "description": "General A4 document scan preset for OCR preprocessing.",
-      "supportsDebug": true
-    }
-  ]
-}
-```
-
-## preset 상세
-
-Response:
+## Preset 상세 응답 예시
 
 ```json
 {
@@ -65,10 +43,10 @@ Response:
   "code": "common200",
   "message": "Request succeeded.",
   "result": {
-    "name": "LOW_CONTRAST_SCAN",
+    "name": "A4_SCAN_300DPI",
     "type": "BUILT_IN",
-    "displayName": "Low contrast scan",
-    "description": "Improves low contrast scans using stronger contrast normalization before binarization.",
+    "displayName": "A4 300 DPI scan",
+    "description": "General A4 document scan preset for OCR preprocessing.",
     "supportsDebug": true,
     "steps": [
       "DECODE",
@@ -88,7 +66,7 @@ Response:
         "name": "contrastClipLimit",
         "type": "DECIMAL",
         "required": true,
-        "defaultValue": "2.4",
+        "defaultValue": "2.5",
         "minValue": "1.0",
         "maxValue": "4.0",
         "allowedValues": []
@@ -108,8 +86,6 @@ Request:
   "parameters": {
     "targetDpi": "300",
     "binarizationMode": "otsu",
-    "contrastClipLimit": "2.0",
-    "denoiseMode": "median",
     "debugArtifacts": "false"
   }
 }
@@ -127,53 +103,53 @@ Response:
     "valid": true,
     "errors": [],
     "resolvedParameters": {
+      "grayscale": "true",
       "targetDpi": "300",
+      "referenceWidthInches": "8.27",
+      "referenceHeightInches": "11.69",
+      "fallbackSourceDpi": "300",
       "maxDeskewAngle": "40.0",
       "binarizationMode": "otsu",
-      "adaptiveBlockSize": "21",
-      "adaptiveC": "5.0",
-      "contrastClipLimit": "2.0",
+      "adaptiveBlockSize": "31",
+      "adaptiveC": "15.0",
+      "contrastNormalize": "false",
+      "contrastClipLimit": "2.5",
       "contrastTileGridSize": "8",
       "denoiseMode": "median",
       "denoiseKernelSize": "3",
-      "denoiseDiameter": "5",
-      "denoiseSigmaColor": "25.0",
-      "denoiseSigmaRange": "75.0",
-      "morphologyMode": "open_close",
+      "denoiseDiameter": "7",
+      "denoiseSigmaColor": "50.0",
+      "denoiseSigmaRange": "50.0",
+      "morphologyMode": "open",
       "morphologyKernelSize": "2",
       "sharpen": "false",
-      "sharpenAmount": "0.8",
-      "sharpenSigma": "1.5",
+      "sharpenAmount": "0.25",
+      "sharpenSigma": "1.2",
       "debugArtifacts": "false"
     }
   }
 }
 ```
 
-잘못된 파라미터 값은 `valid=false`와 `result.errors`로 반환합니다. 알 수 없는 preset 이름은 일반 API 오류 응답을 반환합니다.
+## 주요 기본값
 
-## custom preset
+| 프리셋 | binarizationMode | contrastNormalize | contrastClipLimit | denoiseMode | morphologyMode | sharpen |
+| --- | --- | --- | --- | --- | --- | --- |
+| `A4_SCAN_300DPI` | `otsu` | `false` | `2.5` | `median` | `open` | `false` |
+| `LOW_CONTRAST_SCAN` | `adaptive` | `true` | `2.5` | `median` | `close` | `true` |
+| `RECEIPT` | `adaptive` | `true` | `2.5` | `median` | `close` | `true` |
+| `NOISY_SCAN` | `adaptive` | `false` | `2.5` | `bilateral` | `open` | `false` |
 
-Create request:
+공통 기본값은 `grayscale=true`, `fallbackSourceDpi=300`, `adaptiveBlockSize=31`, `adaptiveC=15.0`,
+`denoiseDiameter=7`, `denoiseSigmaColor=50.0`, `denoiseSigmaRange=50.0`,
+`morphologyKernelSize=2`, `sharpenAmount=0.25`, `sharpenSigma=1.2`다.
 
-```json
-{
-  "name": "Library low contrast",
-  "description": "For old book scans",
-  "basePresetName": "LOW_CONTRAST_SCAN",
-  "parameters": {
-    "targetDpi": "300",
-    "contrastClipLimit": "2.4",
-    "adaptiveBlockSize": "21",
-    "adaptiveC": "5.0"
-  }
-}
-```
+## 오류
 
-custom preset은 현재 backend skeleton입니다. Job 생성과 Worker 실행 연결은 후속 작업에서 처리합니다.
+알 수 없는 파라미터나 범위를 벗어난 값은 `valid=false`와 `result.errors`로 반환된다.
+존재하지 않는 preset 이름은 공통 실패 응답으로 반환된다.
 
 ## 다음 작업
 
-- Job 생성 시 preset validation 연결 상태를 계속 유지합니다.
-- Worker internal preset lookup endpoint가 필요하면 별도 이슈에서 추가합니다.
-- Worker preset registry와 API contract가 다른 값으로 갈라지지 않도록 테스트를 유지합니다.
+- custom preset 실제 저장/조회 기능은 별도 작업에서 구현한다.
+- Worker registry와 API registry의 기본값이 달라지지 않도록 테스트를 유지한다.

--- a/docs/worker/preset-spec.md
+++ b/docs/worker/preset-spec.md
@@ -1,21 +1,21 @@
 # Worker 프리셋 명세
 
-이 문서는 backend-api와 preprocess-worker가 공유하는 전처리 프리셋 이름과 파라미터 계약을 정의합니다.
-API 서버는 프리셋 이름과 파라미터 범위를 검증하고, 실제 OpenCV 문서 전처리는 Worker가 수행합니다.
+이 문서는 `backend-api`와 `preprocess-worker`가 공유하는 문서 이미지 전처리 프리셋 이름과 파라미터 계약을 정의한다.
+API 서버는 Job 생성 전에 파라미터 이름과 범위를 검증하고, 실제 OpenCV 기반 전처리는 Worker가 수행한다.
 
 ## 지원 프리셋
 
 | 프리셋 | 용도 |
 | --- | --- |
 | `A4_SCAN_300DPI` | 일반 A4 300 DPI 스캔 문서 |
-| `LOW_CONTRAST_SCAN` | 저대비 문서 |
+| `LOW_CONTRAST_SCAN` | 저대비 스캔 문서 |
 | `RECEIPT` | 영수증처럼 폭이 좁은 문서 |
 | `NOISY_SCAN` | 배경 노이즈가 강한 문서 |
 | `AUTO` | Worker가 이미지 특성에 따라 프리셋 선택 |
 
-## 처리 단계
+## 공통 처리 순서
 
-`AUTO`를 제외한 기본 문서 프리셋은 아래 순서를 따릅니다.
+`AUTO`를 제외한 기본 문서 프리셋은 아래 순서로 실행된다.
 
 1. `DECODE`
 2. `COLOR_NORMALIZE`
@@ -29,57 +29,77 @@ API 서버는 프리셋 이름과 파라미터 범위를 검증하고, 실제 Op
 10. `DPI_NORMALIZE`
 11. `OPTIONAL_SHARPEN`
 
-이 파이프라인은 단순 resize가 아닙니다. `DPI_NORMALIZE`는 OCR 품질을 맞추기 위한 DPI 정규화 단계입니다.
+이 파이프라인은 단순 resize가 아니다. `DPI_NORMALIZE`는 OCR 품질을 일정하게 맞추기 위한 DPI 보정 단계다.
 
-## 공통 파라미터
+## 현재 기준값
 
-| 파라미터 | 타입 | 기본값 | 설명 |
-| --- | --- | --- | --- |
-| `targetDpi` | integer | `300` | OCR용 목표 DPI |
-| `maxDeskewAngle` | decimal | `40.0` | 허용할 최대 deskew 각도 |
-| `binarizationMode` | enum | 프리셋별 | `otsu`, `adaptive` |
-| `adaptiveBlockSize` | integer | `21` | adaptive threshold block size. 홀수로 보정됨 |
-| `adaptiveC` | decimal | `5.0` | adaptive threshold 평균에서 뺄 C 값 |
-| `contrastClipLimit` | decimal | 프리셋별 | CLAHE clip limit |
-| `contrastTileGridSize` | integer | `8` | CLAHE tile grid size |
-| `denoiseMode` | enum | 프리셋별 | `median`, `bilateral`, `none`, `off`, `false` |
-| `denoiseKernelSize` | integer | `3` | median blur kernel size |
-| `denoiseDiameter` | integer | `5` | bilateral filter diameter |
-| `denoiseSigmaColor` | decimal | `25.0` | bilateral filter color sigma. 텍스트 경계 보존을 위해 낮춤 |
-| `denoiseSigmaRange` | decimal | `75.0` | bilateral filter spatial sigma range |
-| `morphologyMode` | enum | `open_close` | `open`, `close`, `open_close`, `none`, `off`, `false` |
-| `morphologyKernelSize` | integer | `2` | morphology kernel size |
-| `sharpen` | boolean | 프리셋별 | optional sharpen 실행 여부 |
-| `sharpenAmount` | decimal | `0.8` | unsharp mask weight |
-| `sharpenSigma` | decimal | `1.5` | unsharp mask Gaussian sigma |
-| `debugArtifacts` | boolean | `false` | 단계별 debug artifact 저장 여부 |
+`A4_SCAN_300DPI`는 이전 `image-test` 기준에 맞춰 보수적인 OCR 전처리값을 사용한다.
 
-## 이번 튜닝 기준
+| 파라미터 | A4 기본값 | 설명 |
+| --- | --- | --- |
+| `grayscale` | `true` | Color Normalize 단계에서 BGR/BGRA 입력을 그레이스케일로 통일 |
+| `targetDpi` | `300` | OCR 대상 DPI |
+| `referenceWidthInches` | `8.27` | DPI 메타데이터가 없을 때 A4 기준 너비로 source DPI 추정 |
+| `referenceHeightInches` | `11.69` | DPI 메타데이터가 없을 때 A4 기준 높이로 source DPI 추정 |
+| `fallbackSourceDpi` | `300` | 메타데이터와 기준 크기 추정이 모두 없을 때 사용할 source DPI |
+| `maxDeskewAngle` | `40.0` | 이 각도를 넘는 deskew는 안전 범위 밖으로 보고 회전하지 않음 |
+| `binarizationMode` | `otsu` | A4 스캔 문서는 기본 Otsu 이진화 사용 |
+| `adaptiveBlockSize` | `31` | adaptive threshold 사용 시 block size |
+| `adaptiveC` | `15.0` | adaptive threshold 평균에서 뺄 C 값 |
+| `contrastNormalize` | `false` | A4 기본값은 CLAHE 대비 정규화를 건너뜀 |
+| `contrastClipLimit` | `2.5` | CLAHE clip limit |
+| `contrastTileGridSize` | `8` | CLAHE tile grid size |
+| `denoiseMode` | `median` | 기본 노이즈 제거 전략 |
+| `denoiseKernelSize` | `3` | median blur 커널 |
+| `denoiseDiameter` | `7` | bilateral filter 직경 |
+| `denoiseSigmaColor` | `50.0` | bilateral color sigma |
+| `denoiseSigmaRange` | `50.0` | bilateral spatial sigma |
+| `morphologyMode` | `open` | 작은 노이즈 제거 중심 |
+| `morphologyKernelSize` | `2` | morphology 2x2 직사각 커널 |
+| `sharpen` | `false` | A4 기본값은 sharpen 비활성화 |
+| `sharpenAmount` | `0.25` | 활성화 시 unsharp mask 원본/blur 가중치가 1.25/-0.25가 되도록 설정 |
+| `sharpenSigma` | `1.2` | 활성화 시 Gaussian sigma |
+| `debugArtifacts` | `false` | 단계별 debug artifact 저장 여부 |
 
-| 항목 | 이전 값 | 변경 값 | 의도 |
-| --- | --- | --- | --- |
-| `adaptiveBlockSize` | `31` | `21` | 지역 threshold가 더 작은 글자 영역에 반응하도록 조정 |
-| `adaptiveC` | `7.0` | `5.0` | 얇은 획 손실을 줄이기 위해 threshold offset 완화 |
-| `contrastClipLimit` 기본값 | `1.2` | `2.0` | 저대비 문서 대비 개선 강화 |
-| `sharpenAmount` | `0.6` | `0.8` | OCR 전 획 선명도 강화 |
-| `sharpenSigma` | `1.0` | `1.5` | 노이즈보다 문자 획 중심으로 sharpening 조정 |
-| `denoiseSigmaColor` | `75.0` | `25.0` | bilateral denoise에서 텍스트 경계 보존 |
+## 프리셋별 차이
 
-## 프리셋 기본값
+| 프리셋 | binarizationMode | contrastNormalize | contrastClipLimit | denoiseMode | morphologyMode | sharpen |
+| --- | --- | --- | --- | --- | --- | --- |
+| `A4_SCAN_300DPI` | `otsu` | `false` | `2.5` | `median` | `open` | `false` |
+| `LOW_CONTRAST_SCAN` | `adaptive` | `true` | `2.5` | `median` | `close` | `true` |
+| `RECEIPT` | `adaptive` | `true` | `2.5` | `median` | `close` | `true` |
+| `NOISY_SCAN` | `adaptive` | `false` | `2.5` | `bilateral` | `open` | `false` |
 
-| 프리셋 | binarizationMode | contrastClipLimit | denoiseMode | morphologyMode | sharpen |
-| --- | --- | --- | --- | --- | --- |
-| `A4_SCAN_300DPI` | `otsu` | `2.0` | `median` | `open_close` | `false` |
-| `LOW_CONTRAST_SCAN` | `adaptive` | `2.4` | `median` | `open_close` | `true` |
-| `RECEIPT` | `adaptive` | `2.2` | `median` | `open_close` | `true` |
-| `NOISY_SCAN` | `adaptive` | `2.0` | `bilateral` | `open_close` | `false` |
+모든 built-in preset은 `grayscale=true`, `fallbackSourceDpi=300`, `adaptiveBlockSize=31`, `adaptiveC=15.0`,
+`denoiseDiameter=7`, `denoiseSigmaColor=50.0`, `denoiseSigmaRange=50.0`,
+`morphologyKernelSize=2`, `sharpenAmount=0.25`, `sharpenSigma=1.2`를 포함한다.
 
-모든 built-in preset은 `adaptiveBlockSize=21`, `adaptiveC=5.0`, `denoiseSigmaColor=25.0`,
-`denoiseSigmaRange=75.0`, `morphologyKernelSize=2`, `sharpenAmount=0.8`, `sharpenSigma=1.5`를 포함합니다.
+## 방향 보정 기준
+
+`ORIENTATION_NORMALIZE`는 이미지가 가로로 누워 있다고 판단될 때만 90도 반시계 방향으로 회전한다.
+
+```text
+조건: cols > rows * 1.15
+회전: Core.ROTATE_90_COUNTERCLOCKWISE
+리포트 note: grossRotationDegrees=-90.0
+```
+
+이 조건을 만족하지 않는 약한 가로형 이미지는 무리하게 회전하지 않는다.
+
+## DPI Normalize 기준
+
+`DPI_NORMALIZE`는 다음 순서로 source DPI를 결정한다.
+
+1. 입력 메타데이터 또는 Job 파라미터의 `sourceDpi`, `sourceDpiX`, `sourceDpiY`
+2. `referenceWidthInches`, `referenceHeightInches`와 현재 이미지 크기를 이용한 휴리스틱 추정
+3. `fallbackSourceDpi`
+
+스케일은 과도한 확대/축소를 막기 위해 `0.75x`부터 `2.5x` 사이로 제한한다.
+확대 시 `INTER_CUBIC`, 축소 시 `INTER_AREA`를 사용한다.
 
 ## Backend 계약
 
-- backend-api는 `/api/v1/preprocess/presets`에서 프리셋 목록과 파라미터를 노출합니다.
-- backend-api는 Job 생성 전 파라미터 이름과 범위를 검증합니다.
-- backend-api는 OpenCV 전처리를 직접 수행하지 않습니다.
-- Worker는 알 수 없는 프리셋 이름이나 잘못된 파라미터 payload를 거부해야 합니다.
+- `/api/v1/preprocess/presets`는 위 프리셋과 파라미터 기본값을 노출한다.
+- Job 생성 시 backend-api는 프리셋 파라미터를 검증하고 resolved parameter를 Job과 RabbitMQ 메시지에 저장한다.
+- Worker는 메시지에 포함된 파라미터를 우선 사용한다.
+- 따라서 프리셋 기본값 변경 시 `backend-api`와 `preprocess-worker` 값을 함께 맞춰야 한다.

--- a/infra/k8s/preprocess-worker/deployment.yml
+++ b/infra/k8s/preprocess-worker/deployment.yml
@@ -26,6 +26,15 @@ spec:
                 name: preprocess-worker-config
             - secretRef:
                 name: preprocess-worker-secret
+          env:
+            - name: JAVA_TOOL_OPTIONS
+              value: "-Xms512m -Xmx3g -XX:+ExitOnOutOfMemoryError"
+            - name: SPRING_RABBITMQ_LISTENER_SIMPLE_PREFETCH
+              value: "1"
+            - name: SPRING_RABBITMQ_LISTENER_SIMPLE_CONCURRENCY
+              value: "1"
+            - name: SPRING_RABBITMQ_LISTENER_SIMPLE_MAX_CONCURRENCY
+              value: "1"
           ports:
             - name: management
               containerPort: 8081
@@ -51,4 +60,4 @@ spec:
               memory: 1Gi
             limits:
               cpu: "2"
-              memory: 2Gi
+              memory: 4Gi

--- a/infra/k8s/preprocess-worker/scaledobject.yml
+++ b/infra/k8s/preprocess-worker/scaledobject.yml
@@ -21,7 +21,7 @@ spec:
         queueName: image.preprocess.normal
         mode: QueueLength
         value: "25"
-        activationValue: "1"
+        activationValue: "0"
         vhostName: /
       authenticationRef:
         name: preprocess-worker-rabbitmq-auth
@@ -32,7 +32,7 @@ spec:
         queueName: image.preprocess.high
         mode: QueueLength
         value: "10"
-        activationValue: "1"
+        activationValue: "0"
         vhostName: /
       authenticationRef:
         name: preprocess-worker-rabbitmq-auth

--- a/preprocess-worker/src/main/java/com/moonju/preprocess/worker/domain/preprocess/preset/A4Scan300DpiPreset.java
+++ b/preprocess-worker/src/main/java/com/moonju/preprocess/worker/domain/preprocess/preset/A4Scan300DpiPreset.java
@@ -16,22 +16,27 @@ public class A4Scan300DpiPreset implements PreprocessPresetDefinition {
             "General A4 document scan preset for OCR preprocessing.",
             DocumentStepSequence.standard(),
             Map.ofEntries(
+                entry("grayscale", "true"),
                 entry("targetDpi", "300"),
+                entry("referenceWidthInches", "8.27"),
+                entry("referenceHeightInches", "11.69"),
+                entry("fallbackSourceDpi", "300"),
                 entry("binarizationMode", "otsu"),
-                entry("adaptiveBlockSize", "21"),
-                entry("adaptiveC", "5.0"),
-                entry("contrastClipLimit", "2.0"),
+                entry("adaptiveBlockSize", "31"),
+                entry("adaptiveC", "15.0"),
+                entry("contrastNormalize", "false"),
+                entry("contrastClipLimit", "2.5"),
                 entry("contrastTileGridSize", "8"),
                 entry("denoiseMode", "median"),
                 entry("denoiseKernelSize", "3"),
-                entry("denoiseDiameter", "5"),
-                entry("denoiseSigmaColor", "25.0"),
-                entry("denoiseSigmaRange", "75.0"),
-                entry("morphologyMode", "open_close"),
+                entry("denoiseDiameter", "7"),
+                entry("denoiseSigmaColor", "50.0"),
+                entry("denoiseSigmaRange", "50.0"),
+                entry("morphologyMode", "open"),
                 entry("morphologyKernelSize", "2"),
                 entry("sharpen", "false"),
-                entry("sharpenAmount", "0.8"),
-                entry("sharpenSigma", "1.5")
+                entry("sharpenAmount", "0.25"),
+                entry("sharpenSigma", "1.2")
             )
         );
     }

--- a/preprocess-worker/src/main/java/com/moonju/preprocess/worker/domain/preprocess/preset/LowContrastScanPreset.java
+++ b/preprocess-worker/src/main/java/com/moonju/preprocess/worker/domain/preprocess/preset/LowContrastScanPreset.java
@@ -16,22 +16,27 @@ public class LowContrastScanPreset implements PreprocessPresetDefinition {
             "Low contrast document preset with stronger contrast normalization.",
             DocumentStepSequence.standard(),
             Map.ofEntries(
+                entry("grayscale", "true"),
                 entry("targetDpi", "300"),
+                entry("referenceWidthInches", "8.27"),
+                entry("referenceHeightInches", "11.69"),
+                entry("fallbackSourceDpi", "300"),
                 entry("binarizationMode", "adaptive"),
-                entry("adaptiveBlockSize", "21"),
-                entry("adaptiveC", "5.0"),
-                entry("contrastClipLimit", "2.4"),
+                entry("adaptiveBlockSize", "31"),
+                entry("adaptiveC", "15.0"),
+                entry("contrastNormalize", "true"),
+                entry("contrastClipLimit", "2.5"),
                 entry("contrastTileGridSize", "8"),
                 entry("denoiseMode", "median"),
                 entry("denoiseKernelSize", "3"),
-                entry("denoiseDiameter", "5"),
-                entry("denoiseSigmaColor", "25.0"),
-                entry("denoiseSigmaRange", "75.0"),
-                entry("morphologyMode", "open_close"),
+                entry("denoiseDiameter", "7"),
+                entry("denoiseSigmaColor", "50.0"),
+                entry("denoiseSigmaRange", "50.0"),
+                entry("morphologyMode", "close"),
                 entry("morphologyKernelSize", "2"),
                 entry("sharpen", "true"),
-                entry("sharpenAmount", "0.8"),
-                entry("sharpenSigma", "1.5")
+                entry("sharpenAmount", "0.25"),
+                entry("sharpenSigma", "1.2")
             )
         );
     }

--- a/preprocess-worker/src/main/java/com/moonju/preprocess/worker/domain/preprocess/preset/NoisyScanPreset.java
+++ b/preprocess-worker/src/main/java/com/moonju/preprocess/worker/domain/preprocess/preset/NoisyScanPreset.java
@@ -16,22 +16,27 @@ public class NoisyScanPreset implements PreprocessPresetDefinition {
             "Document preset reserved for strong background noise cases.",
             DocumentStepSequence.standard(),
             Map.ofEntries(
+                entry("grayscale", "true"),
                 entry("targetDpi", "300"),
+                entry("referenceWidthInches", "8.27"),
+                entry("referenceHeightInches", "11.69"),
+                entry("fallbackSourceDpi", "300"),
                 entry("binarizationMode", "adaptive"),
-                entry("adaptiveBlockSize", "21"),
-                entry("adaptiveC", "5.0"),
-                entry("contrastClipLimit", "2.0"),
+                entry("adaptiveBlockSize", "31"),
+                entry("adaptiveC", "15.0"),
+                entry("contrastNormalize", "false"),
+                entry("contrastClipLimit", "2.5"),
                 entry("contrastTileGridSize", "8"),
                 entry("denoiseMode", "bilateral"),
                 entry("denoiseKernelSize", "3"),
-                entry("denoiseDiameter", "5"),
-                entry("denoiseSigmaColor", "25.0"),
-                entry("denoiseSigmaRange", "75.0"),
-                entry("morphologyMode", "open_close"),
+                entry("denoiseDiameter", "7"),
+                entry("denoiseSigmaColor", "50.0"),
+                entry("denoiseSigmaRange", "50.0"),
+                entry("morphologyMode", "open"),
                 entry("morphologyKernelSize", "2"),
                 entry("sharpen", "false"),
-                entry("sharpenAmount", "0.8"),
-                entry("sharpenSigma", "1.5")
+                entry("sharpenAmount", "0.25"),
+                entry("sharpenSigma", "1.2")
             )
         );
     }

--- a/preprocess-worker/src/main/java/com/moonju/preprocess/worker/domain/preprocess/preset/ReceiptPreset.java
+++ b/preprocess-worker/src/main/java/com/moonju/preprocess/worker/domain/preprocess/preset/ReceiptPreset.java
@@ -16,22 +16,27 @@ public class ReceiptPreset implements PreprocessPresetDefinition {
             "Narrow receipt-like document preset.",
             DocumentStepSequence.standard(),
             Map.ofEntries(
+                entry("grayscale", "true"),
                 entry("targetDpi", "300"),
+                entry("referenceWidthInches", "3.15"),
+                entry("referenceHeightInches", "8.0"),
+                entry("fallbackSourceDpi", "300"),
                 entry("binarizationMode", "adaptive"),
-                entry("adaptiveBlockSize", "21"),
-                entry("adaptiveC", "5.0"),
-                entry("contrastClipLimit", "2.2"),
+                entry("adaptiveBlockSize", "31"),
+                entry("adaptiveC", "15.0"),
+                entry("contrastNormalize", "true"),
+                entry("contrastClipLimit", "2.5"),
                 entry("contrastTileGridSize", "8"),
                 entry("denoiseMode", "median"),
                 entry("denoiseKernelSize", "3"),
-                entry("denoiseDiameter", "5"),
-                entry("denoiseSigmaColor", "25.0"),
-                entry("denoiseSigmaRange", "75.0"),
-                entry("morphologyMode", "open_close"),
+                entry("denoiseDiameter", "7"),
+                entry("denoiseSigmaColor", "50.0"),
+                entry("denoiseSigmaRange", "50.0"),
+                entry("morphologyMode", "close"),
                 entry("morphologyKernelSize", "2"),
                 entry("sharpen", "true"),
-                entry("sharpenAmount", "0.8"),
-                entry("sharpenSigma", "1.5")
+                entry("sharpenAmount", "0.25"),
+                entry("sharpenSigma", "1.2")
             )
         );
     }

--- a/preprocess-worker/src/main/java/com/moonju/preprocess/worker/domain/preprocess/step/BinarizationStep.java
+++ b/preprocess-worker/src/main/java/com/moonju/preprocess/worker/domain/preprocess/step/BinarizationStep.java
@@ -10,8 +10,8 @@ import org.springframework.stereotype.Component;
 @Component
 public class BinarizationStep implements PreprocessStep {
 
-    private static final int DEFAULT_ADAPTIVE_BLOCK_SIZE = 21;
-    private static final double DEFAULT_ADAPTIVE_C = 5.0;
+    private static final int DEFAULT_ADAPTIVE_BLOCK_SIZE = 31;
+    private static final double DEFAULT_ADAPTIVE_C = 15.0;
 
     @Override
     public PreprocessStepName name() {

--- a/preprocess-worker/src/main/java/com/moonju/preprocess/worker/domain/preprocess/step/ColorNormalizeStep.java
+++ b/preprocess-worker/src/main/java/com/moonju/preprocess/worker/domain/preprocess/step/ColorNormalizeStep.java
@@ -28,6 +28,27 @@ public class ColorNormalizeStep implements PreprocessStep {
         }
 
         String beforeColorSpace = holder.colorSpace();
+        if (grayscaleEnabled(context)) {
+            if ("GRAY".equals(beforeColorSpace)) {
+                context.recordStep(name(), "Color already normalized: GRAY.");
+                return;
+            }
+
+            Mat normalized = new Mat();
+            if ("BGR".equals(beforeColorSpace)) {
+                Imgproc.cvtColor(holder.mat(), normalized, Imgproc.COLOR_BGR2GRAY);
+            } else if ("BGRA".equals(beforeColorSpace)) {
+                Imgproc.cvtColor(holder.mat(), normalized, Imgproc.COLOR_BGRA2GRAY);
+            } else {
+                throw new IllegalStateException("Unsupported color space for normalization: " + beforeColorSpace);
+            }
+
+            ImageMatHolder normalizedHolder = ImageMatHolder.decoded(holder.sourceObjectKey(), normalized);
+            context.storeDecodedImage(normalizedHolder);
+            context.recordStep(name(), "Color normalized: " + beforeColorSpace + " -> GRAY");
+            return;
+        }
+
         if ("BGR".equals(beforeColorSpace)) {
             context.recordStep(name(), "Color already normalized: BGR.");
             return;
@@ -45,5 +66,15 @@ public class ColorNormalizeStep implements PreprocessStep {
         ImageMatHolder normalizedHolder = ImageMatHolder.decoded(holder.sourceObjectKey(), normalized);
         context.storeDecodedImage(normalizedHolder);
         context.recordStep(name(), "Color normalized: " + beforeColorSpace + " -> " + normalizedHolder.colorSpace());
+    }
+
+    private boolean grayscaleEnabled(PreprocessContext context) {
+        String configured = context.parameters().get("grayscale");
+        if (configured == null || configured.isBlank()) {
+            return false;
+        }
+        return "true".equalsIgnoreCase(configured)
+            || "on".equalsIgnoreCase(configured)
+            || "yes".equalsIgnoreCase(configured);
     }
 }

--- a/preprocess-worker/src/main/java/com/moonju/preprocess/worker/domain/preprocess/step/ContrastNormalizeStep.java
+++ b/preprocess-worker/src/main/java/com/moonju/preprocess/worker/domain/preprocess/step/ContrastNormalizeStep.java
@@ -14,7 +14,7 @@ import org.springframework.stereotype.Component;
 @Component
 public class ContrastNormalizeStep implements PreprocessStep {
 
-    private static final double DEFAULT_CLIP_LIMIT = 2.0;
+    private static final double DEFAULT_CLIP_LIMIT = 2.5;
     private static final int DEFAULT_TILE_GRID_SIZE = 8;
 
     @Override
@@ -32,6 +32,11 @@ public class ContrastNormalizeStep implements PreprocessStep {
         ImageMatHolder holder = context.decodedImage().orElseThrow();
         if (!holder.loaded()) {
             context.recordStep(name(), "Decoded image is not loaded; contrast normalization is deferred.");
+            return;
+        }
+
+        if (!enabled(context)) {
+            context.recordStep(name(), "Contrast normalization skipped: disabled by preset parameters.");
             return;
         }
 
@@ -88,6 +93,16 @@ public class ContrastNormalizeStep implements PreprocessStep {
             return defaultValue;
         }
         return Math.max(0.1, Double.parseDouble(value));
+    }
+
+    private boolean enabled(PreprocessContext context) {
+        String configured = context.parameters().get("contrastNormalize");
+        if (configured == null || configured.isBlank()) {
+            return true;
+        }
+        return "true".equalsIgnoreCase(configured)
+            || "on".equalsIgnoreCase(configured)
+            || "yes".equalsIgnoreCase(configured);
     }
 
     private int positiveInt(String value, int defaultValue) {

--- a/preprocess-worker/src/main/java/com/moonju/preprocess/worker/domain/preprocess/step/DenoiseStep.java
+++ b/preprocess-worker/src/main/java/com/moonju/preprocess/worker/domain/preprocess/step/DenoiseStep.java
@@ -11,9 +11,9 @@ import org.springframework.stereotype.Component;
 public class DenoiseStep implements PreprocessStep {
 
     private static final int DEFAULT_MEDIAN_KERNEL_SIZE = 3;
-    private static final int DEFAULT_BILATERAL_DIAMETER = 5;
-    private static final double DEFAULT_BILATERAL_SIGMA_COLOR = 25.0;
-    private static final double DEFAULT_BILATERAL_SIGMA_RANGE = 75.0;
+    private static final int DEFAULT_BILATERAL_DIAMETER = 7;
+    private static final double DEFAULT_BILATERAL_SIGMA_COLOR = 50.0;
+    private static final double DEFAULT_BILATERAL_SIGMA_RANGE = 50.0;
 
     @Override
     public PreprocessStepName name() {

--- a/preprocess-worker/src/main/java/com/moonju/preprocess/worker/domain/preprocess/step/DpiNormalizeStep.java
+++ b/preprocess-worker/src/main/java/com/moonju/preprocess/worker/domain/preprocess/step/DpiNormalizeStep.java
@@ -4,6 +4,7 @@ import com.moonju.preprocess.worker.domain.preprocess.model.DpiInfo;
 import com.moonju.preprocess.worker.domain.preprocess.model.ImageMatHolder;
 import com.moonju.preprocess.worker.domain.preprocess.pipeline.PreprocessContext;
 import java.util.Map;
+import java.util.OptionalDouble;
 import java.util.OptionalInt;
 import org.opencv.core.Mat;
 import org.opencv.core.Size;
@@ -14,8 +15,8 @@ import org.springframework.stereotype.Component;
 public class DpiNormalizeStep implements PreprocessStep {
 
     private static final int DEFAULT_TARGET_DPI = 300;
-    private static final double MIN_SCALE = 0.25;
-    private static final double MAX_SCALE = 4.0;
+    private static final double MIN_SCALE = 0.75;
+    private static final double MAX_SCALE = 2.5;
     private static final double NO_OP_SCALE_DELTA = 0.01;
 
     @Override
@@ -36,7 +37,7 @@ public class DpiNormalizeStep implements PreprocessStep {
             return;
         }
 
-        DpiInfo dpiInfo = dpiInfo(context.parameters());
+        DpiInfo dpiInfo = dpiInfo(context.parameters(), holder);
         if (!dpiInfo.sourceKnown()) {
             context.recordFallback(name(), "Source DPI metadata is missing.", "skip");
             context.recordStep(name(), "DPI normalization skipped: source DPI is unknown.");
@@ -87,13 +88,33 @@ public class DpiNormalizeStep implements PreprocessStep {
         );
     }
 
-    private DpiInfo dpiInfo(Map<String, String> parameters) {
+    private DpiInfo dpiInfo(Map<String, String> parameters, ImageMatHolder holder) {
         int targetDpi = parsePositiveInt(parameters.get("targetDpi")).orElse(DEFAULT_TARGET_DPI);
         OptionalInt sameAxisDpi = firstPositiveInt(parameters, "sourceDpi", "dpi", "xDpi");
         int sourceDpiX = firstPositiveInt(parameters, "sourceDpiX", "dpiX").orElseGet(() -> sameAxisDpi.orElse(0));
         int sourceDpiY = firstPositiveInt(parameters, "sourceDpiY", "dpiY", "yDpi")
             .orElseGet(() -> sameAxisDpi.orElse(0));
+        if (sourceDpiX <= 0 || sourceDpiY <= 0) {
+            OptionalInt estimatedX = estimateDpi(holder.width(), parameters.get("referenceWidthInches"));
+            OptionalInt estimatedY = estimateDpi(holder.height(), parameters.get("referenceHeightInches"));
+            sourceDpiX = sourceDpiX > 0 ? sourceDpiX : estimatedX.orElse(0);
+            sourceDpiY = sourceDpiY > 0 ? sourceDpiY : estimatedY.orElse(0);
+        }
+        if (sourceDpiX <= 0 || sourceDpiY <= 0) {
+            OptionalInt fallbackSourceDpi = parsePositiveInt(parameters.get("fallbackSourceDpi"));
+            sourceDpiX = sourceDpiX > 0 ? sourceDpiX : fallbackSourceDpi.orElse(0);
+            sourceDpiY = sourceDpiY > 0 ? sourceDpiY : fallbackSourceDpi.orElse(0);
+        }
         return new DpiInfo(sourceDpiX, sourceDpiY, targetDpi);
+    }
+
+    private OptionalInt estimateDpi(int pixels, String referenceInches) {
+        OptionalDouble parsedReferenceInches = parsePositiveDouble(referenceInches);
+        if (parsedReferenceInches.isEmpty()) {
+            return OptionalInt.empty();
+        }
+        int estimated = (int) Math.round(pixels / parsedReferenceInches.getAsDouble());
+        return estimated > 0 ? OptionalInt.of(estimated) : OptionalInt.empty();
     }
 
     private OptionalInt firstPositiveInt(Map<String, String> parameters, String... keys) {
@@ -115,6 +136,17 @@ public class DpiNormalizeStep implements PreprocessStep {
             return OptionalInt.empty();
         }
         return OptionalInt.of(parsed);
+    }
+
+    private OptionalDouble parsePositiveDouble(String value) {
+        if (value == null || value.isBlank()) {
+            return OptionalDouble.empty();
+        }
+        double parsed = Double.parseDouble(value);
+        if (parsed <= 0) {
+            return OptionalDouble.empty();
+        }
+        return OptionalDouble.of(parsed);
     }
 
     private double clampScale(double scale) {

--- a/preprocess-worker/src/main/java/com/moonju/preprocess/worker/domain/preprocess/step/MorphologyCleanupStep.java
+++ b/preprocess-worker/src/main/java/com/moonju/preprocess/worker/domain/preprocess/step/MorphologyCleanupStep.java
@@ -32,7 +32,7 @@ public class MorphologyCleanupStep implements PreprocessStep {
             return;
         }
 
-        String mode = context.parameters().getOrDefault("morphologyMode", "open_close")
+        String mode = context.parameters().getOrDefault("morphologyMode", "open")
             .toLowerCase(Locale.ROOT);
         if ("none".equals(mode) || "off".equals(mode) || "false".equals(mode)) {
             context.recordStep(name(), "Morphology cleanup skipped: disabled by preset parameters.");
@@ -40,8 +40,8 @@ public class MorphologyCleanupStep implements PreprocessStep {
         }
 
         if (!isSupportedMode(mode)) {
-            context.recordFallback(name(), "Unsupported morphology mode: " + mode, "open_close");
-            mode = "open_close";
+            context.recordFallback(name(), "Unsupported morphology mode: " + mode, "open");
+            mode = "open";
         }
 
         int kernelSize = kernelSize(context);

--- a/preprocess-worker/src/main/java/com/moonju/preprocess/worker/domain/preprocess/step/OrientationNormalizeStep.java
+++ b/preprocess-worker/src/main/java/com/moonju/preprocess/worker/domain/preprocess/step/OrientationNormalizeStep.java
@@ -9,6 +9,8 @@ import org.springframework.stereotype.Component;
 @Component
 public class OrientationNormalizeStep implements PreprocessStep {
 
+    private static final double LANDSCAPE_ROTATION_THRESHOLD = 1.15;
+
     @Override
     public PreprocessStepName name() {
         return PreprocessStepName.ORIENTATION_NORMALIZE;
@@ -27,18 +29,18 @@ public class OrientationNormalizeStep implements PreprocessStep {
             return;
         }
 
-        if (holder.width() <= holder.height()) {
+        if (holder.width() <= holder.height() * LANDSCAPE_ROTATION_THRESHOLD) {
             context.recordStep(name(), "Orientation already normalized: portrait or square.");
             return;
         }
 
         Mat rotated = new Mat();
-        Core.rotate(holder.mat(), rotated, Core.ROTATE_90_CLOCKWISE);
+        Core.rotate(holder.mat(), rotated, Core.ROTATE_90_COUNTERCLOCKWISE);
         ImageMatHolder rotatedHolder = ImageMatHolder.decoded(holder.sourceObjectKey(), rotated);
         context.storeDecodedImage(rotatedHolder);
         context.recordStep(
             name(),
-            "Orientation normalized: landscape -> portrait, width="
+            "Orientation normalized: landscape -> portrait, grossRotationDegrees=-90.0, width="
                 + rotatedHolder.width()
                 + ", height="
                 + rotatedHolder.height()

--- a/preprocess-worker/src/main/java/com/moonju/preprocess/worker/domain/preprocess/step/SharpenStep.java
+++ b/preprocess-worker/src/main/java/com/moonju/preprocess/worker/domain/preprocess/step/SharpenStep.java
@@ -11,8 +11,8 @@ import org.springframework.stereotype.Component;
 @Component
 public class SharpenStep implements PreprocessStep {
 
-    private static final double DEFAULT_SHARPEN_AMOUNT = 0.8;
-    private static final double DEFAULT_SHARPEN_SIGMA = 1.5;
+    private static final double DEFAULT_SHARPEN_AMOUNT = 0.25;
+    private static final double DEFAULT_SHARPEN_SIGMA = 1.2;
 
     @Override
     public PreprocessStepName name() {

--- a/preprocess-worker/src/main/java/com/moonju/preprocess/worker/domain/workerjob/service/WorkerJobService.java
+++ b/preprocess-worker/src/main/java/com/moonju/preprocess/worker/domain/workerjob/service/WorkerJobService.java
@@ -16,6 +16,7 @@ import com.moonju.preprocess.worker.domain.workerjob.dto.WorkerJobResult;
 import com.moonju.preprocess.worker.domain.workerjob.exception.InvalidWorkerMessageException;
 import com.moonju.preprocess.worker.domain.workerjob.status.WorkerFailureCode;
 import com.moonju.preprocess.worker.infra.api.BackendApiClient;
+import com.moonju.preprocess.worker.infra.api.BackendApiReportException;
 import com.moonju.preprocess.worker.infra.metrics.WorkerMetricsRecorder;
 import com.moonju.preprocess.worker.infra.storage.ObjectStoragePort;
 import java.time.Duration;
@@ -202,7 +203,7 @@ public class WorkerJobService {
                 message,
                 WorkerFailureCode.BACKEND_REPORT_FAILED,
                 exception.getMessage(),
-                true
+                isRetryableBackendReportFailure(exception)
             );
         }
     }
@@ -212,7 +213,16 @@ public class WorkerJobService {
             message,
             WorkerFailureCode.BACKEND_REPORT_FAILED,
             exception.getMessage(),
-            true
+            isRetryableBackendReportFailure(exception)
         );
+    }
+
+    private boolean isRetryableBackendReportFailure(RuntimeException exception) {
+        if (exception instanceof BackendApiReportException
+            && exception.getMessage() != null
+            && exception.getMessage().contains("status 409")) {
+            return false;
+        }
+        return true;
     }
 }

--- a/preprocess-worker/src/test/java/com/moonju/preprocess/worker/domain/preprocess/preset/PreprocessPresetRegistryTests.java
+++ b/preprocess-worker/src/test/java/com/moonju/preprocess/worker/domain/preprocess/preset/PreprocessPresetRegistryTests.java
@@ -40,28 +40,40 @@ class PreprocessPresetRegistryTests {
     @Test
     void builtInPresetsExposeQualityTuningParameters() {
         assertThat(registry.findByName("A4_SCAN_300DPI").defaultParameters())
-            .containsEntry("contrastClipLimit", "2.0")
-            .containsEntry("adaptiveBlockSize", "21")
-            .containsEntry("adaptiveC", "5.0")
+            .containsEntry("grayscale", "true")
+            .containsEntry("referenceWidthInches", "8.27")
+            .containsEntry("referenceHeightInches", "11.69")
+            .containsEntry("fallbackSourceDpi", "300")
+            .containsEntry("contrastNormalize", "false")
+            .containsEntry("contrastClipLimit", "2.5")
+            .containsEntry("adaptiveBlockSize", "31")
+            .containsEntry("adaptiveC", "15.0")
             .containsEntry("denoiseMode", "median")
-            .containsEntry("denoiseSigmaColor", "25.0")
-            .containsEntry("morphologyMode", "open_close")
-            .containsEntry("sharpenAmount", "0.8")
-            .containsEntry("sharpenSigma", "1.5");
+            .containsEntry("denoiseDiameter", "7")
+            .containsEntry("denoiseSigmaColor", "50.0")
+            .containsEntry("denoiseSigmaRange", "50.0")
+            .containsEntry("morphologyMode", "open")
+            .containsEntry("sharpenAmount", "0.25")
+            .containsEntry("sharpenSigma", "1.2");
 
         assertThat(registry.findByName("LOW_CONTRAST_SCAN").defaultParameters())
-            .containsEntry("contrastClipLimit", "2.4")
+            .containsEntry("contrastNormalize", "true")
+            .containsEntry("contrastClipLimit", "2.5")
             .containsEntry("denoiseMode", "median")
+            .containsEntry("morphologyMode", "close")
             .containsEntry("sharpen", "true");
 
         assertThat(registry.findByName("RECEIPT").defaultParameters())
-            .containsEntry("contrastClipLimit", "2.2")
+            .containsEntry("contrastNormalize", "true")
+            .containsEntry("contrastClipLimit", "2.5")
             .containsEntry("denoiseMode", "median")
+            .containsEntry("morphologyMode", "close")
             .containsEntry("morphologyKernelSize", "2");
 
         assertThat(registry.findByName("NOISY_SCAN").defaultParameters())
-            .containsEntry("contrastClipLimit", "2.0")
+            .containsEntry("contrastNormalize", "false")
+            .containsEntry("contrastClipLimit", "2.5")
             .containsEntry("denoiseMode", "bilateral")
-            .containsEntry("denoiseSigmaRange", "75.0");
+            .containsEntry("denoiseSigmaRange", "50.0");
     }
 }

--- a/preprocess-worker/src/test/java/com/moonju/preprocess/worker/domain/preprocess/step/BinarizationStepTests.java
+++ b/preprocess-worker/src/test/java/com/moonju/preprocess/worker/domain/preprocess/step/BinarizationStepTests.java
@@ -71,8 +71,8 @@ class BinarizationStepTests {
         step.execute(context);
 
         assertThat(context.consumeStepNote(PreprocessStepName.BINARIZATION))
-            .contains("blockSize=21")
-            .contains("c=5.0");
+            .contains("blockSize=31")
+            .contains("c=15.0");
         context.releaseDecodedImage();
     }
 

--- a/preprocess-worker/src/test/java/com/moonju/preprocess/worker/domain/preprocess/step/ColorNormalizeStepTests.java
+++ b/preprocess-worker/src/test/java/com/moonju/preprocess/worker/domain/preprocess/step/ColorNormalizeStepTests.java
@@ -39,7 +39,8 @@ class ColorNormalizeStepTests {
         assertThat(normalizedHolder.width()).isEqualTo(3);
         assertThat(normalizedHolder.height()).isEqualTo(2);
         assertThat(normalizedHolder.colorSpace()).isEqualTo("BGR");
-        assertThat(context.consumeStepNote(PreprocessStepName.COLOR_NORMALIZE)).isEqualTo("Color normalized: GRAY -> BGR");
+        assertThat(context.consumeStepNote(PreprocessStepName.COLOR_NORMALIZE))
+            .isEqualTo("Color normalized: GRAY -> BGR");
         context.releaseDecodedImage();
     }
 
@@ -57,7 +58,45 @@ class ColorNormalizeStepTests {
         ImageMatHolder normalizedHolder = context.decodedImage().orElseThrow();
         assertThat(bgraHolder.released()).isTrue();
         assertThat(normalizedHolder.colorSpace()).isEqualTo("BGR");
-        assertThat(context.consumeStepNote(PreprocessStepName.COLOR_NORMALIZE)).isEqualTo("Color normalized: BGRA -> BGR");
+        assertThat(context.consumeStepNote(PreprocessStepName.COLOR_NORMALIZE))
+            .isEqualTo("Color normalized: BGRA -> BGR");
+        context.releaseDecodedImage();
+    }
+
+    @Test
+    void convertsBgrImageToGrayWhenGrayscaleIsEnabled() {
+        PreprocessContext context = context(Map.of("grayscale", "true"));
+        ImageMatHolder bgrHolder = ImageMatHolder.decoded(
+            "originals/bgr.png",
+            new Mat(2, 3, CvType.CV_8UC3, new Scalar(10, 20, 30))
+        );
+        context.storeDecodedImage(bgrHolder);
+
+        step.execute(context);
+
+        ImageMatHolder normalizedHolder = context.decodedImage().orElseThrow();
+        assertThat(bgrHolder.released()).isTrue();
+        assertThat(normalizedHolder.colorSpace()).isEqualTo("GRAY");
+        assertThat(context.consumeStepNote(PreprocessStepName.COLOR_NORMALIZE))
+            .isEqualTo("Color normalized: BGR -> GRAY");
+        context.releaseDecodedImage();
+    }
+
+    @Test
+    void keepsGrayImageAsNoOpWhenGrayscaleIsEnabled() {
+        PreprocessContext context = context(Map.of("grayscale", "true"));
+        ImageMatHolder grayHolder = ImageMatHolder.decoded(
+            "originals/gray.png",
+            new Mat(2, 3, CvType.CV_8UC1, new Scalar(128))
+        );
+        context.storeDecodedImage(grayHolder);
+
+        step.execute(context);
+
+        assertThat(context.decodedImage().orElseThrow()).isSameAs(grayHolder);
+        assertThat(grayHolder.released()).isFalse();
+        assertThat(context.consumeStepNote(PreprocessStepName.COLOR_NORMALIZE))
+            .isEqualTo("Color already normalized: GRAY.");
         context.releaseDecodedImage();
     }
 
@@ -74,7 +113,8 @@ class ColorNormalizeStepTests {
 
         assertThat(context.decodedImage().orElseThrow()).isSameAs(bgrHolder);
         assertThat(bgrHolder.released()).isFalse();
-        assertThat(context.consumeStepNote(PreprocessStepName.COLOR_NORMALIZE)).isEqualTo("Color already normalized: BGR.");
+        assertThat(context.consumeStepNote(PreprocessStepName.COLOR_NORMALIZE))
+            .isEqualTo("Color already normalized: BGR.");
         context.releaseDecodedImage();
     }
 
@@ -104,13 +144,17 @@ class ColorNormalizeStepTests {
     }
 
     private PreprocessContext context() {
+        return context(Map.of());
+    }
+
+    private PreprocessContext context(Map<String, String> parameters) {
         return new PreprocessContext(
             3L,
             1L,
             2L,
             "originals/project/scan.png",
             "LOW_CONTRAST_SCAN",
-            Map.of(),
+            parameters,
             false
         );
     }

--- a/preprocess-worker/src/test/java/com/moonju/preprocess/worker/domain/preprocess/step/ContrastNormalizeStepTests.java
+++ b/preprocess-worker/src/test/java/com/moonju/preprocess/worker/domain/preprocess/step/ContrastNormalizeStepTests.java
@@ -58,14 +58,28 @@ class ContrastNormalizeStepTests {
     }
 
     @Test
-    void usesTunedDefaultClipLimitWhenParameterIsMissing() {
+    void usesImageTestDefaultClipLimitWhenParameterIsMissing() {
         PreprocessContext context = context(Map.of());
         ImageMatHolder sourceHolder = ImageMatHolder.decoded("originals/default.png", lowContrastBgrImage());
         context.storeDecodedImage(sourceHolder);
 
         step.execute(context);
 
-        assertThat(context.consumeStepNote(PreprocessStepName.CONTRAST_NORMALIZE)).contains("clipLimit=2.0");
+        assertThat(context.consumeStepNote(PreprocessStepName.CONTRAST_NORMALIZE)).contains("clipLimit=2.5");
+        context.releaseDecodedImage();
+    }
+
+    @Test
+    void skipsWhenDisabledByPresetParameter() {
+        PreprocessContext context = context(Map.of("contrastNormalize", "false"));
+        ImageMatHolder sourceHolder = ImageMatHolder.decoded("originals/default.png", lowContrastBgrImage());
+        context.storeDecodedImage(sourceHolder);
+
+        step.execute(context);
+
+        assertThat(context.decodedImage().orElseThrow()).isSameAs(sourceHolder);
+        assertThat(sourceHolder.released()).isFalse();
+        assertThat(context.consumeStepNote(PreprocessStepName.CONTRAST_NORMALIZE)).contains("disabled");
         context.releaseDecodedImage();
     }
 

--- a/preprocess-worker/src/test/java/com/moonju/preprocess/worker/domain/preprocess/step/DenoiseStepTests.java
+++ b/preprocess-worker/src/test/java/com/moonju/preprocess/worker/domain/preprocess/step/DenoiseStepTests.java
@@ -69,7 +69,7 @@ class DenoiseStepTests {
     }
 
     @Test
-    void appliesBilateralDenoiseWithTunedDefaultSigmas() {
+    void appliesBilateralDenoiseWithDefaultImageTestSigmas() {
         PreprocessContext context = context(Map.of("denoiseMode", "bilateral"));
         ImageMatHolder sourceHolder = ImageMatHolder.decoded("originals/noisy.png", noisyImage());
         context.storeDecodedImage(sourceHolder);
@@ -78,8 +78,9 @@ class DenoiseStepTests {
 
         assertThat(context.consumeStepNote(PreprocessStepName.DENOISE))
             .contains("mode=bilateral")
-            .contains("sigmaColor=25.0")
-            .contains("sigmaRange=75.0");
+            .contains("diameter=7")
+            .contains("sigmaColor=50.0")
+            .contains("sigmaRange=50.0");
         context.releaseDecodedImage();
     }
 

--- a/preprocess-worker/src/test/java/com/moonju/preprocess/worker/domain/preprocess/step/DpiNormalizeStepTests.java
+++ b/preprocess-worker/src/test/java/com/moonju/preprocess/worker/domain/preprocess/step/DpiNormalizeStepTests.java
@@ -79,6 +79,51 @@ class DpiNormalizeStepTests {
     }
 
     @Test
+    void usesFallbackSourceDpiWhenMetadataIsMissing() {
+        PreprocessContext context = context(Map.of("targetDpi", "300", "fallbackSourceDpi", "150"));
+        ImageMatHolder sourceHolder = ImageMatHolder.decoded(
+            "originals/fallback-dpi.png",
+            new Mat(5, 10, CvType.CV_8UC3, new Scalar(255, 255, 255))
+        );
+        context.storeDecodedImage(sourceHolder);
+
+        step.execute(context);
+
+        ImageMatHolder normalizedHolder = context.decodedImage().orElseThrow();
+        assertThat(sourceHolder.released()).isTrue();
+        assertThat(normalizedHolder.width()).isEqualTo(20);
+        assertThat(normalizedHolder.height()).isEqualTo(10);
+        assertThat(context.consumeStepNote(PreprocessStepName.DPI_NORMALIZE)).contains("sourceDpiX=150");
+        context.releaseDecodedImage();
+    }
+
+    @Test
+    void estimatesSourceDpiFromReferenceSizeWhenMetadataIsMissing() {
+        PreprocessContext context = context(Map.of(
+            "targetDpi",
+            "300",
+            "referenceWidthInches",
+            "10.0",
+            "referenceHeightInches",
+            "5.0"
+        ));
+        ImageMatHolder sourceHolder = ImageMatHolder.decoded(
+            "originals/reference-dpi.png",
+            new Mat(5, 10, CvType.CV_8UC3, new Scalar(255, 255, 255))
+        );
+        context.storeDecodedImage(sourceHolder);
+
+        step.execute(context);
+
+        ImageMatHolder normalizedHolder = context.decodedImage().orElseThrow();
+        assertThat(sourceHolder.released()).isTrue();
+        assertThat(normalizedHolder.width()).isEqualTo(25);
+        assertThat(normalizedHolder.height()).isEqualTo(13);
+        assertThat(context.consumeStepNote(PreprocessStepName.DPI_NORMALIZE)).contains("sourceDpiX=1");
+        context.releaseDecodedImage();
+    }
+
+    @Test
     void defersWhenDecodedImageIsMissing() {
         PreprocessContext context = context(Map.of());
 

--- a/preprocess-worker/src/test/java/com/moonju/preprocess/worker/domain/preprocess/step/MorphologyCleanupStepTests.java
+++ b/preprocess-worker/src/test/java/com/moonju/preprocess/worker/domain/preprocess/step/MorphologyCleanupStepTests.java
@@ -24,7 +24,7 @@ class MorphologyCleanupStepTests {
     }
 
     @Test
-    void appliesOpenCloseCleanupAndReleasesPreviousHolder() {
+    void appliesOpenCleanupByDefaultAndReleasesPreviousHolder() {
         PreprocessContext context = context(Map.of("morphologyKernelSize", "2"));
         ImageMatHolder sourceHolder = ImageMatHolder.decoded("originals/binary.png", binaryDocument());
         context.storeDecodedImage(sourceHolder);
@@ -37,7 +37,7 @@ class MorphologyCleanupStepTests {
         assertThat(cleanedHolder.width()).isEqualTo(16);
         assertThat(cleanedHolder.height()).isEqualTo(16);
         assertThat(cleanedHolder.colorSpace()).isEqualTo("GRAY");
-        assertThat(context.consumeStepNote(PreprocessStepName.MORPHOLOGY_CLEANUP)).contains("mode=open_close");
+        assertThat(context.consumeStepNote(PreprocessStepName.MORPHOLOGY_CLEANUP)).contains("mode=open");
         context.releaseDecodedImage();
     }
 
@@ -56,7 +56,7 @@ class MorphologyCleanupStepTests {
     }
 
     @Test
-    void fallsBackToOpenCloseWhenModeIsUnsupported() {
+    void fallsBackToOpenWhenModeIsUnsupported() {
         PreprocessContext context = context(Map.of("morphologyMode", "unknown"));
         ImageMatHolder sourceHolder = ImageMatHolder.decoded("originals/binary.png", binaryDocument());
         context.storeDecodedImage(sourceHolder);
@@ -65,8 +65,8 @@ class MorphologyCleanupStepTests {
 
         assertThat(context.fallbackNotes()).hasSize(1);
         assertThat(context.fallbackNotes().getFirst().stepName()).isEqualTo("MORPHOLOGY_CLEANUP");
-        assertThat(context.fallbackNotes().getFirst().selectedStrategy()).isEqualTo("open_close");
-        assertThat(context.consumeStepNote(PreprocessStepName.MORPHOLOGY_CLEANUP)).contains("mode=open_close");
+        assertThat(context.fallbackNotes().getFirst().selectedStrategy()).isEqualTo("open");
+        assertThat(context.consumeStepNote(PreprocessStepName.MORPHOLOGY_CLEANUP)).contains("mode=open");
         context.releaseDecodedImage();
     }
 

--- a/preprocess-worker/src/test/java/com/moonju/preprocess/worker/domain/preprocess/step/OrientationNormalizeStepTests.java
+++ b/preprocess-worker/src/test/java/com/moonju/preprocess/worker/domain/preprocess/step/OrientationNormalizeStepTests.java
@@ -38,7 +38,26 @@ class OrientationNormalizeStepTests {
         assertThat(rotatedHolder.height()).isEqualTo(5);
         assertThat(rotatedHolder.colorSpace()).isEqualTo("BGR");
         assertThat(context.consumeStepNote(PreprocessStepName.ORIENTATION_NORMALIZE))
-            .contains("landscape -> portrait");
+            .contains("landscape -> portrait")
+            .contains("grossRotationDegrees=-90.0");
+        context.releaseDecodedImage();
+    }
+
+    @Test
+    void keepsSlightLandscapeImageAsNoOp() {
+        PreprocessContext context = context();
+        ImageMatHolder slightLandscapeHolder = ImageMatHolder.decoded(
+            "originals/slight-landscape.png",
+            new Mat(10, 11, CvType.CV_8UC3, new Scalar(255, 255, 255))
+        );
+        context.storeDecodedImage(slightLandscapeHolder);
+
+        step.execute(context);
+
+        assertThat(context.decodedImage().orElseThrow()).isSameAs(slightLandscapeHolder);
+        assertThat(slightLandscapeHolder.released()).isFalse();
+        assertThat(context.consumeStepNote(PreprocessStepName.ORIENTATION_NORMALIZE))
+            .contains("already normalized");
         context.releaseDecodedImage();
     }
 

--- a/preprocess-worker/src/test/java/com/moonju/preprocess/worker/domain/preprocess/step/SharpenStepTests.java
+++ b/preprocess-worker/src/test/java/com/moonju/preprocess/worker/domain/preprocess/step/SharpenStepTests.java
@@ -47,7 +47,7 @@ class SharpenStepTests {
     }
 
     @Test
-    void usesTunedSharpenDefaultsWhenParametersAreMissing() {
+    void usesImageTestSharpenDefaultsWhenParametersAreMissing() {
         PreprocessContext context = context(Map.of("sharpen", "true"));
         ImageMatHolder sourceHolder = ImageMatHolder.decoded("originals/processed.png", grayscaleImage());
         context.storeDecodedImage(sourceHolder);
@@ -55,8 +55,8 @@ class SharpenStepTests {
         step.execute(context);
 
         assertThat(context.consumeStepNote(PreprocessStepName.OPTIONAL_SHARPEN))
-            .contains("amount=0.8")
-            .contains("sigma=1.5");
+            .contains("amount=0.25")
+            .contains("sigma=1.2");
         context.releaseDecodedImage();
     }
 

--- a/preprocess-worker/src/test/java/com/moonju/preprocess/worker/domain/workerjob/service/WorkerJobServiceTests.java
+++ b/preprocess-worker/src/test/java/com/moonju/preprocess/worker/domain/workerjob/service/WorkerJobServiceTests.java
@@ -34,6 +34,7 @@ import com.moonju.preprocess.worker.domain.workerjob.dto.WorkerJobResult;
 import com.moonju.preprocess.worker.domain.workerjob.status.WorkerFailureCode;
 import com.moonju.preprocess.worker.domain.workerjob.status.WorkerJobStatus;
 import com.moonju.preprocess.worker.infra.api.BackendApiClient;
+import com.moonju.preprocess.worker.infra.api.BackendApiReportException;
 import com.moonju.preprocess.worker.infra.metrics.WorkerMetricsRecorder;
 import com.moonju.preprocess.worker.infra.opencv.OpenCvLoader;
 import com.moonju.preprocess.worker.infra.storage.ObjectStoragePort;
@@ -206,6 +207,19 @@ class WorkerJobServiceTests {
 
         assertThat(result.failureCode()).isEqualTo(WorkerFailureCode.BACKEND_REPORT_FAILED);
         assertThat(result.retryable()).isTrue();
+    }
+
+    @Test
+    void marksBackendConflictReportFailureAsNonRetryable() {
+        PreprocessJobMessage message = validMessage();
+        doThrow(new BackendApiReportException(
+            "Backend internal API returned status 409 for /internal/v1/jobs/1/items/2/started"
+        )).when(backendApiClient).reportStarted(message);
+
+        WorkerJobResult result = service.process(message);
+
+        assertThat(result.failureCode()).isEqualTo(WorkerFailureCode.BACKEND_REPORT_FAILED);
+        assertThat(result.retryable()).isFalse();
     }
 
     @Test


### PR DESCRIPTION
## #️⃣ 기능 설명

Worker 처리 안정성과 A4 300 DPI 문서 전처리 프리셋을 보강합니다.

## 🛠️ 작업 상세 내용

- [x] Worker RabbitMQ 단일 처리 안정화를 위한 K8s env/resource 설정 반영
- [x] KEDA scale-to-zero 상태에서 1개 메시지도 scale-out 되도록 activationValue 조정
- [x] Backend 409 callback 충돌을 재시도 불가 실패로 처리해 poison message 재순환 방지
- [x] A4_SCAN_300DPI 프리셋을 image-test 기준값으로 복원
- [x] Color Normalize의 grayscale 파라미터 지원 추가
- [x] Orientation Normalize 90도 회전 조건과 방향 조정
- [x] DPI Normalize fallbackSourceDpi/reference size 추정 및 0.75x~2.5x clamp 반영
- [x] 프리셋 API/Worker 문서 한글 최신화

## 📁 변경 파일 요약

- `backend-api/src/main/java/com/moonju/preprocess/api/domain/preprocess/service/PreprocessPresetRegistry.java`
- `preprocess-worker/src/main/java/com/moonju/preprocess/worker/domain/preprocess/preset/*Preset.java`
- `preprocess-worker/src/main/java/com/moonju/preprocess/worker/domain/preprocess/step/*Step.java`
- `preprocess-worker/src/main/java/com/moonju/preprocess/worker/domain/workerjob/service/WorkerJobService.java`
- `infra/k8s/preprocess-worker/*`
- `docs/api/preprocess-preset-api.md`
- `docs/worker/preset-spec.md`

## ✅ 검증 내용

- [x] `git diff --check`: 통과
- [x] 관련 preset/step 단위 테스트 기대값 갱신
- [ ] `gradle test`: 로컬에 Gradle/gradlew가 없어 실행하지 못함
- [ ] Docker build: 로컬 Docker Desktop 엔진이 꺼져 있어 실행하지 못함

## 🔎 리뷰어가 확인해야 할 부분

- A4 프리셋 기본값이 발표/데모 의도와 맞는지 확인 필요
- `contrastNormalize=false`가 A4 기본 처리 결과를 과하게 어둡게 만들지 않는지 확인 필요
- KEDA `activationValue=0` 변경으로 단일 메시지도 scale-out 되는지 운영 환경에서 확인 필요

## 💬 기타 공유사항

- `tmp/`, `deliverables/`는 로컬 임시 산출물이라 PR에 포함하지 않았습니다.
- 관련 이슈: #154